### PR TITLE
ci: release automation — tag to GHCR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,84 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+permissions:
+  contents: write       # create GitHub releases
+  packages: write       # push to GHCR
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0   # full history for changelog
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
+
+      - name: Install dependencies and run tests
+        run: |
+          pip install -r requirements.txt pytest pytest-cov
+          pytest tests/ -m "not integration" -q --tb=short
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Generate changelog
+        id: changelog
+        run: |
+          PREV_TAG=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || echo "")
+          if [ -z "$PREV_TAG" ]; then
+            CHANGELOG=$(git log --pretty=format:"- %s (%h)" HEAD)
+          else
+            CHANGELOG=$(git log --pretty=format:"- %s (%h)" ${PREV_TAG}..HEAD)
+          fi
+          echo "CHANGELOG<<EOF" >> $GITHUB_OUTPUT
+          echo "$CHANGELOG" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          body: |
+            ## What's Changed
+            ${{ steps.changelog.outputs.CHANGELOG }}
+
+            ## Docker Image
+            ```
+            docker pull ghcr.io/${{ github.repository }}:${{ github.ref_name }}
+            ```
+          generate_release_notes: false

--- a/README.md
+++ b/README.md
@@ -28,3 +28,12 @@ The app will be available at **http://localhost:8501**.
 8. **Monte Carlo Simulator** — price-path simulation for portfolio and options pricing
 9. **News Sentiment** — NLP-scored headlines aggregated by ticker
 10. **Auto-refresh** — configurable sidebar timer (1 min / 5 min / 15 min / 30 min) to keep live data current
+
+## Making a Release
+
+1. Ensure all tests pass on `main`
+2. Tag the release: `git tag v1.0.0 && git push origin v1.0.0`
+3. The Release workflow runs automatically:
+   - Runs full test suite
+   - Builds and pushes Docker image to `ghcr.io/ghostlobster/quant-platform`
+   - Creates a GitHub Release with auto-generated changelog


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/release.yml` triggered on `v*.*.*` tags
- Runs unit tests (excluding integration), builds and pushes Docker image to GHCR with semver tags, and creates a GitHub Release with auto-generated changelog
- Updates `README.md` with a **Making a Release** section

## Test plan

- [ ] Push a `v*.*.*` tag and verify the workflow triggers
- [ ] Confirm Docker image appears at `ghcr.io/ghostlobster/quant-platform`
- [ ] Confirm GitHub Release is created with changelog body
- [ ] Verify `latest`, `x.y`, and `x.y.z` tags are all pushed

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)