### PR TITLE
ci: add workflow_dispatch to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   push:
     branches: [main]
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
Adds workflow_dispatch trigger so CI can be manually run on branches where the pull_request event failed to fire.