### PR TITLE
feat: implement 2026 quant platform roadmap (Issues #23–#39)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,10 @@ Thumbs.db
 # Jupyter
 .ipynb_checkpoints/
 *.ipynb
+
+# Test / coverage artifacts
+.coverage
+coverage.xml
+coverage-integration.xml
+htmlcov/
+.pytest_cache/

--- a/adapters/execution_algo/market_adapter.py
+++ b/adapters/execution_algo/market_adapter.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+from adapters.execution_algo.result import ExecutionResult
+
 logger = logging.getLogger(__name__)
 
 
@@ -23,16 +25,23 @@ class MarketAlgoAdapter:
         broker: Any,
         *,
         duration_minutes: int = 30,
+        decision_price: float = 0.0,
         **kwargs: Any,
-    ) -> list[dict]:
+    ) -> ExecutionResult:
         logger.info(
             "MarketAlgo: placing single market order %s %s x%.4f",
             side.upper(), symbol, total_qty,
         )
-        result = broker.place_order(
+        fill = broker.place_order(
             symbol=symbol,
             qty=total_qty,
             side=side,
             order_type="market",
         )
-        return [result]
+        return ExecutionResult.from_fills(
+            fills=[fill],
+            symbol=symbol,
+            side=side,
+            algo="market",
+            decision_price=decision_price,
+        )

--- a/adapters/execution_algo/result.py
+++ b/adapters/execution_algo/result.py
@@ -1,0 +1,72 @@
+"""
+adapters/execution_algo/result.py — Typed execution result dataclass.
+
+ExecutionResult captures the outcome of any execution algorithm:
+fill details, slippage metrics, and the algorithm used.
+"""
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+
+
+@dataclass
+class ExecutionResult:
+    """Immutable record of a completed execution algo run."""
+
+    symbol: str
+    side: str                   # 'buy' | 'sell'
+    total_qty: float
+    fills: list[dict] = field(default_factory=list)
+    algo: str = "market"        # 'market' | 'twap' | 'vwap'
+    decision_price: float = 0.0  # price at time of trading decision (pre-execution)
+    avg_fill_price: float = 0.0  # weighted-average actual fill price
+    slippage_bps: float = 0.0   # (avg_fill - decision) / decision * 1e4
+    executed_at: float = field(default_factory=time.time)
+
+    @classmethod
+    def from_fills(
+        cls,
+        fills: list[dict],
+        symbol: str,
+        side: str,
+        algo: str,
+        decision_price: float = 0.0,
+    ) -> "ExecutionResult":
+        """
+        Build an ExecutionResult from a list of raw broker fill dicts.
+
+        Each fill dict is expected to contain at least a 'price' and 'qty'
+        (or 'filled_qty') key.  Missing keys are handled gracefully.
+        """
+        total_qty = 0.0
+        total_notional = 0.0
+
+        for fill in fills:
+            qty = float(
+                fill.get("qty")
+                or fill.get("filled_qty")
+                or fill.get("shares")
+                or 0
+            )
+            price = float(fill.get("price") or fill.get("fill_price") or 0)
+            total_qty += qty
+            total_notional += qty * price
+
+        avg_fill = total_notional / total_qty if total_qty > 0 else 0.0
+
+        if decision_price > 0 and avg_fill > 0:
+            slippage_bps = (avg_fill - decision_price) / decision_price * 1e4
+        else:
+            slippage_bps = 0.0
+
+        return cls(
+            symbol=symbol.upper(),
+            side=side.lower(),
+            total_qty=total_qty,
+            fills=fills,
+            algo=algo,
+            decision_price=decision_price,
+            avg_fill_price=round(avg_fill, 6),
+            slippage_bps=round(slippage_bps, 4),
+        )

--- a/adapters/execution_algo/twap_adapter.py
+++ b/adapters/execution_algo/twap_adapter.py
@@ -16,6 +16,8 @@ import os
 import time
 from typing import Any
 
+from adapters.execution_algo.result import ExecutionResult
+
 logger = logging.getLogger(__name__)
 
 
@@ -35,8 +37,9 @@ class TWAPAdapter:
         broker: Any,
         *,
         duration_minutes: int = 30,
+        decision_price: float = 0.0,
         **kwargs: Any,
-    ) -> list[dict]:
+    ) -> ExecutionResult:
         duration_seconds = duration_minutes * 60
         n_slices = max(1, math.ceil(duration_seconds / self._slice_seconds))
         slice_qty = total_qty / n_slices
@@ -55,15 +58,21 @@ class TWAPAdapter:
             qty = round(total_qty - placed, 4) if is_last else slice_qty
             if qty <= 0:
                 break
-            result = broker.place_order(
+            fill = broker.place_order(
                 symbol=symbol,
                 qty=qty,
                 side=side,
                 order_type="market",
             )
-            fills.append(result)
+            fills.append(fill)
             placed = round(placed + qty, 4)
             if not is_last:
                 time.sleep(self._slice_seconds)
 
-        return fills
+        return ExecutionResult.from_fills(
+            fills=fills,
+            symbol=symbol,
+            side=side,
+            algo="twap",
+            decision_price=decision_price,
+        )

--- a/adapters/execution_algo/vwap_adapter.py
+++ b/adapters/execution_algo/vwap_adapter.py
@@ -17,6 +17,8 @@ import os
 import time
 from typing import Any
 
+from adapters.execution_algo.result import ExecutionResult
+
 logger = logging.getLogger(__name__)
 
 
@@ -70,8 +72,9 @@ class VWAPAdapter:
         broker: Any,
         *,
         duration_minutes: int = 30,
+        decision_price: float = 0.0,
         **kwargs: Any,
-    ) -> list[dict]:
+    ) -> ExecutionResult:
         duration_seconds = duration_minutes * 60
         n_slices = max(1, math.ceil(duration_seconds / self._slice_seconds))
         weights = self._get_volume_weights(symbol, n_slices)
@@ -91,15 +94,21 @@ class VWAPAdapter:
                 qty = round(total_qty * weight, 4)
             if qty <= 0:
                 continue
-            result = broker.place_order(
+            fill = broker.place_order(
                 symbol=symbol,
                 qty=qty,
                 side=side,
                 order_type="market",
             )
-            fills.append(result)
+            fills.append(fill)
             placed = round(placed + qty, 4)
             if not is_last:
                 time.sleep(self._slice_seconds)
 
-        return fills
+        return ExecutionResult.from_fills(
+            fills=fills,
+            symbol=symbol,
+            side=side,
+            algo="vwap",
+            decision_price=decision_price,
+        )

--- a/adapters/model_registry/__init__.py
+++ b/adapters/model_registry/__init__.py
@@ -1,0 +1,1 @@
+# adapters/model_registry — pluggable model registry backends

--- a/adapters/model_registry/mlflow_adapter.py
+++ b/adapters/model_registry/mlflow_adapter.py
@@ -1,0 +1,136 @@
+"""
+adapters/model_registry/mlflow_adapter.py — ModelRegistryProvider backed by MLflow.
+
+Uses local file store by default; switch to S3 or remote tracking server via
+MLFLOW_TRACKING_URI environment variable.
+
+Requires (optional): pip install mlflow>=2.0.0
+
+ENV vars
+--------
+    MLFLOW_TRACKING_URI   local path or remote URI (default: mlruns)
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any
+
+from utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+_TRACKING_URI = os.environ.get("MLFLOW_TRACKING_URI", "mlruns")
+
+
+class MLflowAdapter:
+    """ModelRegistryProvider wrapping the MLflow tracking and registry APIs."""
+
+    def __init__(self, tracking_uri: str | None = None) -> None:
+        self._uri = tracking_uri or _TRACKING_URI
+        try:
+            import mlflow  # type: ignore[import]
+            mlflow.set_tracking_uri(self._uri)
+            self._mlflow = mlflow
+            logger.info("MLflowAdapter: tracking URI = %s", self._uri)
+        except ImportError:
+            self._mlflow = None
+            logger.warning(
+                "mlflow not installed; MLflowAdapter will no-op. "
+                "Install with: pip install mlflow"
+            )
+
+    def log_model(
+        self,
+        run_name: str,
+        model_path: str,
+        metrics: dict[str, float],
+        tags: dict[str, str] | None = None,
+    ) -> str:
+        if self._mlflow is None:
+            logger.warning("MLflowAdapter.log_model: mlflow not available")
+            return ""
+        mlflow = self._mlflow
+        with mlflow.start_run(run_name=run_name) as run:
+            mlflow.log_metrics(metrics)
+            if tags:
+                mlflow.set_tags(tags)
+            # Log the model file as a generic artifact
+            if Path(model_path).exists():
+                mlflow.log_artifact(model_path, artifact_path="model")
+            run_id = run.info.run_id
+        logger.info("MLflowAdapter: logged run %s (model=%s)", run_id, model_path)
+        return run_id
+
+    def load_model(self, model_name: str, stage: str = "Production") -> Any:
+        if self._mlflow is None:
+            raise RuntimeError("mlflow not installed")
+        mlflow = self._mlflow
+        try:
+            client = mlflow.tracking.MlflowClient()
+            versions = client.get_latest_versions(model_name, stages=[stage])
+            if not versions:
+                raise FileNotFoundError(
+                    f"No model '{model_name}' at stage '{stage}'"
+                )
+            version = versions[0]
+            artifact_uri = client.get_model_version_download_uri(
+                model_name, version.version
+            )
+            logger.info(
+                "MLflowAdapter: loading %s v%s from %s",
+                model_name, version.version, artifact_uri,
+            )
+            return artifact_uri  # caller reconstructs model from path
+        except self._mlflow.exceptions.MlflowException as exc:
+            raise FileNotFoundError(str(exc)) from exc
+
+    def list_models(self) -> list[dict]:
+        if self._mlflow is None:
+            return []
+        try:
+            client = self._mlflow.tracking.MlflowClient()
+            registered = client.search_registered_models()
+            return [
+                {
+                    "name": m.name,
+                    "latest_versions": [
+                        {"version": v.version, "stage": v.current_stage}
+                        for v in m.latest_versions
+                    ],
+                }
+                for m in registered
+            ]
+        except Exception as exc:
+            logger.warning("MLflowAdapter.list_models failed: %s", exc)
+            return []
+
+    def promote(self, model_name: str, run_id: str, stage: str) -> None:
+        if self._mlflow is None:
+            logger.warning("MLflowAdapter.promote: mlflow not available")
+            return
+        mlflow = self._mlflow
+        client = mlflow.tracking.MlflowClient()
+        # Register the model if not already registered
+        try:
+            result = mlflow.register_model(
+                f"runs:/{run_id}/model", model_name
+            )
+            version = result.version
+        except Exception as exc:
+            logger.warning("MLflowAdapter: register_model failed: %s", exc)
+            # Fallback: get existing latest version for this run
+            versions = client.search_model_versions(f"run_id='{run_id}'")
+            if not versions:
+                raise
+            version = versions[0].version
+
+        client.transition_model_version_stage(
+            name=model_name,
+            version=version,
+            stage=stage,
+            archive_existing_versions=True,
+        )
+        logger.info(
+            "MLflowAdapter: promoted %s v%s → %s", model_name, version, stage
+        )

--- a/adapters/model_registry/mlflow_adapter.py
+++ b/adapters/model_registry/mlflow_adapter.py
@@ -23,7 +23,7 @@ logger = get_logger(__name__)
 _TRACKING_URI = os.environ.get("MLFLOW_TRACKING_URI", "mlruns")
 
 
-class MLflowAdapter:
+class MLflowAdapter:  # pragma: no cover
     """ModelRegistryProvider wrapping the MLflow tracking and registry APIs."""
 
     def __init__(self, tracking_uri: str | None = None) -> None:

--- a/adapters/model_registry/mock_adapter.py
+++ b/adapters/model_registry/mock_adapter.py
@@ -1,0 +1,50 @@
+"""
+adapters/model_registry/mock_adapter.py — In-memory ModelRegistryProvider for tests.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+
+class MockModelRegistryAdapter:
+    """In-memory model registry — no external dependencies, suitable for unit tests."""
+
+    def __init__(self) -> None:
+        self._runs: dict[str, dict] = {}       # run_id → {name, path, metrics, tags}
+        self._stages: dict[str, str] = {}      # "model_name:version" → stage
+        self._counter = 0
+
+    def log_model(
+        self,
+        run_name: str,
+        model_path: str,
+        metrics: dict[str, float],
+        tags: dict[str, str] | None = None,
+    ) -> str:
+        self._counter += 1
+        run_id = f"mock-run-{self._counter:04d}"
+        self._runs[run_id] = {
+            "run_name": run_name,
+            "model_path": model_path,
+            "metrics": metrics,
+            "tags": tags or {},
+            "version": str(self._counter),
+        }
+        return run_id
+
+    def load_model(self, model_name: str, stage: str = "Production") -> Any:
+        for run_id, info in self._runs.items():
+            key = f"{model_name}:{info['version']}"
+            if self._stages.get(key) == stage and info["run_name"] == model_name:
+                return info["model_path"]
+        raise FileNotFoundError(f"No model '{model_name}' at stage '{stage}'")
+
+    def list_models(self) -> list[dict]:
+        return list(self._runs.values())
+
+    def promote(self, model_name: str, run_id: str, stage: str) -> None:
+        if run_id not in self._runs:
+            raise KeyError(f"Unknown run_id: {run_id!r}")
+        info = self._runs[run_id]
+        key = f"{model_name}:{info['version']}"
+        self._stages[key] = stage

--- a/adapters/options_flow/__init__.py
+++ b/adapters/options_flow/__init__.py
@@ -1,0 +1,1 @@
+# adapters/options_flow — pluggable options flow data providers

--- a/adapters/options_flow/mock_adapter.py
+++ b/adapters/options_flow/mock_adapter.py
@@ -30,7 +30,6 @@ class MockOptionsFlowAdapter:
         flow = self.get_flow(symbol)
         call_vol = sum(r["volume"] for r in flow if r["side"] == "call")
         put_vol = sum(r["volume"] for r in flow if r["side"] == "put")
-        total = call_vol + put_vol or 1
         ratio = call_vol / put_vol if put_vol > 0 else 2.0
         baseline = 1.0
         unusual = ratio > 1.5 or ratio < 0.67

--- a/adapters/options_flow/mock_adapter.py
+++ b/adapters/options_flow/mock_adapter.py
@@ -1,0 +1,47 @@
+"""
+adapters/options_flow/mock_adapter.py — Synthetic options flow adapter for tests.
+"""
+from __future__ import annotations
+
+import random
+
+from providers.options_flow import OptionsFlowResult
+
+
+class MockOptionsFlowAdapter:
+    """Returns deterministic synthetic options flow data. No network calls."""
+
+    def get_flow(self, symbol: str, lookback_days: int = 1) -> list[dict]:
+        rng = random.Random(hash(symbol) % 2**32)
+        records = []
+        for _ in range(10):
+            side = rng.choice(["call", "put"])
+            records.append({
+                "symbol": symbol.upper(),
+                "side": side,
+                "volume": rng.randint(100, 5000),
+                "strike": round(rng.uniform(50, 500), 2),
+                "expiry": "2026-06-20",
+                "premium": round(rng.uniform(1, 20), 2),
+            })
+        return records
+
+    def unusual_activity_score(self, symbol: str) -> OptionsFlowResult:
+        flow = self.get_flow(symbol)
+        call_vol = sum(r["volume"] for r in flow if r["side"] == "call")
+        put_vol = sum(r["volume"] for r in flow if r["side"] == "put")
+        total = call_vol + put_vol or 1
+        ratio = call_vol / put_vol if put_vol > 0 else 2.0
+        baseline = 1.0
+        unusual = ratio > 1.5 or ratio < 0.67
+        score = (ratio - baseline) / (baseline + 1e-6)
+        score = max(-1.0, min(1.0, score))
+        return OptionsFlowResult(
+            symbol=symbol.upper(),
+            call_volume=call_vol,
+            put_volume=put_vol,
+            call_put_ratio=round(ratio, 4),
+            unusual_score=round(score, 4),
+            avg_20d_call_put_ratio=baseline,
+            is_unusual=unusual,
+        )

--- a/adapters/options_flow/thetadata_adapter.py
+++ b/adapters/options_flow/thetadata_adapter.py
@@ -49,7 +49,7 @@ class ThetaDataAdapter:
 
     def get_flow(self, symbol: str, lookback_days: int = 1) -> list[dict]:
         data = self._get(
-            f"/options/trade",
+            "/options/trade",
             params={"root": symbol.upper(), "exp": "all", "days_back": lookback_days},
         )
         return data.get("response", []) if isinstance(data, dict) else []

--- a/adapters/options_flow/thetadata_adapter.py
+++ b/adapters/options_flow/thetadata_adapter.py
@@ -1,0 +1,81 @@
+"""
+adapters/options_flow/thetadata_adapter.py — ThetaData free-tier REST adapter.
+
+Docs: https://docs.thetadata.us/
+
+ENV vars
+--------
+    THETADATA_API_KEY   ThetaData API key (required)
+    THETADATA_BASE_URL  override API base URL (default: https://api.thetadata.us/v2)
+"""
+from __future__ import annotations
+
+import json
+import os
+import urllib.request
+from typing import Any
+
+from providers.options_flow import OptionsFlowResult
+from utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+_BASE_URL = os.environ.get("THETADATA_BASE_URL", "https://api.thetadata.us/v2")
+_API_KEY = os.environ.get("THETADATA_API_KEY", "")
+
+
+class ThetaDataAdapter:
+    """OptionsFlowProvider backed by ThetaData REST API."""
+
+    def _get(self, path: str, params: dict | None = None) -> Any:
+        url = f"{_BASE_URL}{path}"
+        if params:
+            qs = "&".join(f"{k}={v}" for k, v in params.items())
+            url = f"{url}?{qs}"
+        req = urllib.request.Request(
+            url,
+            headers={
+                "Authorization": f"Bearer {_API_KEY}",
+                "Accept": "application/json",
+                "User-Agent": "quant-platform/1.0",
+            },
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=10) as resp:
+                return json.loads(resp.read())
+        except Exception as exc:
+            logger.warning("ThetaData request failed %s: %s", path, exc)
+            return {}
+
+    def get_flow(self, symbol: str, lookback_days: int = 1) -> list[dict]:
+        data = self._get(
+            f"/options/trade",
+            params={"root": symbol.upper(), "exp": "all", "days_back": lookback_days},
+        )
+        return data.get("response", []) if isinstance(data, dict) else []
+
+    def unusual_activity_score(self, symbol: str) -> OptionsFlowResult:
+        flow = self.get_flow(symbol, lookback_days=1)
+        call_vol = sum(float(r.get("size", 0)) for r in flow if str(r.get("right", "")).upper() == "C")
+        put_vol = sum(float(r.get("size", 0)) for r in flow if str(r.get("right", "")).upper() == "P")
+
+        # 20-day baseline
+        flow_20d = self.get_flow(symbol, lookback_days=20)
+        days = max(1, len({str(r.get("date", i)) for i, r in enumerate(flow_20d)}))
+        call_20d = sum(float(r.get("size", 0)) for r in flow_20d if str(r.get("right", "")).upper() == "C")
+        put_20d = sum(float(r.get("size", 0)) for r in flow_20d if str(r.get("right", "")).upper() == "P")
+        baseline = (call_20d / put_20d if put_20d > 0 else 1.0) / days
+
+        ratio = call_vol / put_vol if put_vol > 0 else (2.0 if call_vol > 0 else 1.0)
+        unusual = baseline > 0 and (ratio > 1.5 * baseline or ratio < baseline / 1.5)
+        score = max(-1.0, min(1.0, (ratio - baseline) / (baseline + 1e-6)))
+
+        return OptionsFlowResult(
+            symbol=symbol.upper(),
+            call_volume=call_vol,
+            put_volume=put_vol,
+            call_put_ratio=round(ratio, 4),
+            unusual_score=round(score, 4),
+            avg_20d_call_put_ratio=round(baseline, 4),
+            is_unusual=unusual,
+        )

--- a/adapters/options_flow/unusual_whales_adapter.py
+++ b/adapters/options_flow/unusual_whales_adapter.py
@@ -1,0 +1,73 @@
+"""
+adapters/options_flow/unusual_whales_adapter.py — Unusual Whales REST adapter.
+
+Docs: https://unusualwhales.com/api
+
+ENV vars
+--------
+    UNUSUAL_WHALES_TOKEN   API bearer token (required)
+    UNUSUAL_WHALES_BASE_URL override base URL (default: https://api.unusualwhales.com)
+"""
+from __future__ import annotations
+
+import json
+import os
+import urllib.request
+
+from providers.options_flow import OptionsFlowResult
+from utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+_BASE_URL = os.environ.get("UNUSUAL_WHALES_BASE_URL", "https://api.unusualwhales.com")
+_TOKEN = os.environ.get("UNUSUAL_WHALES_TOKEN", "")
+
+
+class UnusualWhalesAdapter:
+    """OptionsFlowProvider backed by the Unusual Whales API."""
+
+    def _get(self, path: str) -> dict:
+        url = f"{_BASE_URL}{path}"
+        req = urllib.request.Request(
+            url,
+            headers={
+                "Authorization": f"Bearer {_TOKEN}",
+                "Accept": "application/json",
+                "User-Agent": "quant-platform/1.0",
+            },
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=10) as resp:
+                return json.loads(resp.read())
+        except Exception as exc:
+            logger.warning("UnusualWhales request failed %s: %s", path, exc)
+            return {}
+
+    def get_flow(self, symbol: str, lookback_days: int = 1) -> list[dict]:
+        data = self._get(f"/api/v2/options/flow/{symbol.upper()}")
+        return data.get("data", []) if isinstance(data, dict) else []
+
+    def unusual_activity_score(self, symbol: str) -> OptionsFlowResult:
+        flow = self.get_flow(symbol)
+        call_vol = sum(
+            float(r.get("volume", 0)) for r in flow
+            if str(r.get("option_type", r.get("type", ""))).lower() in ("call", "c")
+        )
+        put_vol = sum(
+            float(r.get("volume", 0)) for r in flow
+            if str(r.get("option_type", r.get("type", ""))).lower() in ("put", "p")
+        )
+        ratio = call_vol / put_vol if put_vol > 0 else (2.0 if call_vol > 0 else 1.0)
+        baseline = 1.0
+        unusual = ratio > 1.5 or ratio < 0.67
+        score = max(-1.0, min(1.0, (ratio - baseline) / (baseline + 1e-6)))
+
+        return OptionsFlowResult(
+            symbol=symbol.upper(),
+            call_volume=call_vol,
+            put_volume=put_vol,
+            call_put_ratio=round(ratio, 4),
+            unusual_score=round(score, 4),
+            avg_20d_call_put_ratio=baseline,
+            is_unusual=unusual,
+        )

--- a/adapters/sentiment/cache.py
+++ b/adapters/sentiment/cache.py
@@ -1,0 +1,71 @@
+"""
+adapters/sentiment/cache.py — SQLite-backed TTL cache for sentiment scores.
+
+Uses the shared quant.db via data/db.py:get_connection().
+Cache table: sentiment_cache (symbol, provider, score, fetched_at)
+Default TTL: 1800 seconds (30 minutes).
+"""
+from __future__ import annotations
+
+import time
+
+from data.db import get_connection
+
+_DEFAULT_TTL = 1800  # 30 minutes
+
+
+def cache_read(symbol: str, provider: str, ttl: int = _DEFAULT_TTL) -> float | None:
+    """
+    Return cached sentiment score for (symbol, provider) if fresh, else None.
+
+    Parameters
+    ----------
+    symbol   : ticker symbol, e.g. 'AAPL'
+    provider : adapter name, e.g. 'vader' or 'stocktwits'
+    ttl      : cache lifetime in seconds (default 1800 = 30 min)
+
+    Returns
+    -------
+    float score in [-1.0, 1.0] if cache hit and not stale, else None.
+    """
+    conn = get_connection()
+    try:
+        row = conn.execute(
+            "SELECT score, fetched_at FROM sentiment_cache WHERE symbol=? AND provider=?",
+            (symbol.upper(), provider),
+        ).fetchone()
+    finally:
+        conn.close()
+
+    if row is None:
+        return None
+    age = time.time() - float(row["fetched_at"])
+    if age > ttl:
+        return None
+    return float(row["score"])
+
+
+def cache_write(symbol: str, provider: str, score: float) -> None:
+    """
+    Upsert a sentiment score into the cache with the current timestamp.
+
+    Parameters
+    ----------
+    symbol   : ticker symbol, e.g. 'AAPL'
+    provider : adapter name, e.g. 'vader' or 'stocktwits'
+    score    : sentiment score in [-1.0, 1.0]
+    """
+    conn = get_connection()
+    try:
+        with conn:
+            conn.execute(
+                """
+                INSERT INTO sentiment_cache (symbol, provider, score, fetched_at)
+                VALUES (?, ?, ?, ?)
+                ON CONFLICT (symbol, provider) DO UPDATE
+                    SET score=excluded.score, fetched_at=excluded.fetched_at
+                """,
+                (symbol.upper(), provider, float(score), time.time()),
+            )
+    finally:
+        conn.close()

--- a/adapters/sentiment/stocktwits_adapter.py
+++ b/adapters/sentiment/stocktwits_adapter.py
@@ -62,9 +62,16 @@ class StocktwitsAdapter:
         return [self.score(t) for t in texts]
 
     def ticker_sentiment(self, symbol: str, lookback_hours: int = 24) -> float:
+        """Return sentiment score for symbol (30-min SQLite cache)."""
+        from adapters.sentiment.cache import cache_read, cache_write
+
+        cached = cache_read(symbol, "stocktwits")
+        if cached is not None:
+            return cached
+
         messages = self._fetch_messages(symbol)
         scored = [self._message_score(m) for m in messages]
         valid = [s for s in scored if s is not None]
-        if not valid:
-            return 0.0
-        return sum(valid) / len(valid)
+        score = sum(valid) / len(valid) if valid else 0.0
+        cache_write(symbol, "stocktwits", score)
+        return score

--- a/adapters/sentiment/vader_adapter.py
+++ b/adapters/sentiment/vader_adapter.py
@@ -50,7 +50,13 @@ class VADERAdapter:
         return [self.score(t) for t in texts]
 
     def ticker_sentiment(self, symbol: str, lookback_hours: int = 24) -> float:
-        """Fetch recent news via yfinance and score headlines."""
+        """Fetch recent news via yfinance and score headlines (30-min SQLite cache)."""
+        from adapters.sentiment.cache import cache_read, cache_write
+
+        cached = cache_read(symbol, "vader")
+        if cached is not None:
+            return cached
+
         try:
             import yfinance as yf
             ticker = yf.Ticker(symbol.upper())
@@ -64,9 +70,12 @@ class VADERAdapter:
                 if title:
                     headlines.append(title)
             if not headlines:
-                return 0.0
-            scores = self.batch_score(headlines)
-            return sum(scores) / len(scores)
+                score = 0.0
+            else:
+                scores = self.batch_score(headlines)
+                score = sum(scores) / len(scores)
+            cache_write(symbol, "vader", score)
+            return score
         except Exception as exc:
             logger.warning("ticker_sentiment failed for %s: %s", symbol, exc)
             return 0.0

--- a/agents/__init__.py
+++ b/agents/__init__.py
@@ -1,0 +1,1 @@
+# agents — multi-agent orchestration framework

--- a/agents/base.py
+++ b/agents/base.py
@@ -1,0 +1,48 @@
+"""
+agents/base.py — AgentProvider protocol and AgentSignal result type.
+
+All specialist agents implement AgentProvider.run(context) and return
+an AgentSignal with a direction, confidence, and optional reasoning.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Protocol, runtime_checkable
+
+__all__ = ["AgentSignal", "AgentProvider"]
+
+
+@dataclass
+class AgentSignal:
+    """Structured output from a single specialist agent."""
+
+    agent_name: str
+    signal: str                  # 'bullish' | 'bearish' | 'neutral'
+    confidence: float            # [0.0, 1.0]
+    reasoning: str = ""
+    metadata: dict = field(default_factory=dict)
+
+
+@runtime_checkable
+class AgentProvider(Protocol):
+    """Duck-typed interface for specialist trading agents."""
+
+    name: str
+
+    def run(self, context: dict) -> AgentSignal:
+        """
+        Analyse *context* and return a signal.
+
+        Parameters
+        ----------
+        context : dict with optional keys:
+            ticker    : str   — target symbol
+            regime    : str   — current market regime
+            portfolio : dict  — portfolio snapshot
+            prices    : dict  — {ticker: price}
+
+        Returns
+        -------
+        AgentSignal
+        """
+        ...

--- a/agents/execution_agent.py
+++ b/agents/execution_agent.py
@@ -1,0 +1,36 @@
+"""agents/execution_agent.py — Specialist agent recommending an execution algorithm."""
+from __future__ import annotations
+
+from agents.base import AgentSignal
+from utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+class ExecutionAgent:
+    """Recommends a market | twap | vwap execution algo based on context."""
+
+    name = "execution_agent"
+
+    def run(self, context: dict) -> AgentSignal:
+        regime = context.get("regime", "trending_bull")
+        order_size = float(context.get("order_size", 0))
+
+        # Large orders in volatile regimes → TWAP; normal → market
+        if regime == "high_vol" or order_size > 10_000:
+            algo = "twap"
+            reasoning = f"High vol or large order (${order_size:,.0f}) → TWAP for lower impact"
+        elif order_size > 5_000:
+            algo = "vwap"
+            reasoning = f"Moderate order (${order_size:,.0f}) → VWAP for volume-weighted fill"
+        else:
+            algo = "market"
+            reasoning = "Small order → market order for immediate fill"
+
+        return AgentSignal(
+            agent_name=self.name,
+            signal="neutral",       # execution agent doesn't have direction bias
+            confidence=0.85,
+            reasoning=reasoning,
+            metadata={"recommended_algo": algo},
+        )

--- a/agents/meta_agent.py
+++ b/agents/meta_agent.py
@@ -58,11 +58,11 @@ class MetaAgent:
         weights: dict[str, float] | None = None,
     ) -> None:
         if agents is None:
+            from agents.execution_agent import ExecutionAgent
             from agents.regime_agent import RegimeAgent
             from agents.risk_agent import RiskAgent
-            from agents.sentiment_agent import SentimentAgent
             from agents.screener_agent import ScreenerAgent
-            from agents.execution_agent import ExecutionAgent
+            from agents.sentiment_agent import SentimentAgent
             agents = [RegimeAgent(), RiskAgent(), SentimentAgent(), ScreenerAgent(), ExecutionAgent()]
         self._agents: list[AgentProvider] = agents
         self._weights = weights or _load_weights()

--- a/agents/meta_agent.py
+++ b/agents/meta_agent.py
@@ -1,0 +1,169 @@
+"""
+agents/meta_agent.py — Meta-agent that aggregates specialist signals.
+
+Collects outputs from all specialist agents, applies configurable weights, and
+returns a consensus signal. Optionally calls the LLM to arbitrate when agents
+disagree significantly.
+
+ENV vars
+--------
+    AGENT_WEIGHTS       JSON dict of agent weights, e.g. '{"regime_agent":2.0}'
+    AGENT_LLM_ARBITER   set to '1' to enable LLM meta-arbitration (default: 0)
+"""
+from __future__ import annotations
+
+import json
+import os
+
+from agents.base import AgentProvider, AgentSignal
+from utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+_DEFAULT_WEIGHTS: dict[str, float] = {
+    "regime_agent": 1.5,
+    "risk_agent": 1.2,
+    "sentiment_agent": 0.8,
+    "screener_agent": 1.0,
+    "execution_agent": 0.5,
+}
+
+_SIGNAL_SCORES = {"bullish": 1.0, "neutral": 0.0, "bearish": -1.0}
+
+
+def _load_weights() -> dict[str, float]:
+    raw = os.environ.get("AGENT_WEIGHTS", "")
+    if raw:
+        try:
+            return {**_DEFAULT_WEIGHTS, **json.loads(raw)}
+        except Exception:
+            pass
+    return dict(_DEFAULT_WEIGHTS)
+
+
+class MetaAgent:
+    """
+    Aggregates specialist agent signals using weighted voting.
+
+    Parameters
+    ----------
+    agents : list of AgentProvider instances to consult.
+             Defaults to all five specialists when not provided.
+    weights : optional weight override dict {agent_name: weight}
+    """
+
+    def __init__(
+        self,
+        agents: list[AgentProvider] | None = None,
+        weights: dict[str, float] | None = None,
+    ) -> None:
+        if agents is None:
+            from agents.regime_agent import RegimeAgent
+            from agents.risk_agent import RiskAgent
+            from agents.sentiment_agent import SentimentAgent
+            from agents.screener_agent import ScreenerAgent
+            from agents.execution_agent import ExecutionAgent
+            agents = [RegimeAgent(), RiskAgent(), SentimentAgent(), ScreenerAgent(), ExecutionAgent()]
+        self._agents: list[AgentProvider] = agents
+        self._weights = weights or _load_weights()
+
+    def run(self, context: dict) -> dict:
+        """
+        Run all specialist agents and return a consensus signal dict.
+
+        Returns
+        -------
+        dict with keys:
+            signal       : 'bullish' | 'neutral' | 'bearish'
+            confidence   : float [0.0, 1.0]
+            weighted_score : float [-1.0, 1.0] (positive = bullish)
+            specialist_signals : list of individual AgentSignal dicts
+            reasoning    : str summary
+        """
+        signals: list[AgentSignal] = []
+        for agent in self._agents:
+            try:
+                sig = agent.run(context)
+                signals.append(sig)
+                logger.debug("Agent %s: %s (%.2f)", sig.agent_name, sig.signal, sig.confidence)
+            except Exception as exc:
+                logger.warning("Agent %s failed: %s", getattr(agent, "name", "?"), exc)
+
+        if not signals:
+            return {
+                "signal": "neutral",
+                "confidence": 0.0,
+                "weighted_score": 0.0,
+                "specialist_signals": [],
+                "reasoning": "No agents returned signals",
+            }
+
+        # Weighted vote
+        total_weight = 0.0
+        weighted_sum = 0.0
+        for sig in signals:
+            w = self._weights.get(sig.agent_name, 1.0)
+            score = _SIGNAL_SCORES.get(sig.signal, 0.0)
+            # Weight by both agent weight and signal confidence
+            effective_weight = w * sig.confidence
+            weighted_sum += score * effective_weight
+            total_weight += effective_weight
+
+        weighted_score = weighted_sum / total_weight if total_weight > 0 else 0.0
+
+        if weighted_score > 0.2:
+            consensus = "bullish"
+        elif weighted_score < -0.2:
+            consensus = "bearish"
+        else:
+            consensus = "neutral"
+
+        confidence = min(1.0, abs(weighted_score))
+        reasoning = f"Weighted score={weighted_score:+.3f} → {consensus}"
+
+        # Optional LLM arbitration for close calls
+        if os.environ.get("AGENT_LLM_ARBITER", "0") == "1" and abs(weighted_score) < 0.3:
+            try:
+                reasoning = self._llm_arbitrate(signals, context, weighted_score, reasoning)
+            except Exception as exc:
+                logger.warning("LLM arbiter failed: %s", exc)
+
+        return {
+            "signal": consensus,
+            "confidence": round(confidence, 4),
+            "weighted_score": round(weighted_score, 4),
+            "specialist_signals": [
+                {
+                    "agent": s.agent_name,
+                    "signal": s.signal,
+                    "confidence": s.confidence,
+                    "reasoning": s.reasoning,
+                }
+                for s in signals
+            ],
+            "reasoning": reasoning,
+        }
+
+    def _llm_arbitrate(
+        self,
+        signals: list[AgentSignal],
+        context: dict,
+        weighted_score: float,
+        fallback_reasoning: str,
+    ) -> str:
+        """Ask the LLM to arbitrate when the vote is close."""
+        from providers.llm import get_llm
+        summary = "\n".join(
+            f"- {s.agent_name}: {s.signal} ({s.confidence:.2f}) — {s.reasoning}"
+            for s in signals
+        )
+        ticker = context.get("ticker", "unknown")
+        prompt = (
+            f"You are a quant portfolio manager. The following specialist agents have "
+            f"analysed {ticker} and disagree (weighted score: {weighted_score:+.3f}):\n\n"
+            f"{summary}\n\n"
+            "Provide a one-sentence synthesis of their views and your recommendation. "
+            "Be direct and concise."
+        )
+        llm = get_llm()
+        return llm.complete(prompt)

--- a/agents/regime_agent.py
+++ b/agents/regime_agent.py
@@ -1,0 +1,44 @@
+"""agents/regime_agent.py — Specialist agent wrapping the regime classifier."""
+from __future__ import annotations
+
+from agents.base import AgentSignal
+from utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+class RegimeAgent:
+    """Returns a directional signal based on the current market regime."""
+
+    name = "regime_agent"
+
+    def run(self, context: dict) -> AgentSignal:
+        regime = context.get("regime")
+        if regime is None:
+            try:
+                from analysis.regime import get_live_regime_with_llm
+                data = get_live_regime_with_llm()
+                regime = data["regime"]
+            except Exception as exc:
+                logger.warning("RegimeAgent: regime fetch failed: %s", exc)
+                return AgentSignal(
+                    agent_name=self.name,
+                    signal="neutral",
+                    confidence=0.3,
+                    reasoning="Regime data unavailable",
+                )
+
+        signal_map = {
+            "trending_bull": ("bullish", 0.8),
+            "trending_bear": ("bearish", 0.8),
+            "mean_reverting": ("neutral", 0.5),
+            "high_vol": ("bearish", 0.6),
+        }
+        signal, confidence = signal_map.get(regime, ("neutral", 0.4))
+        return AgentSignal(
+            agent_name=self.name,
+            signal=signal,
+            confidence=confidence,
+            reasoning=f"Market regime is '{regime}'",
+            metadata={"regime": regime},
+        )

--- a/agents/risk_agent.py
+++ b/agents/risk_agent.py
@@ -1,0 +1,50 @@
+"""agents/risk_agent.py — Specialist agent wrapping correlation & VaR checks."""
+from __future__ import annotations
+
+from agents.base import AgentSignal
+from utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+class RiskAgent:
+    """Returns a risk signal based on portfolio concentration and VaR."""
+
+    name = "risk_agent"
+
+    def run(self, context: dict) -> AgentSignal:
+        portfolio = context.get("portfolio", {})
+        positions = portfolio.get("positions", {})
+
+        warnings: list[str] = []
+
+        # Correlation check
+        if len(positions) >= 2:
+            try:
+                from risk.correlation import check_correlation_alerts
+                from data.fetcher import fetch_ohlcv
+                price_data = {}
+                for ticker in list(positions.keys())[:10]:
+                    df = fetch_ohlcv(ticker, period="3mo")
+                    if not df.empty and "Close" in df.columns:
+                        price_data[ticker] = df["Close"]
+                alerts = check_correlation_alerts(price_data, positions)
+                for alert in alerts:
+                    warnings.append(alert.message)
+            except Exception as exc:
+                logger.debug("RiskAgent: correlation check failed: %s", exc)
+
+        if warnings:
+            return AgentSignal(
+                agent_name=self.name,
+                signal="bearish",
+                confidence=0.65,
+                reasoning=" | ".join(warnings[:2]),
+                metadata={"warning_count": len(warnings)},
+            )
+        return AgentSignal(
+            agent_name=self.name,
+            signal="neutral",
+            confidence=0.7,
+            reasoning="Portfolio risk metrics within normal thresholds",
+        )

--- a/agents/risk_agent.py
+++ b/agents/risk_agent.py
@@ -21,8 +21,8 @@ class RiskAgent:
         # Correlation check
         if len(positions) >= 2:
             try:
-                from risk.correlation import check_correlation_alerts
                 from data.fetcher import fetch_ohlcv
+                from risk.correlation import check_correlation_alerts
                 price_data = {}
                 for ticker in list(positions.keys())[:10]:
                     df = fetch_ohlcv(ticker, period="3mo")

--- a/agents/screener_agent.py
+++ b/agents/screener_agent.py
@@ -1,0 +1,47 @@
+"""agents/screener_agent.py — Specialist agent wrapping the equity screener."""
+from __future__ import annotations
+
+from agents.base import AgentSignal
+from utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+class ScreenerAgent:
+    """Returns a signal based on the screener's signal for the target ticker."""
+
+    name = "screener_agent"
+
+    def run(self, context: dict) -> AgentSignal:
+        ticker = context.get("ticker", "")
+        if not ticker:
+            return AgentSignal(
+                agent_name=self.name, signal="neutral", confidence=0.3,
+                reasoning="No ticker in context",
+            )
+        try:
+            from screener.screener import run_screener
+            results = run_screener(tickers=[ticker])
+            if results.empty:
+                raise ValueError("No screener results")
+            row = results.iloc[0]
+            signal_label = str(row.get("Signal", "Neutral")).lower()
+            if "trending up" in signal_label or "overbought" in signal_label:
+                signal, conf = "bullish", 0.7
+            elif "trending down" in signal_label or "oversold" in signal_label:
+                signal, conf = "bearish", 0.7
+            else:
+                signal, conf = "neutral", 0.5
+            return AgentSignal(
+                agent_name=self.name,
+                signal=signal,
+                confidence=conf,
+                reasoning=f"Screener signal for {ticker}: {signal_label}",
+                metadata={"screener_signal": signal_label},
+            )
+        except Exception as exc:
+            logger.debug("ScreenerAgent: screener failed for %s: %s", ticker, exc)
+            return AgentSignal(
+                agent_name=self.name, signal="neutral", confidence=0.3,
+                reasoning="Screener data unavailable",
+            )

--- a/agents/sentiment_agent.py
+++ b/agents/sentiment_agent.py
@@ -1,0 +1,43 @@
+"""agents/sentiment_agent.py — Specialist agent wrapping the sentiment provider."""
+from __future__ import annotations
+
+from agents.base import AgentSignal
+from utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+class SentimentAgent:
+    """Returns a signal based on ticker-level sentiment score."""
+
+    name = "sentiment_agent"
+
+    def run(self, context: dict) -> AgentSignal:
+        ticker = context.get("ticker", "SPY")
+        try:
+            from providers.sentiment import get_sentiment
+            provider = get_sentiment()
+            score = provider.ticker_sentiment(ticker)
+        except Exception as exc:
+            logger.debug("SentimentAgent: sentiment fetch failed: %s", exc)
+            return AgentSignal(
+                agent_name=self.name,
+                signal="neutral",
+                confidence=0.3,
+                reasoning="Sentiment data unavailable",
+            )
+
+        if score > 0.2:
+            signal, confidence = "bullish", min(0.9, 0.5 + score)
+        elif score < -0.2:
+            signal, confidence = "bearish", min(0.9, 0.5 + abs(score))
+        else:
+            signal, confidence = "neutral", 0.5
+
+        return AgentSignal(
+            agent_name=self.name,
+            signal=signal,
+            confidence=round(confidence, 2),
+            reasoning=f"Sentiment score for {ticker}: {score:.3f}",
+            metadata={"score": score},
+        )

--- a/analysis/anomaly_detector.py
+++ b/analysis/anomaly_detector.py
@@ -1,0 +1,272 @@
+"""
+analysis/anomaly_detector.py — Automated anomaly detection for signals, prices, and P&L.
+
+Detects three categories of anomalies:
+  1. Signal drought  — strategy produced zero signals for N hours
+  2. Price spike     — live price deviates > threshold% from recent mean
+  3. P&L divergence  — live P&L diverges from paper P&L over lookback window
+
+Designed to be called by scheduler/alerts.py:run_anomaly_checks() on a
+15-minute schedule.
+"""
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+
+import pandas as pd
+
+from utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+@dataclass
+class Anomaly:
+    """A detected anomaly event."""
+
+    type: str                          # 'signal_drought' | 'price_spike' | 'pnl_divergence'
+    severity: str                      # 'warning' | 'critical'
+    symbol: str                        # ticker or '' if not symbol-specific
+    details: dict = field(default_factory=dict)
+    message: str = ""
+    detected_at: float = field(default_factory=time.time)
+
+
+class AnomalyDetector:
+    """
+    Stateless anomaly detector — each method returns an Anomaly or None.
+
+    All external calls (DB, market data) are made lazily and guarded so a
+    single source failure does not suppress the other checks.
+    """
+
+    # ── Signal drought ─────────────────────────────────────────────────────────
+
+    def check_signal_drought(
+        self,
+        signal_log: list[dict] | None = None,
+        window_hours: int = 4,
+    ) -> Anomaly | None:
+        """
+        Return an Anomaly if no trading signals were generated in *window_hours*.
+
+        Parameters
+        ----------
+        signal_log   : list of dicts with 'entry_time' key (Unix timestamps).
+                       If None, queries the journal DB for recent entries.
+        window_hours : silence window that triggers the anomaly (default 4h)
+        """
+        now = time.time()
+        cutoff = now - window_hours * 3600
+
+        if signal_log is None:
+            try:
+                from journal.trading_journal import get_trades
+                trades = get_trades()
+                if trades is not None and not trades.empty:
+                    # Use executed_at or entry_time column
+                    ts_col = next(
+                        (c for c in trades.columns if "time" in c.lower() or "at" in c.lower()),
+                        None,
+                    )
+                    if ts_col is not None:
+                        recent = trades[pd.to_numeric(trades[ts_col], errors="coerce") > cutoff]
+                        if len(recent) > 0:
+                            return None  # signals exist — no drought
+                signal_log = []
+            except Exception as exc:
+                logger.debug("signal_drought: journal query failed: %s", exc)
+                return None
+
+        # Check provided log
+        if signal_log:
+            recent = [s for s in signal_log if float(s.get("entry_time", 0)) > cutoff]
+            if recent:
+                return None
+
+        msg = (
+            f"Signal drought detected: no trading signals in the last {window_hours} hours. "
+            "Check strategy logic, market data feed, and position limits."
+        )
+        logger.warning(msg)
+        return Anomaly(
+            type="signal_drought",
+            severity="warning",
+            symbol="",
+            details={"window_hours": window_hours, "last_checked": now},
+            message=msg,
+        )
+
+    # ── Price spike ───────────────────────────────────────────────────────────
+
+    def check_price_spike(
+        self,
+        symbol: str,
+        current_price: float,
+        lookback_days: int = 5,
+        threshold_pct: float = 0.10,
+    ) -> Anomaly | None:
+        """
+        Return an Anomaly if *current_price* deviates more than *threshold_pct*
+        from the mean over *lookback_days*.
+
+        Parameters
+        ----------
+        symbol        : ticker to check
+        current_price : latest price
+        lookback_days : historical window for mean calculation
+        threshold_pct : alert if |deviation| > this fraction (default 0.10 = 10%)
+        """
+        try:
+            from data.fetcher import fetch_ohlcv
+            period = f"{lookback_days + 5}d"
+            df = fetch_ohlcv(symbol, period=period)
+            if df.empty or "Close" not in df.columns:
+                return None
+            recent_prices = df["Close"].dropna().tail(lookback_days)
+            if len(recent_prices) < 2:
+                return None
+            mean_price = float(recent_prices.mean())
+            if mean_price <= 0:
+                return None
+            deviation = abs(current_price - mean_price) / mean_price
+            if deviation > threshold_pct:
+                msg = (
+                    f"Price spike detected for {symbol}: current=${current_price:.2f}, "
+                    f"{lookback_days}d mean=${mean_price:.2f}, "
+                    f"deviation={deviation:.1%} > threshold={threshold_pct:.1%}."
+                )
+                logger.warning(msg)
+                return Anomaly(
+                    type="price_spike",
+                    severity="warning" if deviation < 0.20 else "critical",
+                    symbol=symbol,
+                    details={
+                        "current_price": current_price,
+                        "mean_price": mean_price,
+                        "deviation_pct": round(deviation, 4),
+                        "threshold_pct": threshold_pct,
+                    },
+                    message=msg,
+                )
+        except Exception as exc:
+            logger.debug("price_spike check failed for %s: %s", symbol, exc)
+        return None
+
+    # ── P&L divergence ────────────────────────────────────────────────────────
+
+    def check_pnl_divergence(
+        self,
+        live_pnl_series: list[float],
+        paper_pnl_series: list[float],
+        threshold_pct: float = 0.05,
+        lookback_days: int = 5,
+    ) -> Anomaly | None:
+        """
+        Return an Anomaly if live P&L diverges from paper P&L by more than
+        *threshold_pct* over *lookback_days*.
+
+        Parameters
+        ----------
+        live_pnl_series  : list of daily live P&L values (most recent last)
+        paper_pnl_series : list of daily paper P&L values (most recent last)
+        threshold_pct    : fractional divergence threshold (default 0.05 = 5%)
+        lookback_days    : number of data points to compare
+        """
+        if not live_pnl_series or not paper_pnl_series:
+            return None
+
+        live = list(live_pnl_series[-lookback_days:])
+        paper = list(paper_pnl_series[-lookback_days:])
+        n = min(len(live), len(paper))
+        if n < 2:
+            return None
+
+        live_sum = sum(live[-n:])
+        paper_sum = sum(paper[-n:])
+        denom = max(abs(paper_sum), 1.0)
+        divergence = abs(live_sum - paper_sum) / denom
+
+        if divergence > threshold_pct:
+            msg = (
+                f"P&L divergence detected: live={live_sum:+.2f}, paper={paper_sum:+.2f} "
+                f"over {n} days — divergence {divergence:.1%} > threshold {threshold_pct:.1%}. "
+                "Investigate execution differences between live and paper accounts."
+            )
+            logger.warning(msg)
+            return Anomaly(
+                type="pnl_divergence",
+                severity="warning" if divergence < 0.15 else "critical",
+                symbol="",
+                details={
+                    "live_sum": live_sum,
+                    "paper_sum": paper_sum,
+                    "divergence_pct": round(divergence, 4),
+                    "lookback_days": n,
+                },
+                message=msg,
+            )
+        return None
+
+    # ── Orchestrator ───────────────────────────────────────────────────────────
+
+    def run_all_checks(
+        self,
+        watchlist: list[str],
+        current_prices: dict[str, float],
+    ) -> list[dict]:
+        """
+        Run all three anomaly checks and return a list of anomaly dicts.
+
+        Parameters
+        ----------
+        watchlist       : list of tickers to check for price spikes
+        current_prices  : {ticker: price} mapping
+
+        Returns
+        -------
+        List of dicts, one per detected anomaly.
+        """
+        anomalies: list[Anomaly] = []
+
+        # 1. Signal drought
+        drought = self.check_signal_drought()
+        if drought:
+            anomalies.append(drought)
+
+        # 2. Price spikes for each watched ticker
+        for ticker in watchlist:
+            price = current_prices.get(ticker)
+            if price is not None and price > 0:
+                spike = self.check_price_spike(ticker, price)
+                if spike:
+                    anomalies.append(spike)
+
+        # 3. P&L divergence (best-effort from portfolio history)
+        try:
+            from data.db import get_connection
+            conn = get_connection()
+            rows = conn.execute(
+                "SELECT total_value FROM portfolio_history ORDER BY record_date DESC LIMIT 10"
+            ).fetchall()
+            conn.close()
+            if rows and len(rows) >= 2:
+                paper_values = [float(r[0]) for r in reversed(rows)]
+                paper_pnl = [paper_values[i] - paper_values[i - 1] for i in range(1, len(paper_values))]
+                # Without a separate live account we skip this check
+                # (it activates when a live broker is connected)
+        except Exception:
+            pass
+
+        return [
+            {
+                "type": a.type,
+                "severity": a.severity,
+                "symbol": a.symbol,
+                "message": a.message,
+                "details": a.details,
+                "detected_at": a.detected_at,
+            }
+            for a in anomalies
+        ]

--- a/analysis/anomaly_detector.py
+++ b/analysis/anomaly_detector.py
@@ -252,10 +252,10 @@ class AnomalyDetector:
             ).fetchall()
             conn.close()
             if rows and len(rows) >= 2:
-                paper_values = [float(r[0]) for r in reversed(rows)]
-                paper_pnl = [paper_values[i] - paper_values[i - 1] for i in range(1, len(paper_values))]
-                # Without a separate live account we skip this check
-                # (it activates when a live broker is connected)
+                # Without a separate live account we skip this check.
+                # When a live broker is connected, call check_pnl_divergence() directly
+                # with both live and paper P&L series.
+                pass
         except Exception:
             pass
 

--- a/analysis/regime.py
+++ b/analysis/regime.py
@@ -1,9 +1,33 @@
-"""Market Regime Detector — classifies market conditions using SPY vs 200d SMA and VIX."""
+"""
+analysis/regime.py — Market Regime Detector.
+
+Classifies market conditions using SPY vs 200d SMA and VIX into one of four
+states: trending_bull, trending_bear, mean_reverting, high_vol.
+
+Optional LLM fusion: set REGIME_LLM_WEIGHT > 0.0 to blend a macro LLM signal
+with the quantitative signal. Requires LLM_PROVIDER to be configured.
+
+ENV vars
+--------
+    REGIME_LLM_WEIGHT   float 0.0–1.0 (default 0.0 = disabled)
+"""
+from __future__ import annotations
+
+import json
+import os
+
 import pandas as pd
 
 from utils.logger import get_logger
 
 logger = get_logger(__name__)
+
+REGIME_STATES: list[str] = [
+    "trending_bull",
+    "trending_bear",
+    "mean_reverting",
+    "high_vol",
+]
 
 # ── Regime metadata ────────────────────────────────────────────────────────────
 
@@ -152,3 +176,144 @@ def get_live_regime() -> dict:
         "description": meta["description"],
         "recommended_strategies": list(meta["recommended_strategies"]),
     }
+
+
+# ── LLM fusion helpers ─────────────────────────────────────────────────────────
+
+def _build_macro_prompt(spy_price: float, spy_sma200: float, vix: float) -> str:
+    """Build a structured prompt asking the LLM to classify the market regime."""
+    trend = "above" if spy_price > spy_sma200 else "below"
+    return (
+        "You are a quantitative macro analyst. Classify the current US equity market regime "
+        "based on the data below. Respond ONLY with valid JSON — no explanation.\n\n"
+        f"SPY price: {spy_price:.2f}\n"
+        f"SPY 200-day SMA: {spy_sma200:.2f}  (SPY is {trend} its 200d SMA)\n"
+        f"VIX: {vix:.2f}\n\n"
+        'Return JSON with exactly two keys: "regime" and "confidence".\n'
+        f'"regime" must be one of: {REGIME_STATES}.\n'
+        '"confidence" must be a float between 0.0 and 1.0.\n'
+        'Example: {"regime": "trending_bull", "confidence": 0.82}'
+    )
+
+
+def _parse_llm_regime(llm_response: str) -> tuple[str, float]:
+    """
+    Parse the LLM's JSON regime response.
+
+    Returns (regime_label, confidence). Falls back to ('high_vol', 0.5) on
+    any parse failure so the system degrades gracefully.
+    """
+    _FALLBACK = ("high_vol", 0.5)
+    try:
+        # Strip markdown code fences if present
+        text = llm_response.strip()
+        if text.startswith("```"):
+            lines = text.splitlines()
+            text = "\n".join(
+                line for line in lines if not line.startswith("```")
+            ).strip()
+        data = json.loads(text)
+        regime = str(data.get("regime", "")).strip()
+        if regime not in REGIME_STATES:
+            logger.warning("LLM returned unknown regime %r; falling back", regime)
+            return _FALLBACK
+        confidence = float(data.get("confidence", 0.5))
+        confidence = max(0.0, min(1.0, confidence))
+        return regime, confidence
+    except Exception as exc:
+        logger.warning("Failed to parse LLM regime response: %s  raw=%r", exc, llm_response[:200])
+        return _FALLBACK
+
+
+def _blend_regimes(
+    quant_regime: str,
+    llm_regime: str,
+    llm_confidence: float,
+    weight: float,
+) -> str:
+    """
+    Blend a quantitative regime signal with an LLM regime signal.
+
+    At weight=0.0 returns quant_regime unchanged.
+    At weight=1.0 returns llm_regime (scaled by llm_confidence).
+    In between, builds probability vectors over REGIME_STATES and takes argmax.
+    """
+    if weight <= 0.0:
+        return quant_regime
+    if weight >= 1.0:
+        return llm_regime
+
+    # Quant signal: full confidence in its single prediction
+    q_vec = [1.0 if r == quant_regime else 0.0 for r in REGIME_STATES]
+    # LLM signal: llm_confidence on the predicted regime, remainder spread uniformly
+    remainder = (1.0 - llm_confidence) / (len(REGIME_STATES) - 1)
+    l_vec = [
+        llm_confidence if r == llm_regime else remainder
+        for r in REGIME_STATES
+    ]
+    # Weighted blend
+    blended = [
+        (1.0 - weight) * q + weight * l
+        for q, l in zip(q_vec, l_vec)
+    ]
+    best_idx = blended.index(max(blended))
+    return REGIME_STATES[best_idx]
+
+
+def get_live_regime_with_llm(llm_weight: float | None = None) -> dict:
+    """
+    Fetch live SPY/VIX data, classify regime, and optionally blend with an LLM
+    macro signal.
+
+    Parameters
+    ----------
+    llm_weight : float or None
+        Weight for the LLM signal in [0.0, 1.0].  None reads REGIME_LLM_WEIGHT
+        env var (default 0.0 = disabled — identical to get_live_regime()).
+
+    Returns
+    -------
+    dict with all keys from get_live_regime() plus, when LLM is enabled:
+        llm_regime      : str  — regime label returned by LLM
+        llm_confidence  : float
+        llm_weight      : float
+        quant_regime    : str  — original price-based regime before blending
+    """
+    result = get_live_regime()
+
+    weight = llm_weight if llm_weight is not None else float(
+        os.environ.get("REGIME_LLM_WEIGHT", "0.0")
+    )
+
+    if weight <= 0.0:
+        return result
+
+    try:
+        from providers.llm import get_llm
+        llm = get_llm()
+        prompt = _build_macro_prompt(
+            result["spy_price"], result["spy_sma200"], result["vix"]
+        )
+        raw = llm.complete(prompt)
+        llm_regime, llm_conf = _parse_llm_regime(raw)
+        quant_regime = result["regime"]
+        blended = _blend_regimes(quant_regime, llm_regime, llm_conf, weight)
+
+        result["quant_regime"] = quant_regime
+        result["llm_regime"] = llm_regime
+        result["llm_confidence"] = llm_conf
+        result["llm_weight"] = weight
+        result["regime"] = blended
+        # Update description/strategies for the blended regime
+        meta = REGIME_METADATA[blended]
+        result["description"] = meta["description"]
+        result["recommended_strategies"] = list(meta["recommended_strategies"])
+
+        logger.info(
+            "LLM regime fusion: quant=%s llm=%s(%.2f) weight=%.2f → %s",
+            quant_regime, llm_regime, llm_conf, weight, blended,
+        )
+    except Exception as exc:
+        logger.warning("LLM regime fusion failed, using quant regime: %s", exc)
+
+    return result

--- a/analysis/regime.py
+++ b/analysis/regime.py
@@ -253,8 +253,8 @@ def _blend_regimes(
     ]
     # Weighted blend
     blended = [
-        (1.0 - weight) * q + weight * l
-        for q, l in zip(q_vec, l_vec)
+        (1.0 - weight) * q_val + weight * llm_val
+        for q_val, llm_val in zip(q_vec, l_vec)
     ]
     best_idx = blended.index(max(blended))
     return REGIME_STATES[best_idx]

--- a/analysis/rl_sizer.py
+++ b/analysis/rl_sizer.py
@@ -1,0 +1,186 @@
+"""
+analysis/rl_sizer.py — Reinforcement Learning position sizer.
+
+Trains a PPO agent (Stable-Baselines3) on historical journal trade data to
+output a position size multiplier in [0.0, 2.0].  Falls back to Kelly criterion
+when the model is not loaded or when stable-baselines3 is not installed.
+
+ENV vars
+--------
+    RL_SIZER_MODEL_PATH     path to SB3 zip checkpoint (default: models/rl_sizer.zip)
+    RL_SIZER_RETRAIN        set to '1' to trigger retraining in monthly cron
+
+Optional dependencies (guarded):
+    stable-baselines3 >= 2.0.0
+    gymnasium >= 0.29.0
+"""
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+
+from analysis.regime import REGIME_STATES, kelly_regime_multiplier
+from risk.kelly import kelly_fraction
+from utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+_DEFAULT_MODEL_PATH = os.environ.get("RL_SIZER_MODEL_PATH", "models/rl_sizer.zip")
+
+# Observation vector layout:
+#   [0..3] regime one-hot (trending_bull, trending_bear, mean_reverting, high_vol)
+#   [4]    30-day realised volatility (annualised, e.g. 0.20 = 20%)
+#   [5]    recent win rate (last 20 trades)
+#   [6]    current drawdown from peak (e.g. 0.05 = 5%)
+_OBS_DIM = 7
+_ACTION_LOW, _ACTION_HIGH = 0.0, 2.0
+
+
+@dataclass
+class RLSizerObservation:
+    """Structured observation for the RL position sizer."""
+
+    regime: str          # one of REGIME_STATES
+    volatility: float    # annualised realised vol, e.g. 0.20
+    win_rate: float      # recent win rate in [0, 1]
+    drawdown: float      # current drawdown from equity peak, in [0, 1]
+
+
+def _obs_to_array(obs: RLSizerObservation) -> np.ndarray:
+    """Encode observation to a fixed-length float32 array of shape (7,)."""
+    regime_oh = [1.0 if r == obs.regime else 0.0 for r in REGIME_STATES]
+    return np.array(
+        regime_oh + [obs.volatility, obs.win_rate, obs.drawdown],
+        dtype=np.float32,
+    )
+
+
+class RLPositionSizer:
+    """
+    Position size multiplier using a trained PPO agent.
+
+    Falls back to Kelly-based sizing when:
+    - stable-baselines3 is not installed
+    - the model checkpoint file does not exist
+    - any inference error occurs
+    """
+
+    def __init__(self, model_path: str | None = None) -> None:
+        self._model_path = model_path or _DEFAULT_MODEL_PATH
+        self._model = None
+        self._load_if_available()
+
+    def _load_if_available(self) -> None:
+        path = Path(self._model_path)
+        if not path.exists():
+            logger.info("RL sizer: model not found at %s, will use Kelly fallback", path)
+            return
+        try:
+            from stable_baselines3 import PPO  # type: ignore[import]
+            self._model = PPO.load(str(path))
+            logger.info("RL sizer: loaded model from %s", path)
+        except ImportError:
+            logger.info("stable-baselines3 not installed; RL sizer using Kelly fallback")
+        except Exception as exc:
+            logger.warning("RL sizer: failed to load model: %s", exc)
+
+    def load(self, path: str) -> None:
+        """Hot-reload a new checkpoint without restarting."""
+        self._model_path = path
+        self._model = None
+        self._load_if_available()
+
+    def predict(self, obs: RLSizerObservation) -> float:
+        """
+        Return a position size multiplier in [0.0, 2.0].
+
+        Uses the PPO model when available; otherwise delegates to Kelly fallback.
+        """
+        if self._model is None:
+            return self._kelly_fallback(obs)
+        try:
+            arr = _obs_to_array(obs)
+            action, _ = self._model.predict(arr, deterministic=True)
+            multiplier = float(np.clip(action, _ACTION_LOW, _ACTION_HIGH))
+            logger.debug("RL sizer: obs=%s → multiplier=%.3f", obs, multiplier)
+            return multiplier
+        except Exception as exc:
+            logger.warning("RL sizer predict error: %s; using Kelly fallback", exc)
+            return self._kelly_fallback(obs)
+
+    def _kelly_fallback(self, obs: RLSizerObservation) -> float:
+        """Derive a size multiplier from Kelly fraction and regime adjustment."""
+        # Conservative Kelly parameters inferred from win rate
+        avg_win = 0.05   # assume 5% average win
+        avg_loss = 0.03  # assume 3% average loss
+        kelly = kelly_fraction(obs.win_rate, avg_win, avg_loss, max_fraction=0.5)
+        regime_mult = kelly_regime_multiplier(obs.regime)
+        # Normalise Kelly [0, 0.5] to multiplier [0, 2], then apply regime factor
+        raw = (kelly / 0.25) * regime_mult  # 0.25 Kelly → 1.0x multiplier
+        return float(np.clip(raw, _ACTION_LOW, _ACTION_HIGH))
+
+
+def build_observation_from_live() -> RLSizerObservation:
+    """
+    Build an RLSizerObservation from live platform data.
+
+    Fetches regime, SPY volatility, journal win rate, and paper account drawdown.
+    Falls back gracefully if any source is unavailable.
+    """
+    # 1. Regime
+    try:
+        from analysis.regime import get_live_regime
+        regime_data = get_live_regime()
+        regime = regime_data["regime"]
+    except Exception as exc:
+        logger.warning("build_observation_from_live: regime fetch failed: %s", exc)
+        regime = "high_vol"  # conservative fallback
+
+    # 2. Realised volatility (SPY 30-day)
+    try:
+        from data.fetcher import fetch_ohlcv
+        spy_df = fetch_ohlcv("SPY", period="3mo")
+        if not spy_df.empty and "Close" in spy_df.columns:
+            returns = spy_df["Close"].pct_change().dropna()
+            volatility = float(returns.std() * (252 ** 0.5))  # annualised
+        else:
+            volatility = 0.20
+    except Exception:
+        volatility = 0.20
+
+    # 3. Recent win rate (last 20 closed trades from journal)
+    win_rate = 0.5  # neutral default
+    try:
+        from journal.trading_journal import get_trades
+        trades = get_trades()
+        if trades is not None and not trades.empty:
+            closes = trades[trades.get("action", trades.columns[0]).str.upper() == "SELL"] \
+                if "action" in trades.columns else trades
+            if "realised_pnl" in closes.columns:
+                recent = closes["realised_pnl"].dropna().tail(20)
+                if len(recent) > 0:
+                    win_rate = float((recent > 0).mean())
+    except Exception:
+        pass
+
+    # 4. Current drawdown from paper account
+    drawdown = 0.0
+    try:
+        from broker.paper_trader import get_account
+        acct = get_account()
+        starting = acct.get("starting_cash", 100_000)
+        total = acct.get("total_value", starting)
+        if starting > 0:
+            drawdown = float(max(0.0, (starting - total) / starting))
+    except Exception:
+        pass
+
+    return RLSizerObservation(
+        regime=regime,
+        volatility=volatility,
+        win_rate=win_rate,
+        drawdown=drawdown,
+    )

--- a/analysis/rl_trainer.py
+++ b/analysis/rl_trainer.py
@@ -1,0 +1,192 @@
+"""
+analysis/rl_trainer.py — PPO training loop for the RL position sizer.
+
+Requires: stable-baselines3 >= 2.0.0, gymnasium >= 0.29.0
+
+All imports are guarded so the rest of the platform continues to work when
+these heavy ML dependencies are not installed.
+
+ENV vars
+--------
+    RL_SIZER_MODEL_PATH     destination for saved checkpoint (default: models/rl_sizer.zip)
+    RL_SIZER_TIMESTEPS      PPO training timesteps (default: 50000)
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+from analysis.rl_sizer import (
+    REGIME_STATES,
+    RLSizerObservation,
+    _ACTION_HIGH,
+    _ACTION_LOW,
+    _OBS_DIM,
+    _obs_to_array,
+)
+from utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+_DEFAULT_MODEL_PATH = os.environ.get("RL_SIZER_MODEL_PATH", "models/rl_sizer.zip")
+_DEFAULT_TIMESTEPS = int(os.environ.get("RL_SIZER_TIMESTEPS", "50000"))
+
+
+def _build_env(trades_df: pd.DataFrame):
+    """
+    Build a gymnasium Env from a DataFrame of closed trades.
+
+    Each row must contain at minimum:
+        regime        : str (one of REGIME_STATES)
+        volatility    : float
+        win_rate      : float  (rolling up to that trade)
+        drawdown      : float
+        realised_pnl  : float  (reward signal)
+
+    Returns a QuantTradingEnv instance.
+    """
+    try:
+        import gymnasium as gym  # type: ignore[import]
+        from gymnasium import spaces  # type: ignore[import]
+    except ImportError as exc:
+        raise ImportError(
+            "gymnasium is required for RL training. "
+            "Install it with: pip install gymnasium"
+        ) from exc
+
+    class QuantTradingEnv(gym.Env):
+        """Single-episode environment: walks through the trade DataFrame."""
+
+        metadata = {"render_modes": []}
+
+        def __init__(self, df: pd.DataFrame) -> None:
+            super().__init__()
+            self._df = df.reset_index(drop=True)
+            self._idx = 0
+            self.observation_space = spaces.Box(
+                low=np.zeros(_OBS_DIM, dtype=np.float32),
+                high=np.ones(_OBS_DIM, dtype=np.float32) * 10,
+                dtype=np.float32,
+            )
+            self.action_space = spaces.Box(
+                low=np.array([_ACTION_LOW], dtype=np.float32),
+                high=np.array([_ACTION_HIGH], dtype=np.float32),
+                dtype=np.float32,
+            )
+
+        def _get_obs(self) -> np.ndarray:
+            row = self._df.iloc[self._idx]
+            obs = RLSizerObservation(
+                regime=str(row.get("regime", "high_vol")),
+                volatility=float(row.get("volatility", 0.20)),
+                win_rate=float(row.get("win_rate", 0.5)),
+                drawdown=float(row.get("drawdown", 0.0)),
+            )
+            return _obs_to_array(obs)
+
+        def reset(self, *, seed=None, options=None):
+            super().reset(seed=seed)
+            self._idx = 0
+            return self._get_obs(), {}
+
+        def step(self, action):
+            row = self._df.iloc[self._idx]
+            pnl = float(row.get("realised_pnl", 0.0))
+            multiplier = float(np.clip(action[0], _ACTION_LOW, _ACTION_HIGH))
+            reward = pnl * multiplier  # reward = scaled P&L
+            self._idx += 1
+            done = self._idx >= len(self._df)
+            obs = self._get_obs() if not done else np.zeros(_OBS_DIM, dtype=np.float32)
+            return obs, reward, done, False, {}
+
+    return QuantTradingEnv(trades_df)
+
+
+def _prepare_training_df(trades_df: pd.DataFrame) -> pd.DataFrame:
+    """
+    Enrich raw trade records with rolling win_rate and dummy regime/vol/drawdown
+    columns where they are absent.
+    """
+    df = trades_df.copy()
+
+    # Ensure required columns exist
+    if "realised_pnl" not in df.columns:
+        raise ValueError("trades_df must contain a 'realised_pnl' column")
+
+    if "regime" not in df.columns:
+        df["regime"] = "trending_bull"  # neutral assumption when missing
+    df["regime"] = df["regime"].fillna("trending_bull")
+    # Validate and replace unknown regimes
+    df["regime"] = df["regime"].where(df["regime"].isin(REGIME_STATES), "trending_bull")
+
+    if "volatility" not in df.columns:
+        df["volatility"] = 0.20
+
+    # Rolling win rate (window=20)
+    if "win_rate" not in df.columns:
+        is_win = (df["realised_pnl"] > 0).astype(float)
+        df["win_rate"] = is_win.rolling(20, min_periods=1).mean()
+
+    if "drawdown" not in df.columns:
+        pnl_cum = df["realised_pnl"].cumsum()
+        running_max = pnl_cum.cummax()
+        df["drawdown"] = ((running_max - pnl_cum) / running_max.replace(0, 1)).clip(0, 1)
+
+    return df.dropna(subset=["realised_pnl"])
+
+
+def train(
+    trades_df: pd.DataFrame,
+    total_timesteps: int = _DEFAULT_TIMESTEPS,
+    save_path: str = _DEFAULT_MODEL_PATH,
+) -> str:
+    """
+    Train a PPO position sizer on the given trade DataFrame and save the checkpoint.
+
+    Parameters
+    ----------
+    trades_df       : DataFrame of closed trades with at least 'realised_pnl' column
+    total_timesteps : PPO training steps (default: RL_SIZER_TIMESTEPS env var)
+    save_path       : destination .zip path for the checkpoint
+
+    Returns
+    -------
+    Absolute path to the saved checkpoint file.
+
+    Raises
+    ------
+    ImportError  if stable-baselines3 or gymnasium are not installed
+    ValueError   if trades_df is missing required columns or has < 10 rows
+    """
+    try:
+        from stable_baselines3 import PPO  # type: ignore[import]
+    except ImportError as exc:
+        raise ImportError(
+            "stable-baselines3 is required for RL training. "
+            "Install it with: pip install stable-baselines3"
+        ) from exc
+
+    df = _prepare_training_df(trades_df)
+    if len(df) < 10:
+        raise ValueError(
+            f"Need at least 10 closed trades to train the RL sizer; got {len(df)}."
+        )
+
+    # Ensure model directory exists
+    Path(save_path).parent.mkdir(parents=True, exist_ok=True)
+
+    env = _build_env(df)
+    logger.info(
+        "RL sizer: starting PPO training on %d trades, %d timesteps",
+        len(df), total_timesteps,
+    )
+    model = PPO("MlpPolicy", env, verbose=0)
+    model.learn(total_timesteps=total_timesteps)
+    model.save(save_path)
+
+    abs_path = str(Path(save_path).resolve())
+    logger.info("RL sizer: checkpoint saved to %s", abs_path)
+    return abs_path

--- a/analysis/rl_trainer.py
+++ b/analysis/rl_trainer.py
@@ -20,11 +20,11 @@ import numpy as np
 import pandas as pd
 
 from analysis.rl_sizer import (
-    REGIME_STATES,
-    RLSizerObservation,
     _ACTION_HIGH,
     _ACTION_LOW,
     _OBS_DIM,
+    REGIME_STATES,
+    RLSizerObservation,
     _obs_to_array,
 )
 from utils.logger import get_logger

--- a/analysis/rl_trainer.py
+++ b/analysis/rl_trainer.py
@@ -35,7 +35,7 @@ _DEFAULT_MODEL_PATH = os.environ.get("RL_SIZER_MODEL_PATH", "models/rl_sizer.zip
 _DEFAULT_TIMESTEPS = int(os.environ.get("RL_SIZER_TIMESTEPS", "50000"))
 
 
-def _build_env(trades_df: pd.DataFrame):
+def _build_env(trades_df: pd.DataFrame):  # pragma: no cover
     """
     Build a gymnasium Env from a DataFrame of closed trades.
 
@@ -138,7 +138,7 @@ def _prepare_training_df(trades_df: pd.DataFrame) -> pd.DataFrame:
     return df.dropna(subset=["realised_pnl"])
 
 
-def train(
+def train(  # pragma: no cover
     trades_df: pd.DataFrame,
     total_timesteps: int = _DEFAULT_TIMESTEPS,
     save_path: str = _DEFAULT_MODEL_PATH,

--- a/analysis/stress_test.py
+++ b/analysis/stress_test.py
@@ -1,0 +1,250 @@
+"""
+analysis/stress_test.py — Portfolio stress testing with historical crisis scenarios.
+
+Applies percentage shocks to an open portfolio and computes projected NAV impact.
+Optionally calls the LLM provider to generate plausible adverse scenarios.
+
+ENV vars
+--------
+    LLM_STRESS_SCENARIOS    set to '1' to enable LLM scenario generation (default: 0)
+"""
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+
+import pandas as pd
+
+from utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+@dataclass
+class StressScenario:
+    """Description of a historical or synthetic stress scenario."""
+
+    name: str
+    description: str
+    equity_shock: float      # fractional change, e.g. -0.52 = -52%
+    vol_multiplier: float = 1.0
+    rates_bps: float = 0.0   # interest rate change in basis points (informational)
+
+
+@dataclass
+class StressResult:
+    """Outcome of applying a scenario to the current portfolio."""
+
+    scenario_name: str
+    description: str
+    pre_nav: float
+    post_nav: float
+    nav_change: float          # absolute dollar change
+    nav_change_pct: float      # percentage change, e.g. -0.52
+    worst_position: str        # ticker with largest absolute loss
+    position_impacts: dict[str, float] = field(default_factory=dict)  # ticker → dollar impact
+
+
+# ── Pre-built historical scenarios ────────────────────────────────────────────
+
+HISTORICAL_SCENARIOS: list[StressScenario] = [
+    StressScenario(
+        name="2008_gfc",
+        description="2008 Global Financial Crisis — peak-to-trough S&P 500 drawdown of ~55%.",
+        equity_shock=-0.52,
+        vol_multiplier=4.0,
+        rates_bps=-200,
+    ),
+    StressScenario(
+        name="2020_covid",
+        description="2020 COVID-19 crash — S&P 500 fell ~34% in 33 days (Feb–Mar 2020).",
+        equity_shock=-0.34,
+        vol_multiplier=5.0,
+        rates_bps=-150,
+    ),
+    StressScenario(
+        name="2022_rate_hike",
+        description="2022 Fed rate-hike cycle — S&P 500 -25%, bonds -15%, VIX doubled.",
+        equity_shock=-0.25,
+        vol_multiplier=2.0,
+        rates_bps=450,
+    ),
+]
+
+
+# ── Core logic ────────────────────────────────────────────────────────────────
+
+def apply_scenario(portfolio_df: pd.DataFrame, scenario: StressScenario) -> StressResult:
+    """
+    Apply a stress scenario to the portfolio and return projected impact.
+
+    Parameters
+    ----------
+    portfolio_df : DataFrame with at minimum columns 'Ticker' and 'Market Value'.
+                   (matches the output of broker/paper_trader.get_portfolio())
+    scenario     : StressScenario to apply
+
+    Returns
+    -------
+    StressResult with pre/post NAV and per-position impacts.
+    """
+    if portfolio_df.empty:
+        return StressResult(
+            scenario_name=scenario.name,
+            description=scenario.description,
+            pre_nav=0.0,
+            post_nav=0.0,
+            nav_change=0.0,
+            nav_change_pct=0.0,
+            worst_position="N/A",
+            position_impacts={},
+        )
+
+    # Normalise column name variations
+    mv_col = next(
+        (c for c in portfolio_df.columns if c.lower().replace(" ", "_") == "market_value"),
+        None,
+    )
+    ticker_col = next(
+        (c for c in portfolio_df.columns if c.lower() == "ticker"),
+        None,
+    )
+    if mv_col is None or ticker_col is None:
+        raise ValueError(
+            "portfolio_df must contain 'Ticker' and 'Market Value' columns"
+        )
+
+    pre_nav = float(portfolio_df[mv_col].fillna(0).sum())
+    impacts: dict[str, float] = {}
+
+    for _, row in portfolio_df.iterrows():
+        ticker = str(row[ticker_col])
+        mv = float(row[mv_col] or 0)
+        dollar_impact = mv * scenario.equity_shock
+        impacts[ticker] = dollar_impact
+
+    total_impact = sum(impacts.values())
+    post_nav = pre_nav + total_impact
+    nav_change_pct = total_impact / pre_nav if pre_nav != 0 else 0.0
+
+    worst = min(impacts, key=impacts.get) if impacts else "N/A"
+
+    return StressResult(
+        scenario_name=scenario.name,
+        description=scenario.description,
+        pre_nav=round(pre_nav, 2),
+        post_nav=round(post_nav, 2),
+        nav_change=round(total_impact, 2),
+        nav_change_pct=round(nav_change_pct, 4),
+        worst_position=worst,
+        position_impacts={k: round(v, 2) for k, v in impacts.items()},
+    )
+
+
+def apply_custom_shock(
+    portfolio_df: pd.DataFrame,
+    equity_pct: float,
+    vol_mult: float = 1.0,
+    name: str = "custom",
+) -> StressResult:
+    """
+    Apply a custom equity shock percentage to the portfolio.
+
+    Parameters
+    ----------
+    portfolio_df : portfolio DataFrame (same format as apply_scenario)
+    equity_pct   : shock as a fraction, e.g. -0.30 = -30%, 0.10 = +10%
+    vol_mult     : volatility multiplier (informational only)
+    name         : label for the result
+    """
+    scenario = StressScenario(
+        name=name,
+        description=f"Custom shock: equity {equity_pct:+.1%}, vol ×{vol_mult:.1f}",
+        equity_shock=equity_pct,
+        vol_multiplier=vol_mult,
+    )
+    return apply_scenario(portfolio_df, scenario)
+
+
+def run_stress_tests(
+    portfolio_df: pd.DataFrame,
+    scenarios: list[StressScenario] | None = None,
+) -> list[StressResult]:
+    """
+    Run a list of stress scenarios against the portfolio.
+
+    Parameters
+    ----------
+    portfolio_df : portfolio DataFrame
+    scenarios    : list of StressScenario objects; defaults to HISTORICAL_SCENARIOS
+
+    Returns
+    -------
+    List of StressResult objects, one per scenario.
+    """
+    to_run = scenarios if scenarios is not None else HISTORICAL_SCENARIOS
+    results = []
+    for scenario in to_run:
+        try:
+            results.append(apply_scenario(portfolio_df, scenario))
+        except Exception as exc:
+            logger.warning("Stress test failed for %s: %s", scenario.name, exc)
+    return results
+
+
+def generate_llm_scenarios(
+    portfolio_summary: str,
+    regime: str = "unknown",
+    n_scenarios: int = 3,
+) -> list[StressScenario]:
+    """
+    Ask the LLM to generate plausible adverse scenarios for the current regime.
+
+    Returns an empty list when LLM_STRESS_SCENARIOS != '1' or when the LLM
+    is unavailable.
+
+    Parameters
+    ----------
+    portfolio_summary : human-readable summary of portfolio holdings
+    regime            : current market regime label
+    n_scenarios       : number of scenarios to request (default 3)
+    """
+    if os.environ.get("LLM_STRESS_SCENARIOS", "0") != "1":
+        return []
+
+    prompt = (
+        f"You are a risk manager. The current market regime is '{regime}'.\n"
+        f"Portfolio summary:\n{portfolio_summary}\n\n"
+        f"Generate {n_scenarios} plausible adverse scenarios for this portfolio. "
+        "For each scenario respond with a JSON object with keys: "
+        '"name" (short slug), "description" (1 sentence), '
+        '"equity_shock" (float, e.g. -0.30 for -30%), '
+        '"vol_multiplier" (float ≥ 1.0), "rates_bps" (int).\n'
+        f"Return a JSON array of exactly {n_scenarios} objects. No other text."
+    )
+
+    try:
+        from providers.llm import get_llm
+        import json
+        llm = get_llm()
+        raw = llm.complete(prompt)
+        # Strip markdown code fences
+        text = raw.strip()
+        if text.startswith("```"):
+            lines = text.splitlines()
+            text = "\n".join(l for l in lines if not l.startswith("```")).strip()
+        items = json.loads(text)
+        scenarios = []
+        for item in items:
+            scenarios.append(StressScenario(
+                name=str(item.get("name", "llm_scenario")),
+                description=str(item.get("description", "")),
+                equity_shock=float(item.get("equity_shock", -0.20)),
+                vol_multiplier=float(item.get("vol_multiplier", 1.5)),
+                rates_bps=float(item.get("rates_bps", 0)),
+            ))
+        logger.info("LLM generated %d stress scenarios", len(scenarios))
+        return scenarios
+    except Exception as exc:
+        logger.warning("LLM scenario generation failed: %s", exc)
+        return []

--- a/analysis/stress_test.py
+++ b/analysis/stress_test.py
@@ -224,15 +224,16 @@ def generate_llm_scenarios(
     )
 
     try:
-        from providers.llm import get_llm
         import json
+
+        from providers.llm import get_llm
         llm = get_llm()
         raw = llm.complete(prompt)
         # Strip markdown code fences
         text = raw.strip()
         if text.startswith("```"):
             lines = text.splitlines()
-            text = "\n".join(l for l in lines if not l.startswith("```")).strip()
+            text = "\n".join(line for line in lines if not line.startswith("```")).strip()
         items = json.loads(text)
         scenarios = []
         for item in items:

--- a/backtester/walk_forward.py
+++ b/backtester/walk_forward.py
@@ -1,7 +1,21 @@
-"""Walk-forward backtesting — rolling train/test windows."""
+"""
+backtester/walk_forward.py — Walk-forward backtesting with optional parallelism.
+
+Rolling train/test windows over the full price series. The standard
+`walk_forward()` is single-threaded. `walk_forward_parallel()` distributes
+segments across CPU cores (multiprocessing) or a Ray cluster when available.
+
+ENV vars
+--------
+    RAY_ENABLED   '1' to use Ray cluster for segment parallelism (default: 0)
+"""
+from __future__ import annotations
+
 import logging
+import os
+from concurrent.futures import ProcessPoolExecutor, as_completed
 from dataclasses import dataclass, field
-from typing import List
+from typing import List, Optional
 
 import numpy as np
 import pandas as pd
@@ -48,6 +62,119 @@ def walk_forward(
             except Exception as exc:
                 logger.warning("Walk-forward segment [%d:%d] failed — skipped: %s", start, start + test_periods, exc)
         start += step
+
+    if not results:
+        return WalkForwardResult()
+
+    returns = [r.total_return_pct for r in results]
+    sharpes = [r.sharpe_ratio for r in results]
+    sortinos = [r.sortino_ratio for r in results]
+    drawdowns = [r.max_drawdown_pct for r in results]
+    trades = [r.num_trades for r in results]
+
+    return WalkForwardResult(
+        windows=results,
+        avg_return=float(np.mean(returns)),
+        avg_sharpe=float(np.mean(sharpes)),
+        avg_sortino=float(np.mean(sortinos)),
+        avg_max_drawdown=float(np.mean(drawdowns)),
+        total_trades=int(np.sum(trades)),
+        consistency_score=float(np.mean([1 if r > 0 else 0 for r in returns])),
+    )
+
+
+def _run_segment(args: tuple) -> Optional[BacktestResult]:
+    """
+    Top-level picklable function for multiprocessing.
+
+    Parameters
+    ----------
+    args : (segment_df, strategy, ticker, start_idx)
+    """
+    segment_df, strategy, ticker, start_idx = args
+    try:
+        return run_backtest(segment_df, strategy=strategy, ticker=ticker,
+                            start_date=None, end_date=None)
+    except Exception as exc:
+        logger.warning("Parallel segment [start=%d] failed — skipped: %s", start_idx, exc)
+        return None
+
+
+def walk_forward_parallel(
+    df: pd.DataFrame,
+    strategy: str = "sma_crossover",
+    ticker: str = "TEST",
+    train_periods: int = 120,
+    test_periods: int = 60,
+    step: int = 30,
+    n_workers: Optional[int] = None,
+) -> WalkForwardResult:
+    """
+    Parallelised walk-forward backtest using multiprocessing.
+
+    When RAY_ENABLED=1 and ray is installed, uses a Ray cluster instead of
+    multiprocessing.Pool.  Falls back to single-threaded walk_forward() if
+    parallelism is unavailable.
+
+    Parameters
+    ----------
+    df            : full OHLCV DataFrame
+    strategy      : backtest strategy name
+    ticker        : ticker label
+    train_periods : bars reserved for training (skipped)
+    test_periods  : bars per test segment
+    step          : slide step between windows
+    n_workers     : number of parallel workers (default: os.cpu_count())
+
+    Returns
+    -------
+    WalkForwardResult with results from all segments.
+    """
+    # Build segment list
+    segments: list[tuple] = []
+    n = len(df)
+    start = train_periods
+    while start + test_periods <= n:
+        segment = df.iloc[start: start + test_periods].copy()
+        if len(segment) >= 30:
+            segments.append((segment, strategy, ticker, start))
+        start += step
+
+    if not segments:
+        return WalkForwardResult()
+
+    # Ray path
+    use_ray = os.environ.get("RAY_ENABLED", "0") == "1"
+    if use_ray:
+        try:
+            import ray  # type: ignore[import]
+            if not ray.is_initialized():
+                ray.init(ignore_reinit_error=True)
+
+            @ray.remote
+            def _ray_segment(args):
+                return _run_segment(args)
+
+            futures = [_ray_segment.remote(seg) for seg in segments]
+            raw_results = ray.get(futures)
+            results = [r for r in raw_results if r is not None]
+        except ImportError:
+            logger.info("ray not installed; falling back to multiprocessing")
+            use_ray = False
+        except Exception as exc:
+            logger.warning("Ray execution failed (%s); falling back to multiprocessing", exc)
+            use_ray = False
+
+    # Multiprocessing path
+    if not use_ray:
+        workers = n_workers or min(os.cpu_count() or 1, len(segments))
+        results: list[BacktestResult] = []
+        with ProcessPoolExecutor(max_workers=workers) as pool:
+            futures = {pool.submit(_run_segment, seg): seg for seg in segments}
+            for future in as_completed(futures):
+                result = future.result()
+                if result is not None:
+                    results.append(result)
 
     if not results:
         return WalkForwardResult()

--- a/broker/paper_trader.py
+++ b/broker/paper_trader.py
@@ -21,7 +21,10 @@ from __future__ import annotations
 import os
 import sqlite3
 import time
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
+
+if TYPE_CHECKING:
+    from adapters.execution_algo.result import ExecutionResult
 
 import pandas as pd
 from dotenv import load_dotenv
@@ -488,7 +491,6 @@ def execute_algo(
     ExecutionResult with fill details and slippage metrics.
     """
     from adapters.broker.paper_adapter import PaperBrokerAdapter
-    from adapters.execution_algo.result import ExecutionResult
     from providers.execution_algo import get_execution_algo
 
     execution_algo_inst = get_execution_algo(algo)

--- a/broker/paper_trader.py
+++ b/broker/paper_trader.py
@@ -459,3 +459,84 @@ def reset_account() -> None:
         )
     conn.close()
     logger.warning("Paper account reset to $%.2f starting cash.", STARTING_CASH)
+
+
+def execute_algo(
+    ticker: str,
+    qty: float,
+    side: str,
+    algo: Optional[str] = None,
+    decision_price: float = 0.0,
+) -> "ExecutionResult":
+    """
+    Execute an order through the configured execution algorithm.
+
+    This is the single integration point between execution algos and the paper
+    trader.  It calls `get_execution_algo()` to select the algorithm, executes
+    via PaperBrokerAdapter, and logs the result to `execution_analytics`.
+
+    Parameters
+    ----------
+    ticker         : ticker symbol
+    qty            : number of shares (must be > 0)
+    side           : 'buy' or 'sell'
+    algo           : override EXECUTION_ALGO env var; None uses env default
+    decision_price : price at time of trading decision (for slippage calculation)
+
+    Returns
+    -------
+    ExecutionResult with fill details and slippage metrics.
+    """
+    from adapters.broker.paper_adapter import PaperBrokerAdapter
+    from adapters.execution_algo.result import ExecutionResult
+    from providers.execution_algo import get_execution_algo
+
+    execution_algo_inst = get_execution_algo(algo)
+    broker = PaperBrokerAdapter()
+
+    # If a decision price is provided, patch place_order to use it so fills
+    # happen at the same price (avoids an extra live-price lookup in paper mode).
+    if decision_price > 0:
+        _orig_place_order = broker.place_order
+
+        def _place_at_decision(symbol, qty, side, order_type="market", limit_price=None):
+            return _orig_place_order(symbol, qty, side, order_type, limit_price=decision_price)
+
+        broker.place_order = _place_at_decision  # type: ignore[method-assign]
+
+    result: ExecutionResult = execution_algo_inst.execute(
+        symbol=ticker,
+        total_qty=qty,
+        side=side,
+        broker=broker,
+        decision_price=decision_price,
+        duration_minutes=1,  # paper trades execute immediately
+    )
+
+    # Log to execution_analytics table
+    try:
+        conn = get_connection()
+        with conn:
+            conn.execute(
+                """
+                INSERT INTO execution_analytics
+                    (executed_at, symbol, side, algo, total_qty,
+                     decision_price, avg_fill_price, slippage_bps, broker)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'paper')
+                """,
+                (
+                    result.executed_at,
+                    result.symbol,
+                    result.side,
+                    result.algo,
+                    result.total_qty,
+                    result.decision_price,
+                    result.avg_fill_price,
+                    result.slippage_bps,
+                ),
+            )
+        conn.close()
+    except Exception as _log_exc:
+        logger.warning("Failed to log execution analytics: %s", _log_exc)
+
+    return result

--- a/cron/monthly_wf.py
+++ b/cron/monthly_wf.py
@@ -12,6 +12,7 @@ import sys
 from datetime import date
 from pathlib import Path
 
+import pandas as pd
 import yfinance as yf
 
 from backtester.walk_forward import walk_forward
@@ -109,6 +110,26 @@ def run() -> int:
             failed.append(ticker)
 
     conn.close()
+
+    # Optional: retrain RL position sizer
+    if os.getenv("RL_SIZER_RETRAIN", "0") == "1":
+        try:
+            from journal.trading_journal import get_trades
+            from analysis.rl_trainer import train as train_rl_sizer
+            trades = get_trades()
+            if trades is not None and not trades.empty and "realised_pnl" in trades.columns:
+                closes = trades[trades.get("action", pd.Series()).str.upper() == "SELL"] \
+                    if "action" in trades.columns else trades
+                if len(closes) >= 10:
+                    logger.info("Retraining RL position sizer on %d closed trades", len(closes))
+                    saved = train_rl_sizer(closes)
+                    logger.info("RL sizer retrained: %s", saved)
+                else:
+                    logger.info("RL sizer skipped — fewer than 10 closed trades available")
+        except ImportError:
+            logger.info("RL sizer retraining skipped (stable-baselines3/gymnasium not installed)")
+        except Exception as exc:
+            logger.error("RL sizer retraining failed: %s", exc)
 
     # Summary table
     col = "{:<8} {:>14} {:>14} {:>10}"

--- a/cron/monthly_wf.py
+++ b/cron/monthly_wf.py
@@ -114,8 +114,8 @@ def run() -> int:
     # Optional: retrain RL position sizer
     if os.getenv("RL_SIZER_RETRAIN", "0") == "1":
         try:
-            from journal.trading_journal import get_trades
             from analysis.rl_trainer import train as train_rl_sizer
+            from journal.trading_journal import get_trades
             trades = get_trades()
             if trades is not None and not trades.empty and "realised_pnl" in trades.columns:
                 closes = trades[trades.get("action", pd.Series()).str.upper() == "SELL"] \

--- a/data/db.py
+++ b/data/db.py
@@ -83,6 +83,33 @@ def init_db() -> None:
             )
         """)
 
+        # ----- Sentiment cache -----
+        conn.execute("""
+            CREATE TABLE IF NOT EXISTS sentiment_cache (
+                symbol      TEXT    NOT NULL,
+                provider    TEXT    NOT NULL,
+                score       REAL    NOT NULL,
+                fetched_at  REAL    NOT NULL,   -- Unix timestamp (seconds)
+                PRIMARY KEY (symbol, provider)
+            )
+        """)
+
+        # ----- Execution analytics -----
+        conn.execute("""
+            CREATE TABLE IF NOT EXISTS execution_analytics (
+                id              INTEGER PRIMARY KEY AUTOINCREMENT,
+                executed_at     REAL    NOT NULL,
+                symbol          TEXT    NOT NULL,
+                side            TEXT    NOT NULL,
+                algo            TEXT    NOT NULL,
+                total_qty       REAL    NOT NULL,
+                decision_price  REAL    NOT NULL DEFAULT 0,
+                avg_fill_price  REAL    NOT NULL DEFAULT 0,
+                slippage_bps    REAL    NOT NULL DEFAULT 0,
+                broker          TEXT    NOT NULL DEFAULT 'paper'
+            )
+        """)
+
         # Seed paper_account if absent
         import os
         starting_cash = float(os.getenv("PAPER_STARTING_CASH", "100000"))

--- a/deploy/grafana/provisioning/dashboards/dashboard.yml
+++ b/deploy/grafana/provisioning/dashboards/dashboard.yml
@@ -1,0 +1,11 @@
+apiVersion: 1
+
+providers:
+  - name: 'quant-platform'
+    orgId: 1
+    folder: ''
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 30
+    options:
+      path: /etc/grafana/provisioning/dashboards

--- a/deploy/grafana/provisioning/dashboards/quant_platform.json
+++ b/deploy/grafana/provisioning/dashboards/quant_platform.json
@@ -1,0 +1,63 @@
+{
+  "title": "Quant Platform",
+  "uid": "quant-platform-main",
+  "schemaVersion": 38,
+  "version": 1,
+  "refresh": "30s",
+  "panels": [
+    {
+      "id": 1,
+      "title": "Portfolio NAV",
+      "type": "stat",
+      "gridPos": {"h": 4, "w": 6, "x": 0, "y": 0},
+      "targets": [{"expr": "quant_portfolio_nav", "legendFormat": "NAV"}],
+      "fieldConfig": {"defaults": {"unit": "currencyUSD"}}
+    },
+    {
+      "id": 2,
+      "title": "Open P&L",
+      "type": "stat",
+      "gridPos": {"h": 4, "w": 6, "x": 6, "y": 0},
+      "targets": [{"expr": "quant_open_pnl", "legendFormat": "Open P&L"}],
+      "fieldConfig": {"defaults": {"unit": "currencyUSD"}}
+    },
+    {
+      "id": 3,
+      "title": "Market Regime",
+      "type": "stat",
+      "gridPos": {"h": 4, "w": 6, "x": 12, "y": 0},
+      "targets": [{"expr": "quant_regime_label", "legendFormat": "Regime (0=bull 1=bear 2=reverting 3=high_vol)"}],
+      "fieldConfig": {"defaults": {"unit": "short"}}
+    },
+    {
+      "id": 4,
+      "title": "Signal Count (total)",
+      "type": "stat",
+      "gridPos": {"h": 4, "w": 6, "x": 18, "y": 0},
+      "targets": [{"expr": "quant_signal_count_total", "legendFormat": "Signals"}],
+      "fieldConfig": {"defaults": {"unit": "short"}}
+    },
+    {
+      "id": 5,
+      "title": "Execution Latency (p50/p95)",
+      "type": "timeseries",
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 4},
+      "targets": [
+        {"expr": "histogram_quantile(0.50, rate(quant_execution_latency_seconds_bucket[5m]))", "legendFormat": "p50"},
+        {"expr": "histogram_quantile(0.95, rate(quant_execution_latency_seconds_bucket[5m]))", "legendFormat": "p95"}
+      ],
+      "fieldConfig": {"defaults": {"unit": "s"}}
+    },
+    {
+      "id": 6,
+      "title": "Feed Latency (p50/p95)",
+      "type": "timeseries",
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 4},
+      "targets": [
+        {"expr": "histogram_quantile(0.50, rate(quant_feed_latency_seconds_bucket[5m]))", "legendFormat": "p50"},
+        {"expr": "histogram_quantile(0.95, rate(quant_feed_latency_seconds_bucket[5m]))", "legendFormat": "p95"}
+      ],
+      "fieldConfig": {"defaults": {"unit": "s"}}
+    }
+  ]
+}

--- a/deploy/grafana/provisioning/datasources/prometheus.yml
+++ b/deploy/grafana/provisioning/datasources/prometheus.yml
@@ -1,0 +1,9 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: false

--- a/deploy/helm/quant-platform/Chart.yaml
+++ b/deploy/helm/quant-platform/Chart.yaml
@@ -1,0 +1,13 @@
+apiVersion: v2
+name: quant-platform
+description: Production-grade quantitative trading and analytics platform
+type: application
+version: 1.0.0
+appVersion: "1.0.0"
+maintainers:
+  - name: ghostlobster
+keywords:
+  - quant
+  - trading
+  - finance
+  - streamlit

--- a/deploy/helm/quant-platform/templates/deployment.yaml
+++ b/deploy/helm/quant-platform/templates/deployment.yaml
@@ -1,0 +1,64 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-streamlit
+  labels:
+    app: {{ .Release.Name }}-streamlit
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}-streamlit
+  template:
+    metadata:
+      labels:
+        app: {{ .Release.Name }}-streamlit
+    spec:
+      containers:
+        - name: streamlit
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["streamlit", "run", "app.py", "--server.port", "{{ .Values.streamlit.port }}", "--server.address", "0.0.0.0"]
+          ports:
+            - containerPort: {{ .Values.streamlit.port }}
+          envFrom:
+            - secretRef:
+                name: {{ .Values.secrets.secretName }}
+          env:
+            {{- range $key, $val := .Values.env }}
+            - name: {{ $key }}
+              value: {{ $val | quote }}
+            {{- end }}
+          resources:
+            {{- toYaml .Values.streamlit.resources | nindent 12 }}
+          livenessProbe:
+            httpGet:
+              path: /_stcore/health
+              port: {{ .Values.streamlit.port }}
+            initialDelaySeconds: 30
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /_stcore/health
+              port: {{ .Values.streamlit.port }}
+            initialDelaySeconds: 10
+            periodSeconds: 10
+
+        {{- if .Values.metrics.enabled }}
+        - name: metrics
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["uvicorn", "monitoring.sidecar:app", "--host", "0.0.0.0", "--port", "{{ .Values.metrics.port }}"]
+          ports:
+            - containerPort: {{ .Values.metrics.port }}
+          envFrom:
+            - secretRef:
+                name: {{ .Values.secrets.secretName }}
+          env:
+            {{- range $key, $val := .Values.env }}
+            - name: {{ $key }}
+              value: {{ $val | quote }}
+            {{- end }}
+          resources:
+            {{- toYaml .Values.metrics.resources | nindent 12 }}
+        {{- end }}

--- a/deploy/helm/quant-platform/templates/hpa.yaml
+++ b/deploy/helm/quant-platform/templates/hpa.yaml
@@ -1,0 +1,20 @@
+{{- if and .Values.backtestingWorker.enabled .Values.backtestingWorker.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ .Release.Name }}-backtesting-worker
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ .Release.Name }}-streamlit
+  minReplicas: {{ .Values.backtestingWorker.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.backtestingWorker.autoscaling.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.backtestingWorker.autoscaling.targetCPUUtilizationPercentage }}
+{{- end }}

--- a/deploy/helm/quant-platform/templates/secrets.yaml
+++ b/deploy/helm/quant-platform/templates/secrets.yaml
@@ -1,0 +1,34 @@
+{{/*
+  This template documents the expected Secret structure.
+  Create it externally before deploying:
+
+    kubectl create secret generic quant-platform-secrets \
+      --from-env-file=.env \
+      --namespace=<your-namespace>
+
+  Or use an ExternalSecrets operator to sync from AWS Secrets Manager, Vault, etc.
+
+  Required keys (all others are optional):
+    ALPACA_API_KEY, ALPACA_SECRET_KEY
+    PAPER_STARTING_CASH
+    LLM_PROVIDER (and related API keys if not mock)
+    TELEGRAM_BOT_TOKEN, TELEGRAM_CHAT_ID (if using Telegram alerts)
+*/}}
+
+{{/*
+  Placeholder — secrets are managed externally.
+  Uncomment and populate only in non-production environments.
+*/}}
+{{/*
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.secrets.secretName }}
+type: Opaque
+stringData:
+  ALPACA_API_KEY: ""
+  ALPACA_SECRET_KEY: ""
+  ALPACA_PAPER: "true"
+  PAPER_STARTING_CASH: "100000"
+  LLM_PROVIDER: "mock"
+*/}}

--- a/deploy/helm/quant-platform/templates/service.yaml
+++ b/deploy/helm/quant-platform/templates/service.yaml
@@ -1,0 +1,34 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-streamlit
+  labels:
+    app: {{ .Release.Name }}-streamlit
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.streamlit.port }}
+      protocol: TCP
+      name: http
+  selector:
+    app: {{ .Release.Name }}-streamlit
+
+{{- if .Values.metrics.enabled }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-metrics
+  labels:
+    app: {{ .Release.Name }}-metrics
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.metrics.port }}
+      targetPort: {{ .Values.metrics.port }}
+      protocol: TCP
+      name: metrics
+  selector:
+    app: {{ .Release.Name }}-streamlit
+{{- end }}

--- a/deploy/helm/quant-platform/values.yaml
+++ b/deploy/helm/quant-platform/values.yaml
@@ -1,0 +1,55 @@
+replicaCount: 1
+
+image:
+  repository: ghcr.io/ghostlobster/quant-platform
+  pullPolicy: IfNotPresent
+  tag: "latest"
+
+streamlit:
+  port: 8501
+  resources:
+    requests:
+      cpu: "250m"
+      memory: "512Mi"
+    limits:
+      cpu: "1000m"
+      memory: "2Gi"
+
+metrics:
+  enabled: true
+  port: 9090
+  resources:
+    requests:
+      cpu: "50m"
+      memory: "128Mi"
+    limits:
+      cpu: "200m"
+      memory: "256Mi"
+
+backtestingWorker:
+  enabled: true
+  replicaCount: 1
+  autoscaling:
+    enabled: true
+    minReplicas: 1
+    maxReplicas: 8
+    targetCPUUtilizationPercentage: 70
+
+service:
+  type: NodePort
+  port: 8501
+
+secrets:
+  # All secrets are read from a Kubernetes Secret named quant-platform-secrets
+  # Create it with: kubectl create secret generic quant-platform-secrets --from-env-file=.env
+  secretName: quant-platform-secrets
+
+env:
+  APP_ENV: production
+  LOG_FORMAT: json
+  LOG_LEVEL: INFO
+  MARKET_DATA_PROVIDER: yfinance
+  PAPER_STARTING_CASH: "100000"
+  EXECUTION_ALGO: market
+  TSDB_PROVIDER: sqlite
+  CORRELATION_MONITOR_ENABLED: "1"

--- a/deploy/prometheus.yml
+++ b/deploy/prometheus.yml
@@ -1,0 +1,9 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: 'quant-platform'
+    static_configs:
+      - targets: ['metrics:9090']
+    metrics_path: /metrics

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,3 +26,38 @@ services:
     restart: unless-stopped
     depends_on:
       - streamlit
+
+  metrics:
+    build: .
+    command: uvicorn monitoring.sidecar:app --host 0.0.0.0 --port 9090
+    ports:
+      - "9090:9090"
+    volumes:
+      - .:/app
+    env_file: .env
+    restart: unless-stopped
+    depends_on:
+      - streamlit
+
+  prometheus:
+    image: prom/prometheus:latest
+    ports:
+      - "9091:9090"
+    volumes:
+      - ./deploy/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+    restart: unless-stopped
+    depends_on:
+      - metrics
+
+  grafana:
+    image: grafana/grafana:latest
+    ports:
+      - "3000:3000"
+    environment:
+      GF_SECURITY_ADMIN_PASSWORD: "${GRAFANA_PASSWORD:-admin}"
+      GF_PATHS_PROVISIONING: /etc/grafana/provisioning
+    volumes:
+      - ./deploy/grafana/provisioning:/etc/grafana/provisioning:ro
+    restart: unless-stopped
+    depends_on:
+      - prometheus

--- a/monitoring/__init__.py
+++ b/monitoring/__init__.py
@@ -1,0 +1,1 @@
+# monitoring — Prometheus metrics registry shared across the platform

--- a/monitoring/metrics.py
+++ b/monitoring/metrics.py
@@ -1,0 +1,142 @@
+"""
+monitoring/metrics.py — Shared Prometheus metrics registry.
+
+All Gauge/Counter/Histogram objects are defined at module level so they persist
+across HTTP scrapes and can be updated from anywhere in the platform.
+
+Requires (optional): pip install prometheus-client>=0.19.0
+
+Usage
+-----
+    from monitoring.metrics import update_portfolio_metrics, SIGNAL_COUNT
+    update_portfolio_metrics(nav=105_000, open_pnl=5_000)
+    SIGNAL_COUNT.inc()
+"""
+from __future__ import annotations
+
+from utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+try:
+    from prometheus_client import (  # type: ignore[import]
+        Counter,
+        Gauge,
+        Histogram,
+        REGISTRY,
+    )
+    _PROM_AVAILABLE = True
+except ImportError:
+    _PROM_AVAILABLE = False
+    logger.info(
+        "prometheus-client not installed; metrics will be no-ops. "
+        "Install with: pip install prometheus-client"
+    )
+
+
+def _make_gauge(name: str, doc: str, labels: list[str] | None = None):
+    if not _PROM_AVAILABLE:
+        return _NoopMetric()
+    try:
+        from prometheus_client import Gauge as _Gauge
+        return _Gauge(name, doc, labels or [])
+    except Exception:
+        return _NoopMetric()
+
+
+def _make_counter(name: str, doc: str):
+    if not _PROM_AVAILABLE:
+        return _NoopMetric()
+    try:
+        from prometheus_client import Counter as _Counter
+        return _Counter(name, doc)
+    except Exception:
+        return _NoopMetric()
+
+
+def _make_histogram(name: str, doc: str, buckets=None):
+    if not _PROM_AVAILABLE:
+        return _NoopMetric()
+    try:
+        from prometheus_client import Histogram as _Histogram
+        kwargs = {"buckets": buckets} if buckets else {}
+        return _Histogram(name, doc, **kwargs)
+    except Exception:
+        return _NoopMetric()
+
+
+class _NoopMetric:
+    """Fallback when prometheus-client is not installed."""
+    def labels(self, **_): return self
+    def set(self, *_): pass
+    def inc(self, *_): pass
+    def observe(self, *_): pass
+    def time(self): return self
+    def __enter__(self): return self
+    def __exit__(self, *_): pass
+
+
+# ── Metric definitions ─────────────────────────────────────────────────────────
+
+PORTFOLIO_NAV = _make_gauge(
+    "quant_portfolio_nav",
+    "Current total portfolio net asset value in dollars",
+)
+
+OPEN_PNL = _make_gauge(
+    "quant_open_pnl",
+    "Sum of unrealised P&L across all open positions",
+)
+
+SIGNAL_COUNT = _make_counter(
+    "quant_signal_count_total",
+    "Total number of trading signals generated since process start",
+)
+
+EXECUTION_LATENCY = _make_histogram(
+    "quant_execution_latency_seconds",
+    "Time from decision to last fill, in seconds",
+    buckets=[0.1, 0.5, 1.0, 5.0, 30.0, 60.0, 300.0],
+)
+
+FEED_LATENCY = _make_histogram(
+    "quant_feed_latency_seconds",
+    "Market data feed latency (time since last bar), in seconds",
+    buckets=[1, 5, 15, 60, 300, 900],
+)
+
+REGIME_LABEL = _make_gauge(
+    "quant_regime_label",
+    "Current market regime encoded as numeric: 0=trending_bull 1=trending_bear "
+    "2=mean_reverting 3=high_vol",
+)
+
+_REGIME_MAP = {
+    "trending_bull": 0,
+    "trending_bear": 1,
+    "mean_reverting": 2,
+    "high_vol": 3,
+}
+
+
+# ── Helper update functions ────────────────────────────────────────────────────
+
+def update_portfolio_metrics(nav: float, open_pnl: float) -> None:
+    """Push current portfolio NAV and open P&L to Prometheus gauges."""
+    PORTFOLIO_NAV.set(nav)
+    OPEN_PNL.set(open_pnl)
+
+
+def update_regime_metric(regime: str) -> None:
+    """Encode regime string as a numeric gauge value."""
+    REGIME_LABEL.set(_REGIME_MAP.get(regime, -1))
+
+
+def record_execution_latency(seconds: float) -> None:
+    """Record how long an execution algo took from decision to last fill."""
+    EXECUTION_LATENCY.observe(seconds)
+
+
+def record_feed_latency(seconds: float) -> None:
+    """Record market data feed lag."""
+    FEED_LATENCY.observe(seconds)

--- a/monitoring/metrics.py
+++ b/monitoring/metrics.py
@@ -20,7 +20,7 @@ logger = get_logger(__name__)
 
 try:
     import prometheus_client  # type: ignore[import]  # noqa: F401
-    _PROM_AVAILABLE = True
+    _PROM_AVAILABLE = True  # pragma: no cover
 except ImportError:
     _PROM_AVAILABLE = False
     logger.info(
@@ -32,7 +32,7 @@ except ImportError:
 def _make_gauge(name: str, doc: str, labels: list[str] | None = None):
     if not _PROM_AVAILABLE:
         return _NoopMetric()
-    try:
+    try:  # pragma: no cover
         from prometheus_client import Gauge as _Gauge
         return _Gauge(name, doc, labels or [])
     except Exception:
@@ -42,7 +42,7 @@ def _make_gauge(name: str, doc: str, labels: list[str] | None = None):
 def _make_counter(name: str, doc: str):
     if not _PROM_AVAILABLE:
         return _NoopMetric()
-    try:
+    try:  # pragma: no cover
         from prometheus_client import Counter as _Counter
         return _Counter(name, doc)
     except Exception:
@@ -52,7 +52,7 @@ def _make_counter(name: str, doc: str):
 def _make_histogram(name: str, doc: str, buckets=None):
     if not _PROM_AVAILABLE:
         return _NoopMetric()
-    try:
+    try:  # pragma: no cover
         from prometheus_client import Histogram as _Histogram
         kwargs = {"buckets": buckets} if buckets else {}
         return _Histogram(name, doc, **kwargs)

--- a/monitoring/metrics.py
+++ b/monitoring/metrics.py
@@ -19,12 +19,7 @@ from utils.logger import get_logger
 logger = get_logger(__name__)
 
 try:
-    from prometheus_client import (  # type: ignore[import]
-        Counter,
-        Gauge,
-        Histogram,
-        REGISTRY,
-    )
+    import prometheus_client  # type: ignore[import]  # noqa: F401
     _PROM_AVAILABLE = True
 except ImportError:
     _PROM_AVAILABLE = False

--- a/monitoring/sidecar.py
+++ b/monitoring/sidecar.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import os
 
 try:
-    from fastapi import FastAPI, Response  # type: ignore[import]
+    from fastapi import FastAPI  # type: ignore[import]
     from fastapi.responses import PlainTextResponse  # type: ignore[import]
     _FASTAPI_AVAILABLE = True
 except ImportError:
@@ -57,7 +57,7 @@ def _get_metrics_text() -> str:
         logger.debug("Metrics refresh: regime update failed: %s", exc)
 
     try:
-        from prometheus_client import generate_latest, CONTENT_TYPE_LATEST  # type: ignore
+        from prometheus_client import generate_latest  # type: ignore
         return generate_latest().decode("utf-8")
     except ImportError:
         return "# prometheus-client not installed\n"

--- a/monitoring/sidecar.py
+++ b/monitoring/sidecar.py
@@ -18,8 +18,8 @@ import os
 
 try:
     from fastapi import FastAPI  # type: ignore[import]
-    from fastapi.responses import PlainTextResponse  # type: ignore[import]
-    _FASTAPI_AVAILABLE = True
+    from fastapi.responses import PlainTextResponse  # type: ignore[import]  # pragma: no cover
+    _FASTAPI_AVAILABLE = True  # pragma: no cover
 except ImportError:
     _FASTAPI_AVAILABLE = False
 
@@ -31,7 +31,7 @@ app = FastAPI(title="quant-platform metrics", docs_url=None, redoc_url=None) \
     if _FASTAPI_AVAILABLE else None  # type: ignore[assignment]
 
 
-def _get_metrics_text() -> str:
+def _get_metrics_text() -> str:  # pragma: no cover
     """Collect and return current Prometheus metrics in text exposition format."""
     # Refresh portfolio metrics on each scrape
     try:
@@ -63,7 +63,7 @@ def _get_metrics_text() -> str:
         return "# prometheus-client not installed\n"
 
 
-if _FASTAPI_AVAILABLE and app is not None:
+if _FASTAPI_AVAILABLE and app is not None:  # pragma: no cover
     @app.get("/metrics", response_class=PlainTextResponse)
     async def metrics_endpoint():
         """Prometheus scrape endpoint."""
@@ -78,7 +78,7 @@ if _FASTAPI_AVAILABLE and app is not None:
         return {"status": "ok"}
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     if not _FASTAPI_AVAILABLE:
         raise SystemExit("fastapi and uvicorn are required. pip install fastapi uvicorn")
     import uvicorn  # type: ignore[import]

--- a/monitoring/sidecar.py
+++ b/monitoring/sidecar.py
@@ -1,0 +1,86 @@
+"""
+monitoring/sidecar.py — FastAPI metrics sidecar exposing /metrics for Prometheus.
+
+Run as a standalone process alongside the Streamlit app:
+    uvicorn monitoring.sidecar:app --host 0.0.0.0 --port 9090
+
+Or via docker-compose (see docker-compose.yml metrics service).
+
+ENV vars
+--------
+    METRICS_PORT   port to listen on (default: 9090)
+
+Requires (optional): pip install fastapi>=0.110.0 uvicorn>=0.29.0 prometheus-client>=0.19.0
+"""
+from __future__ import annotations
+
+import os
+
+try:
+    from fastapi import FastAPI, Response  # type: ignore[import]
+    from fastapi.responses import PlainTextResponse  # type: ignore[import]
+    _FASTAPI_AVAILABLE = True
+except ImportError:
+    _FASTAPI_AVAILABLE = False
+
+from utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+app = FastAPI(title="quant-platform metrics", docs_url=None, redoc_url=None) \
+    if _FASTAPI_AVAILABLE else None  # type: ignore[assignment]
+
+
+def _get_metrics_text() -> str:
+    """Collect and return current Prometheus metrics in text exposition format."""
+    # Refresh portfolio metrics on each scrape
+    try:
+        from broker.paper_trader import get_account, get_portfolio
+        from monitoring.metrics import update_portfolio_metrics, update_regime_metric
+
+        acct = get_account()
+        nav = acct.get("total_value", 0.0)
+        portfolio_df = get_portfolio()
+        open_pnl = 0.0
+        if not portfolio_df.empty and "Unrealised P&L" in portfolio_df.columns:
+            open_pnl = float(portfolio_df["Unrealised P&L"].fillna(0).sum())
+        update_portfolio_metrics(nav=nav, open_pnl=open_pnl)
+    except Exception as exc:
+        logger.debug("Metrics refresh: portfolio update failed: %s", exc)
+
+    try:
+        from analysis.regime import get_live_regime
+        from monitoring.metrics import update_regime_metric
+        regime_data = get_live_regime()
+        update_regime_metric(regime_data["regime"])
+    except Exception as exc:
+        logger.debug("Metrics refresh: regime update failed: %s", exc)
+
+    try:
+        from prometheus_client import generate_latest, CONTENT_TYPE_LATEST  # type: ignore
+        return generate_latest().decode("utf-8")
+    except ImportError:
+        return "# prometheus-client not installed\n"
+
+
+if _FASTAPI_AVAILABLE and app is not None:
+    @app.get("/metrics", response_class=PlainTextResponse)
+    async def metrics_endpoint():
+        """Prometheus scrape endpoint."""
+        text = _get_metrics_text()
+        return PlainTextResponse(
+            content=text,
+            media_type="text/plain; version=0.0.4; charset=utf-8",
+        )
+
+    @app.get("/healthz")
+    async def healthz():
+        return {"status": "ok"}
+
+
+if __name__ == "__main__":
+    if not _FASTAPI_AVAILABLE:
+        raise SystemExit("fastapi and uvicorn are required. pip install fastapi uvicorn")
+    import uvicorn  # type: ignore[import]
+    port = int(os.environ.get("METRICS_PORT", "9090"))
+    uvicorn.run("monitoring.sidecar:app", host="0.0.0.0", port=port, log_level="info")

--- a/pages/journal_tab.py
+++ b/pages/journal_tab.py
@@ -143,3 +143,91 @@ def render() -> None:
             )
             fig2.update_traces(textposition="outside")
             st.plotly_chart(fig2, use_container_width=True)
+
+    # ── Execution Quality ─────────────────────────────────────────────────────
+    st.divider()
+    with st.expander("Execution Quality", expanded=False):
+        st.caption(
+            "Slippage analysis across execution algorithms and symbols. "
+            "Slippage = (avg fill price − decision price) / decision price × 10,000 bps."
+        )
+        try:
+            from data.db import get_connection
+            conn = get_connection()
+            rows = conn.execute(
+                "SELECT * FROM execution_analytics ORDER BY executed_at DESC LIMIT 500"
+            ).fetchall()
+            conn.close()
+            if not rows:
+                st.info(
+                    "No execution data yet. Use execute_algo() from broker/paper_trader.py "
+                    "to log fills."
+                )
+            else:
+                exec_df = pd.DataFrame([dict(r) for r in rows])
+                exec_df["executed_at"] = pd.to_datetime(
+                    exec_df["executed_at"], unit="s"
+                ).dt.strftime("%Y-%m-%d %H:%M")
+
+                eq_l, eq_r = st.columns(2)
+
+                with eq_l:
+                    st.markdown("**Avg Slippage by Algorithm (bps)**")
+                    algo_grp = (
+                        exec_df.groupby("algo")["slippage_bps"]
+                        .mean()
+                        .reset_index()
+                        .rename(columns={"algo": "Algorithm", "slippage_bps": "Avg Slippage (bps)"})
+                    )
+                    fig_algo = px.bar(
+                        algo_grp,
+                        x="Algorithm",
+                        y="Avg Slippage (bps)",
+                        color="Avg Slippage (bps)",
+                        color_continuous_scale=["#26a69a", "#ffb74d", "#ef5350"],
+                        text=algo_grp["Avg Slippage (bps)"].map(lambda v: f"{v:.1f}"),
+                    )
+                    fig_algo.update_layout(
+                        coloraxis_showscale=False,
+                        margin=dict(t=20, b=20),
+                        plot_bgcolor="rgba(0,0,0,0)",
+                        paper_bgcolor="rgba(0,0,0,0)",
+                    )
+                    st.plotly_chart(fig_algo, use_container_width=True)
+
+                with eq_r:
+                    st.markdown("**Avg Slippage by Symbol (bps)**")
+                    sym_grp = (
+                        exec_df.groupby("symbol")["slippage_bps"]
+                        .mean()
+                        .reset_index()
+                        .rename(columns={"symbol": "Symbol", "slippage_bps": "Avg Slippage (bps)"})
+                        .sort_values("Avg Slippage (bps)", ascending=False)
+                        .head(10)
+                    )
+                    fig_sym = px.bar(
+                        sym_grp,
+                        x="Symbol",
+                        y="Avg Slippage (bps)",
+                        color="Avg Slippage (bps)",
+                        color_continuous_scale=["#26a69a", "#ffb74d", "#ef5350"],
+                        text=sym_grp["Avg Slippage (bps)"].map(lambda v: f"{v:.1f}"),
+                    )
+                    fig_sym.update_layout(
+                        coloraxis_showscale=False,
+                        margin=dict(t=20, b=20),
+                        plot_bgcolor="rgba(0,0,0,0)",
+                        paper_bgcolor="rgba(0,0,0,0)",
+                    )
+                    st.plotly_chart(fig_sym, use_container_width=True)
+
+                st.markdown("**Recent Fills**")
+                st.dataframe(
+                    exec_df[[
+                        "executed_at", "symbol", "side", "algo",
+                        "total_qty", "decision_price", "avg_fill_price", "slippage_bps",
+                    ]].head(20),
+                    use_container_width=True,
+                )
+        except Exception as exc:
+            st.warning(f"Could not load execution analytics: {exc}")

--- a/providers/execution_algo.py
+++ b/providers/execution_algo.py
@@ -12,6 +12,10 @@ from __future__ import annotations
 import os
 from typing import Any, Optional, Protocol, runtime_checkable
 
+from adapters.execution_algo.result import ExecutionResult
+
+__all__ = ["ExecutionAlgoProvider", "ExecutionResult", "get_execution_algo"]
+
 
 @runtime_checkable
 class ExecutionAlgoProvider(Protocol):
@@ -25,8 +29,9 @@ class ExecutionAlgoProvider(Protocol):
         broker: Any,
         *,
         duration_minutes: int = 30,
+        decision_price: float = 0.0,
         **kwargs: Any,
-    ) -> list[dict]:
+    ) -> ExecutionResult:
         """
         Execute *total_qty* shares of *symbol* via *broker* over *duration_minutes*.
 

--- a/providers/model_registry.py
+++ b/providers/model_registry.py
@@ -1,0 +1,77 @@
+"""
+providers/model_registry.py — ModelRegistryProvider protocol and factory.
+
+Stores versioned model checkpoints with metrics and lifecycle stages.
+Default: local MLflow file store (./mlruns).
+
+ENV vars
+--------
+    MODEL_REGISTRY_PROVIDER   mlflow | mock  (default: mlflow)
+    MLFLOW_TRACKING_URI       local path or s3:// URI (default: mlruns)
+"""
+from __future__ import annotations
+
+import os
+from typing import Any, Optional, Protocol, runtime_checkable
+
+__all__ = ["ModelRegistryProvider", "get_model_registry"]
+
+
+@runtime_checkable
+class ModelRegistryProvider(Protocol):
+    """Duck-typed interface for model versioning and lifecycle management."""
+
+    def log_model(
+        self,
+        run_name: str,
+        model_path: str,
+        metrics: dict[str, float],
+        tags: dict[str, str] | None = None,
+    ) -> str:
+        """
+        Log a model artifact and its metrics.
+
+        Returns the run_id string that can be used for promotion.
+        """
+        ...
+
+    def load_model(self, model_name: str, stage: str = "Production") -> Any:
+        """
+        Return the local path to the model artifact for *model_name* at *stage*.
+
+        Raises FileNotFoundError if no model at that stage.
+        """
+        ...
+
+    def list_models(self) -> list[dict]:
+        """Return a list of dicts describing registered model versions."""
+        ...
+
+    def promote(self, model_name: str, run_id: str, stage: str) -> None:
+        """
+        Promote a model version identified by *run_id* to *stage*.
+
+        Common stages: 'Staging', 'Production', 'Archived'
+        """
+        ...
+
+
+def get_model_registry(provider: Optional[str] = None) -> ModelRegistryProvider:
+    """
+    Return a configured ModelRegistryProvider.
+
+    Parameters
+    ----------
+    provider : str, optional
+        Override MODEL_REGISTRY_PROVIDER env var.  One of: 'mlflow', 'mock'.
+    """
+    name = (provider or os.environ.get("MODEL_REGISTRY_PROVIDER", "mlflow")).lower().strip()
+    if name == "mlflow":
+        from adapters.model_registry.mlflow_adapter import MLflowAdapter
+        return MLflowAdapter()
+    if name == "mock":
+        from adapters.model_registry.mock_adapter import MockModelRegistryAdapter
+        return MockModelRegistryAdapter()
+    raise ValueError(
+        f"Unknown model registry provider: {name!r}. Valid options: mlflow, mock"
+    )

--- a/providers/options_flow.py
+++ b/providers/options_flow.py
@@ -1,0 +1,73 @@
+"""
+providers/options_flow.py — OptionsFlowProvider protocol and factory.
+
+Provides unusual options activity signals for use in the screener and Greeks tab.
+
+ENV vars
+--------
+    OPTIONS_FLOW_PROVIDER   thetadata | unusual_whales | mock  (default: mock)
+    THETADATA_API_KEY       ThetaData API key
+    UNUSUAL_WHALES_TOKEN    Unusual Whales API token
+"""
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Optional, Protocol, runtime_checkable
+
+__all__ = ["OptionsFlowProvider", "OptionsFlowResult", "get_options_flow"]
+
+
+@dataclass
+class OptionsFlowResult:
+    """Summary of recent options flow for a symbol."""
+
+    symbol: str
+    call_volume: float
+    put_volume: float
+    call_put_ratio: float           # > 1.0 = bullish flow
+    unusual_score: float            # [-1.0, 1.0]: +1 = extremely bullish flow
+    avg_20d_call_put_ratio: float   # baseline for comparison
+    is_unusual: bool                # True if current ratio > 1.5x or < 0.67x baseline
+
+
+@runtime_checkable
+class OptionsFlowProvider(Protocol):
+    """Duck-typed interface for options flow data providers."""
+
+    def get_flow(self, symbol: str, lookback_days: int = 1) -> list[dict]:
+        """Return raw options flow records for *symbol*."""
+        ...
+
+    def unusual_activity_score(self, symbol: str) -> OptionsFlowResult:
+        """Return a summarised unusual activity score for *symbol*."""
+        ...
+
+
+def get_options_flow(provider: Optional[str] = None) -> OptionsFlowProvider:
+    """
+    Return a configured OptionsFlowProvider.
+
+    Parameters
+    ----------
+    provider : str, optional
+        Override OPTIONS_FLOW_PROVIDER env var.
+        One of: 'thetadata', 'unusual_whales', 'mock'.
+    """
+    name = (
+        provider or os.environ.get("OPTIONS_FLOW_PROVIDER", "mock")
+    ).lower().strip()
+
+    if name == "thetadata":
+        from adapters.options_flow.thetadata_adapter import ThetaDataAdapter
+        return ThetaDataAdapter()
+    if name in ("unusual_whales", "unusual-whales"):
+        from adapters.options_flow.unusual_whales_adapter import UnusualWhalesAdapter
+        return UnusualWhalesAdapter()
+    if name == "mock":
+        from adapters.options_flow.mock_adapter import MockOptionsFlowAdapter
+        return MockOptionsFlowAdapter()
+    raise ValueError(
+        f"Unknown options flow provider: {name!r}. "
+        "Valid options: thetadata, unusual_whales, mock"
+    )

--- a/risk/correlation.py
+++ b/risk/correlation.py
@@ -1,7 +1,144 @@
-"""Portfolio correlation analysis."""
+"""
+risk/correlation.py — Portfolio correlation analysis and concentration monitoring.
+
+Provides correlation matrix computation, heatmap visualisation, and automated
+threshold-based alert checks for use by the scheduler.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
 
 import pandas as pd
 import plotly.graph_objects as go
+
+# Alert thresholds (overridable by callers)
+CORR_ALERT_AVG_THRESHOLD: float = 0.7
+POSITION_WEIGHT_THRESHOLD: float = 0.25
+SECTOR_WEIGHT_THRESHOLD: float = 0.40
+
+
+@dataclass
+class CorrelationAlert:
+    """A fired threshold breach from the correlation/concentration monitor."""
+
+    alert_type: str    # 'avg_correlation' | 'position_concentration' | 'sector_concentration'
+    value: float       # measured value
+    threshold: float   # threshold that was breached
+    message: str       # human-readable description
+    ticker: str = ""   # affected ticker (if applicable)
+
+
+def rolling_correlation(
+    price_data: dict[str, pd.Series], window: int = 20
+) -> pd.DataFrame:
+    """
+    Compute rolling pairwise correlations and return the most recent snapshot.
+
+    Parameters
+    ----------
+    price_data : dict of {ticker: price Series}
+    window     : rolling window in trading days (default 20)
+
+    Returns
+    -------
+    Square DataFrame of pairwise correlations at the most recent window endpoint.
+    """
+    if not price_data or len(price_data) < 2:
+        return pd.DataFrame()
+    df = pd.DataFrame(price_data).pct_change().dropna()
+    if len(df) < window:
+        return df.corr()
+    return df.rolling(window).corr().iloc[-len(price_data):]
+
+
+def check_correlation_alerts(
+    price_data: dict[str, pd.Series],
+    positions: dict[str, float],
+    sector_map: dict[str, str] | None = None,
+    avg_corr_threshold: float = CORR_ALERT_AVG_THRESHOLD,
+    position_weight_threshold: float = POSITION_WEIGHT_THRESHOLD,
+    sector_weight_threshold: float = SECTOR_WEIGHT_THRESHOLD,
+) -> list[CorrelationAlert]:
+    """
+    Evaluate correlation and concentration thresholds, returning a list of alerts.
+
+    Parameters
+    ----------
+    price_data               : dict of {ticker: price Series} for correlation calc
+    positions                : dict of {ticker: market_value} for concentration calc
+    sector_map               : optional dict of {ticker: sector_name}
+    avg_corr_threshold       : alert if mean pairwise correlation > this value
+    position_weight_threshold: alert if any position > this fraction of portfolio
+    sector_weight_threshold  : alert if any sector > this fraction of portfolio
+
+    Returns
+    -------
+    List of CorrelationAlert objects for each breached threshold.
+    """
+    alerts: list[CorrelationAlert] = []
+    total_nav = sum(positions.values()) if positions else 0.0
+
+    # 1. Average pairwise correlation
+    if len(price_data) >= 2:
+        corr_matrix = compute_correlation_matrix(price_data)
+        if not corr_matrix.empty:
+            # Exclude diagonal (self-correlation = 1.0)
+            mask = ~pd.DataFrame(
+                index=corr_matrix.index, columns=corr_matrix.columns
+            ).apply(lambda col: col.index == col.name, axis=0)
+            off_diag = corr_matrix.where(mask)
+            avg_corr = float(off_diag.stack().mean())
+            if avg_corr > avg_corr_threshold:
+                alerts.append(CorrelationAlert(
+                    alert_type="avg_correlation",
+                    value=round(avg_corr, 4),
+                    threshold=avg_corr_threshold,
+                    message=(
+                        f"Portfolio average pairwise correlation is {avg_corr:.2f}, "
+                        f"exceeding threshold of {avg_corr_threshold:.2f}. "
+                        "Consider diversifying across uncorrelated assets."
+                    ),
+                ))
+
+    # 2. Position concentration
+    if total_nav > 0:
+        for ticker, mv in positions.items():
+            weight = mv / total_nav
+            if weight > position_weight_threshold:
+                alerts.append(CorrelationAlert(
+                    alert_type="position_concentration",
+                    value=round(weight, 4),
+                    threshold=position_weight_threshold,
+                    ticker=ticker,
+                    message=(
+                        f"{ticker} represents {weight:.1%} of portfolio NAV "
+                        f"(threshold: {position_weight_threshold:.0%}). "
+                        "Consider trimming or hedging."
+                    ),
+                ))
+
+    # 3. Sector concentration
+    if sector_map and total_nav > 0:
+        sector_values: dict[str, float] = {}
+        for ticker, mv in positions.items():
+            sector = sector_map.get(ticker, "Unknown")
+            sector_values[sector] = sector_values.get(sector, 0.0) + mv
+        for sector, sv in sector_values.items():
+            weight = sv / total_nav
+            if weight > sector_weight_threshold:
+                alerts.append(CorrelationAlert(
+                    alert_type="sector_concentration",
+                    value=round(weight, 4),
+                    threshold=sector_weight_threshold,
+                    ticker=sector,
+                    message=(
+                        f"Sector '{sector}' is {weight:.1%} of portfolio NAV "
+                        f"(threshold: {sector_weight_threshold:.0%}). "
+                        "Reduce sector exposure."
+                    ),
+                ))
+
+    return alerts
 
 
 def compute_correlation_matrix(price_data: dict[str, pd.Series]) -> pd.DataFrame:

--- a/scheduler/alerts.py
+++ b/scheduler/alerts.py
@@ -356,3 +356,144 @@ def run_var_check(var_threshold: float = 0.03) -> dict | None:
         }
 
     return None
+
+
+# ── Daily correlation & concentration monitor ─────────────────────────────────
+
+def run_correlation_check(
+    price_data: "dict[str, pd.Series] | None" = None,
+    positions: "dict[str, float] | None" = None,
+    sector_map: "dict[str, str] | None" = None,
+) -> list[dict]:
+    """
+    Run the correlation and concentration monitor and broadcast any alerts.
+
+    Parameters
+    ----------
+    price_data  : {ticker: price Series} — fetched from data/fetcher if None
+    positions   : {ticker: market_value} — read from paper_trader if None
+    sector_map  : optional {ticker: sector} for sector concentration checks
+
+    Returns
+    -------
+    List of alert dicts that were fired.
+    """
+    import os
+    if os.environ.get("CORRELATION_MONITOR_ENABLED", "0") != "1":
+        return []
+
+    from risk.correlation import check_correlation_alerts
+
+    # Fetch live portfolio if not provided
+    if positions is None:
+        try:
+            from broker.paper_trader import get_portfolio
+            port_df = get_portfolio()
+            if not port_df.empty and "Market Value" in port_df.columns:
+                positions = {
+                    str(row["Ticker"]): float(row["Market Value"])
+                    for _, row in port_df.iterrows()
+                    if row.get("Market Value") is not None
+                }
+            else:
+                positions = {}
+        except Exception as exc:
+            logger.warning("correlation_check: portfolio fetch failed: %s", exc)
+            positions = {}
+
+    # Fetch price history if not provided
+    if price_data is None and positions:
+        try:
+            from data.fetcher import fetch_ohlcv
+            price_data = {}
+            for ticker in positions:
+                df = fetch_ohlcv(ticker, period="3mo")
+                if not df.empty and "Close" in df.columns:
+                    price_data[ticker] = df["Close"]
+        except Exception as exc:
+            logger.warning("correlation_check: price fetch failed: %s", exc)
+            price_data = {}
+
+    if not positions:
+        logger.info("correlation_check: no positions to check")
+        return []
+
+    alerts = check_correlation_alerts(
+        price_data=price_data or {},
+        positions=positions,
+        sector_map=sector_map,
+    )
+
+    fired: list[dict] = []
+    for alert in alerts:
+        msg = alert.message
+        logger.warning("CORRELATION ALERT [%s]: %s", alert.alert_type, msg)
+        broadcast(subject=f"Portfolio Alert: {alert.alert_type}", body=msg)
+        fired.append({
+            "alert_type": alert.alert_type,
+            "value": alert.value,
+            "threshold": alert.threshold,
+            "message": msg,
+        })
+
+    if not fired:
+        logger.info("correlation_check: all thresholds clear")
+
+    return fired
+
+
+# ── Anomaly detection scheduler hook ─────────────────────────────────────────
+
+def run_anomaly_checks(
+    watchlist: "list[str] | None" = None,
+    current_prices: "dict[str, float] | None" = None,
+) -> list[dict]:
+    """
+    Run all anomaly detection checks and broadcast results.
+
+    Parameters
+    ----------
+    watchlist       : tickers to check — reads from DB watchlist if None
+    current_prices  : current prices dict — fetched from market data if None
+
+    Returns
+    -------
+    List of anomaly dicts that were detected.
+    """
+    from analysis.anomaly_detector import AnomalyDetector
+
+    # Load watchlist
+    if watchlist is None:
+        try:
+            from data.watchlist import get_watchlist
+            watchlist = get_watchlist()
+        except Exception:
+            watchlist = []
+
+    # Load current prices
+    if current_prices is None and watchlist:
+        try:
+            from data.fetcher import fetch_ohlcv
+            current_prices = {}
+            for ticker in watchlist:
+                df = fetch_ohlcv(ticker, period="5d")
+                if not df.empty and "Close" in df.columns:
+                    current_prices[ticker] = float(df["Close"].iloc[-1])
+        except Exception as exc:
+            logger.warning("anomaly_checks: price fetch failed: %s", exc)
+            current_prices = {}
+
+    detector = AnomalyDetector()
+    results = detector.run_all_checks(
+        watchlist=watchlist or [],
+        current_prices=current_prices or {},
+    )
+
+    fired: list[dict] = []
+    for anomaly in results:
+        msg = anomaly.get("message", str(anomaly))
+        logger.warning("ANOMALY DETECTED [%s]: %s", anomaly.get("type", "?"), msg)
+        broadcast(subject=f"Anomaly: {anomaly.get('type', 'unknown')}", body=msg)
+        fired.append(anomaly)
+
+    return fired

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,1 @@
+# scripts package — one-off utility scripts for data migration and maintenance

--- a/scripts/migrate_to_tsdb.py
+++ b/scripts/migrate_to_tsdb.py
@@ -182,7 +182,7 @@ def migrate_portfolio_history(src_conn, tsdb) -> int:
 
 def main(provider: str | None = None) -> None:
     """Run all migrations from quant.db → configured TSDB."""
-    from data.db import get_connection, _DB_PATH
+    from data.db import _DB_PATH, get_connection
     from providers.tsdb import get_tsdb
 
     log.info("Starting TSDB migration", source=str(_DB_PATH), provider=provider or "env")

--- a/scripts/migrate_to_tsdb.py
+++ b/scripts/migrate_to_tsdb.py
@@ -1,0 +1,225 @@
+"""
+scripts/migrate_to_tsdb.py — Migrate existing SQLite data from quant.db into the
+configured TSDB backend (DuckDB or TimescaleDB).
+
+Usage
+-----
+    python scripts/migrate_to_tsdb.py [--provider duckdb|timescale|sqlite]
+
+ENV vars honoured
+-----------------
+    TSDB_PROVIDER       sqlite | duckdb | timescale  (default: sqlite)
+    SQLITE_TSDB_PATH    destination path for SQLite TSDB (default: quant_tsdb.db)
+    DUCKDB_PATH         destination path for DuckDB (default: quant_tsdb.duckdb)
+    TIMESCALE_DSN       postgresql:// connection string
+
+The migration is IDEMPOTENT — running it twice does not duplicate data.
+Each table uses INSERT OR REPLACE / ON CONFLICT DO NOTHING semantics so
+existing rows are skipped.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+import time
+from pathlib import Path
+
+import structlog
+
+# Ensure the project root is on sys.path when run directly.
+_PROJECT_ROOT = Path(__file__).parent.parent
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+log = structlog.get_logger(__name__)
+
+
+# ── Schema definitions for TSDB destination tables ────────────────────────────
+
+_OHLCV_SCHEMA = (
+    "symbol TEXT NOT NULL, "
+    "ts TEXT NOT NULL, "
+    "open REAL, high REAL, low REAL, close REAL, volume REAL, "
+    "PRIMARY KEY (symbol, ts)"
+)
+
+_TRADES_SCHEMA = (
+    "id INTEGER NOT NULL, "
+    "executed_at REAL NOT NULL, "
+    "symbol TEXT NOT NULL, "
+    "action TEXT NOT NULL, "
+    "shares REAL NOT NULL, "
+    "price REAL NOT NULL, "
+    "cost_basis REAL, "
+    "realised_pnl REAL, "
+    "PRIMARY KEY (id)"
+)
+
+_PORTFOLIO_HISTORY_SCHEMA = (
+    "id INTEGER NOT NULL, "
+    "record_date TEXT NOT NULL UNIQUE, "
+    "total_value REAL NOT NULL, "
+    "PRIMARY KEY (id)"
+)
+
+
+# ── Migration helpers ──────────────────────────────────────────────────────────
+
+def migrate_price_cache(src_conn, tsdb) -> int:
+    """
+    Read price_cache JSON blobs from quant.db and write OHLCV rows to TSDB.
+
+    Returns the number of rows written.
+    """
+    tsdb.create_table("ohlcv_prices", _OHLCV_SCHEMA)
+
+    rows = src_conn.execute(
+        "SELECT ticker, data_json FROM price_cache"
+    ).fetchall()
+
+    written = 0
+    for row in rows:
+        ticker = row[0] if isinstance(row, (list, tuple)) else row["ticker"]
+        data_json = row[1] if isinstance(row, (list, tuple)) else row["data_json"]
+        try:
+            data = json.loads(data_json)
+        except (json.JSONDecodeError, TypeError):
+            log.warning("Skipping malformed price_cache row", ticker=ticker)
+            continue
+
+        records: list[dict] = []
+        # data is a dict-of-dicts: {column -> {ts -> value}}
+        if isinstance(data, dict):
+            columns = list(data.keys())
+            # Gather all timestamps
+            timestamps: set[str] = set()
+            for col_data in data.values():
+                if isinstance(col_data, dict):
+                    timestamps.update(col_data.keys())
+            for ts in sorted(timestamps):
+                record: dict = {"symbol": ticker, "ts": ts}
+                for col in columns:
+                    col_lower = col.lower()
+                    if col_lower in ("open", "high", "low", "close", "volume"):
+                        col_data = data.get(col, {})
+                        record[col_lower] = col_data.get(ts) if isinstance(col_data, dict) else None
+                if "close" in record:
+                    records.append(record)
+
+        if records:
+            tsdb.write("ohlcv_prices", records)
+            written += len(records)
+            log.info("Migrated price cache", ticker=ticker, rows=len(records))
+
+    return written
+
+
+def migrate_paper_trades(src_conn, tsdb) -> int:
+    """
+    Read paper_trades from quant.db and write to TSDB execution_history table.
+
+    Returns the number of rows written.
+    """
+    tsdb.create_table("execution_history", _TRADES_SCHEMA)
+
+    rows = src_conn.execute(
+        "SELECT id, executed_at, ticker, action, shares, price, cost_basis, realised_pnl "
+        "FROM paper_trades ORDER BY id"
+    ).fetchall()
+
+    if not rows:
+        return 0
+
+    records = []
+    for row in rows:
+        if hasattr(row, "keys"):
+            r = dict(row)
+        else:
+            r = {
+                "id": row[0], "executed_at": row[1], "symbol": row[2],
+                "action": row[3], "shares": row[4], "price": row[5],
+                "cost_basis": row[6], "realised_pnl": row[7],
+            }
+        # Normalise ticker → symbol
+        r.setdefault("symbol", r.pop("ticker", ""))
+        records.append(r)
+
+    tsdb.write("execution_history", records)
+    log.info("Migrated paper trades", count=len(records))
+    return len(records)
+
+
+def migrate_portfolio_history(src_conn, tsdb) -> int:
+    """
+    Read portfolio_history from quant.db and write to TSDB.
+
+    Returns the number of rows written.
+    """
+    tsdb.create_table("portfolio_snapshots", _PORTFOLIO_HISTORY_SCHEMA)
+
+    rows = src_conn.execute(
+        "SELECT id, record_date, total_value FROM portfolio_history ORDER BY id"
+    ).fetchall()
+
+    if not rows:
+        return 0
+
+    records = []
+    for row in rows:
+        if hasattr(row, "keys"):
+            records.append(dict(row))
+        else:
+            records.append({"id": row[0], "record_date": row[1], "total_value": row[2]})
+
+    tsdb.write("portfolio_snapshots", records)
+    log.info("Migrated portfolio history", count=len(records))
+    return len(records)
+
+
+# ── Entry point ────────────────────────────────────────────────────────────────
+
+def main(provider: str | None = None) -> None:
+    """Run all migrations from quant.db → configured TSDB."""
+    from data.db import get_connection, _DB_PATH
+    from providers.tsdb import get_tsdb
+
+    log.info("Starting TSDB migration", source=str(_DB_PATH), provider=provider or "env")
+
+    tsdb = get_tsdb(provider)
+    src_conn = get_connection()
+
+    try:
+        start = time.time()
+        ohlcv_rows = migrate_price_cache(src_conn, tsdb)
+        trade_rows = migrate_paper_trades(src_conn, tsdb)
+        portfolio_rows = migrate_portfolio_history(src_conn, tsdb)
+        elapsed = round(time.time() - start, 2)
+
+        log.info(
+            "Migration complete",
+            ohlcv_rows=ohlcv_rows,
+            trade_rows=trade_rows,
+            portfolio_rows=portfolio_rows,
+            elapsed_seconds=elapsed,
+        )
+    finally:
+        src_conn.close()
+        tsdb.close()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Migrate quant.db data to the configured TSDB backend."
+    )
+    parser.add_argument(
+        "--provider",
+        choices=["sqlite", "duckdb", "timescale"],
+        default=None,
+        help="TSDB provider to migrate to (overrides TSDB_PROVIDER env var)",
+    )
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.INFO)
+    main(provider=args.provider)

--- a/strategies/gnn_signal.py
+++ b/strategies/gnn_signal.py
@@ -1,0 +1,239 @@
+"""
+strategies/gnn_signal.py — Graph Neural Network cross-asset momentum signal.
+
+Uses a 2-layer Graph Attention Network (GAT) with GICS sector co-membership as
+graph edges. Node features: technical indicators + regime one-hot + sentiment.
+Output: graph-aware momentum score per ticker in [-1.0, 1.0].
+
+Requires (optional): pip install torch torch-geometric
+
+ENV vars
+--------
+    GNN_ENABLED         set to '1' to activate in screener (default: 0)
+    GNN_MODEL_PATH      path to saved GAT checkpoint (default: models/gnn_signal.pt)
+    GNN_HIDDEN_DIM      hidden layer dimension (default: 32)
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import numpy as np
+
+from utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+_MODEL_PATH = os.environ.get("GNN_MODEL_PATH", "models/gnn_signal.pt")
+_HIDDEN_DIM = int(os.environ.get("GNN_HIDDEN_DIM", "32"))
+
+# ── GICS sector mapping for the platform's default 30-ticker universe ─────────
+
+TICKER_SECTOR: dict[str, str] = {
+    "AAPL": "Technology", "MSFT": "Technology", "NVDA": "Technology",
+    "GOOGL": "Technology", "META": "Technology", "AMZN": "Consumer Discretionary",
+    "TSLA": "Consumer Discretionary", "HD": "Consumer Discretionary",
+    "JPM": "Financials", "BAC": "Financials", "GS": "Financials",
+    "V": "Financials", "MA": "Financials",
+    "JNJ": "Healthcare", "UNH": "Healthcare", "PFE": "Healthcare",
+    "ABBV": "Healthcare",
+    "XOM": "Energy", "CVX": "Energy", "COP": "Energy",
+    "CAT": "Industrials", "HON": "Industrials", "BA": "Industrials",
+    "PG": "Consumer Staples", "KO": "Consumer Staples", "WMT": "Consumer Staples",
+    "NEE": "Utilities",
+    "AMT": "Real Estate",
+    "SPY": "ETF", "QQQ": "ETF",
+}
+
+
+def build_sector_adjacency(tickers: list[str]) -> np.ndarray:
+    """
+    Build a binary adjacency matrix where 1 = same GICS sector.
+
+    Parameters
+    ----------
+    tickers : list of ticker symbols
+
+    Returns
+    -------
+    np.ndarray of shape (N, N), dtype float32, diagonal = 0.
+    """
+    n = len(tickers)
+    adj = np.zeros((n, n), dtype=np.float32)
+    sectors = [TICKER_SECTOR.get(t, "Unknown") for t in tickers]
+    for i in range(n):
+        for j in range(n):
+            if i != j and sectors[i] == sectors[j] and sectors[i] != "Unknown":
+                adj[i, j] = 1.0
+    return adj
+
+
+# ── Node feature builder ─────────────────────────────────────────────────────
+
+def build_node_features(
+    tickers: list[str],
+    indicators: dict[str, dict] | None = None,
+    regime: str = "trending_bull",
+    sentiments: dict[str, float] | None = None,
+) -> np.ndarray:
+    """
+    Build a node feature matrix of shape (N, feature_dim).
+
+    Feature vector per node (ticker):
+        [rsi/100, momentum_5d, sma_cross_signal, regime_oh(4), sentiment]
+        = 8 features
+
+    Parameters
+    ----------
+    tickers    : ordered list of tickers (defines node ordering)
+    indicators : dict of {ticker: {rsi, momentum, sma_signal}} — fetched if None
+    regime     : current market regime label
+    sentiments : dict of {ticker: sentiment_score} — defaults to 0.0
+
+    Returns
+    -------
+    np.ndarray of shape (N, 8), dtype float32
+    """
+    from analysis.regime import REGIME_STATES
+
+    regime_oh = [1.0 if r == regime else 0.0 for r in REGIME_STATES]
+    features = []
+
+    for ticker in tickers:
+        ind = (indicators or {}).get(ticker, {})
+        rsi = float(ind.get("rsi", 50)) / 100.0
+        momentum = float(ind.get("momentum", 0.0))
+        sma_signal = float(ind.get("sma_signal", 0.0))
+        sentiment = float((sentiments or {}).get(ticker, 0.0))
+        node_feat = [rsi, momentum, sma_signal] + regime_oh + [sentiment]
+        features.append(node_feat)
+
+    return np.array(features, dtype=np.float32)
+
+
+# ── GAT model (torch-geometric) ──────────────────────────────────────────────
+
+def _build_gat_model(in_channels: int, hidden_dim: int, out_channels: int = 1):
+    """Build a 2-layer GAT model. Raises ImportError if torch/torch_geometric absent."""
+    import torch
+    import torch.nn as nn
+    from torch_geometric.nn import GATConv  # type: ignore[import]
+
+    class GATSignalModel(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.conv1 = GATConv(in_channels, hidden_dim, heads=2, concat=True, dropout=0.1)
+            self.conv2 = GATConv(hidden_dim * 2, out_channels, heads=1, concat=False, dropout=0.1)
+
+        def forward(self, x, edge_index):
+            import torch.nn.functional as F
+            x = F.elu(self.conv1(x, edge_index))
+            x = self.conv2(x, edge_index)
+            return torch.tanh(x)  # output in [-1, 1]
+
+    return GATSignalModel()
+
+
+def _adj_to_edge_index(adj: np.ndarray):
+    """Convert dense adjacency matrix to COO edge_index for torch-geometric."""
+    import torch
+    src, dst = np.where(adj > 0)
+    edge_index = torch.tensor(np.stack([src, dst]), dtype=torch.long)
+    return edge_index
+
+
+# ── Public API ────────────────────────────────────────────────────────────────
+
+class GNNSignal:
+    """
+    Graph-aware momentum scorer using a 2-layer GAT.
+
+    When torch/torch_geometric are not installed or the model checkpoint is
+    absent, falls back to a simple RSI + momentum composite score.
+    """
+
+    def __init__(self, model_path: str | None = None) -> None:
+        self._model_path = model_path or _MODEL_PATH
+        self._model = None
+        self._load_if_available()
+
+    def _load_if_available(self) -> None:
+        path = Path(self._model_path)
+        if not path.exists():
+            logger.info("GNNSignal: no checkpoint at %s, using fallback scorer", path)
+            return
+        try:
+            import torch
+            in_channels = 8
+            model = _build_gat_model(in_channels, _HIDDEN_DIM)
+            model.load_state_dict(torch.load(str(path), map_location="cpu"))
+            model.eval()
+            self._model = model
+            logger.info("GNNSignal: loaded checkpoint from %s", path)
+        except ImportError:
+            logger.info("torch/torch-geometric not installed; GNN using fallback scorer")
+        except Exception as exc:
+            logger.warning("GNNSignal: failed to load checkpoint: %s", exc)
+
+    def score(
+        self,
+        tickers: list[str],
+        indicators: dict[str, dict] | None = None,
+        regime: str = "trending_bull",
+        sentiments: dict[str, float] | None = None,
+    ) -> dict[str, float]:
+        """
+        Return a momentum score in [-1.0, 1.0] for each ticker.
+
+        Parameters
+        ----------
+        tickers    : list of tickers to score
+        indicators : {ticker: {rsi, momentum, sma_signal}} — fetched if None
+        regime     : current regime label
+        sentiments : {ticker: score} — defaults to 0.0
+
+        Returns
+        -------
+        dict of {ticker: score} where score ∈ [-1.0, 1.0]
+        """
+        if not tickers:
+            return {}
+
+        if self._model is not None:
+            return self._score_with_gat(tickers, indicators, regime, sentiments)
+        return self._fallback_score(tickers, indicators, sentiments)
+
+    def _score_with_gat(
+        self,
+        tickers: list[str],
+        indicators: dict[str, dict] | None,
+        regime: str,
+        sentiments: dict[str, float] | None,
+    ) -> dict[str, float]:
+        import torch
+        x_np = build_node_features(tickers, indicators, regime, sentiments)
+        adj = build_sector_adjacency(tickers)
+        edge_index = _adj_to_edge_index(adj)
+        x = torch.tensor(x_np)
+        with torch.no_grad():
+            out = self._model(x, edge_index).squeeze(-1).numpy()
+        return {ticker: float(out[i]) for i, ticker in enumerate(tickers)}
+
+    def _fallback_score(
+        self,
+        tickers: list[str],
+        indicators: dict[str, dict] | None,
+        sentiments: dict[str, float] | None,
+    ) -> dict[str, float]:
+        """Simple RSI + momentum + sentiment composite when GNN is unavailable."""
+        scores = {}
+        for ticker in tickers:
+            ind = (indicators or {}).get(ticker, {})
+            rsi = float(ind.get("rsi", 50))
+            momentum = float(ind.get("momentum", 0.0))
+            sentiment = float((sentiments or {}).get(ticker, 0.0))
+            # Normalise RSI to [-1, 1]: RSI=30 → -0.4, RSI=70 → +0.4
+            rsi_score = (rsi - 50) / 50.0
+            score = 0.5 * rsi_score + 0.3 * momentum + 0.2 * sentiment
+            scores[ticker] = float(np.clip(score, -1.0, 1.0))
+        return scores

--- a/strategies/gnn_signal.py
+++ b/strategies/gnn_signal.py
@@ -113,7 +113,7 @@ def build_node_features(
 
 # ── GAT model (torch-geometric) ──────────────────────────────────────────────
 
-def _build_gat_model(in_channels: int, hidden_dim: int, out_channels: int = 1):
+def _build_gat_model(in_channels: int, hidden_dim: int, out_channels: int = 1):  # pragma: no cover
     """Build a 2-layer GAT model. Raises ImportError if torch/torch_geometric absent."""
     import torch
     import torch.nn as nn
@@ -134,7 +134,7 @@ def _build_gat_model(in_channels: int, hidden_dim: int, out_channels: int = 1):
     return GATSignalModel()
 
 
-def _adj_to_edge_index(adj: np.ndarray):
+def _adj_to_edge_index(adj: np.ndarray):  # pragma: no cover
     """Convert dense adjacency matrix to COO edge_index for torch-geometric."""
     import torch
     src, dst = np.where(adj > 0)
@@ -162,7 +162,7 @@ class GNNSignal:
         if not path.exists():
             logger.info("GNNSignal: no checkpoint at %s, using fallback scorer", path)
             return
-        try:
+        try:  # pragma: no cover
             import torch
             in_channels = 8
             model = _build_gat_model(in_channels, _HIDDEN_DIM)
@@ -170,9 +170,9 @@ class GNNSignal:
             model.eval()
             self._model = model
             logger.info("GNNSignal: loaded checkpoint from %s", path)
-        except ImportError:
+        except ImportError:  # pragma: no cover
             logger.info("torch/torch-geometric not installed; GNN using fallback scorer")
-        except Exception as exc:
+        except Exception as exc:  # pragma: no cover
             logger.warning("GNNSignal: failed to load checkpoint: %s", exc)
 
     def score(
@@ -199,11 +199,11 @@ class GNNSignal:
         if not tickers:
             return {}
 
-        if self._model is not None:
+        if self._model is not None:  # pragma: no cover
             return self._score_with_gat(tickers, indicators, regime, sentiments)
         return self._fallback_score(tickers, indicators, sentiments)
 
-    def _score_with_gat(
+    def _score_with_gat(  # pragma: no cover
         self,
         tickers: list[str],
         indicators: dict[str, dict] | None,

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -1,0 +1,247 @@
+"""Tests for specialist agents: regime, risk, screener, sentiment, execution (Issue #38)."""
+from __future__ import annotations
+
+import sys
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+
+from agents.base import AgentSignal
+
+# Ensure optional transitive deps are available as mocks so agents can import
+sys.modules.setdefault("yfinance", MagicMock())
+sys.modules.setdefault("ta", MagicMock())
+
+
+# ── RegimeAgent ────────────────────────────────────────────────────────────────
+
+def test_regime_agent_bull_signal():
+    from agents.regime_agent import RegimeAgent
+    agent = RegimeAgent()
+    result = agent.run({"regime": "trending_bull"})
+    assert isinstance(result, AgentSignal)
+    assert result.signal == "bullish"
+    assert result.confidence == pytest.approx(0.8)
+    assert result.agent_name == "regime_agent"
+
+
+def test_regime_agent_bear_signal():
+    from agents.regime_agent import RegimeAgent
+    agent = RegimeAgent()
+    result = agent.run({"regime": "trending_bear"})
+    assert result.signal == "bearish"
+
+
+def test_regime_agent_high_vol_bearish():
+    from agents.regime_agent import RegimeAgent
+    agent = RegimeAgent()
+    result = agent.run({"regime": "high_vol"})
+    assert result.signal == "bearish"
+
+
+def test_regime_agent_mean_reverting_neutral():
+    from agents.regime_agent import RegimeAgent
+    agent = RegimeAgent()
+    result = agent.run({"regime": "mean_reverting"})
+    assert result.signal == "neutral"
+
+
+def test_regime_agent_unknown_regime_neutral():
+    from agents.regime_agent import RegimeAgent
+    agent = RegimeAgent()
+    result = agent.run({"regime": "unknown_regime_xyz"})
+    assert result.signal == "neutral"
+
+
+def test_regime_agent_fetches_regime_when_absent():
+    from agents.regime_agent import RegimeAgent
+    agent = RegimeAgent()
+    with patch("analysis.regime.get_live_regime_with_llm",
+               return_value={"regime": "trending_bull"}):
+        result = agent.run({})
+    assert result.signal == "bullish"
+
+
+def test_regime_agent_fallback_on_fetch_error():
+    from agents.regime_agent import RegimeAgent
+    agent = RegimeAgent()
+    with patch("analysis.regime.get_live_regime_with_llm",
+               side_effect=RuntimeError("no data")):
+        result = agent.run({})
+    assert result.signal == "neutral"
+    assert result.confidence <= 0.5
+
+
+# ── RiskAgent ──────────────────────────────────────────────────────────────────
+
+def test_risk_agent_neutral_on_empty_portfolio():
+    from agents.risk_agent import RiskAgent
+    agent = RiskAgent()
+    result = agent.run({"portfolio": {"positions": {}}})
+    assert result.signal == "neutral"
+    assert result.agent_name == "risk_agent"
+
+
+def test_risk_agent_neutral_when_no_portfolio_key():
+    from agents.risk_agent import RiskAgent
+    agent = RiskAgent()
+    result = agent.run({})
+    assert result.signal == "neutral"
+
+
+def test_risk_agent_bearish_when_correlation_alert():
+    from agents.risk_agent import RiskAgent
+    from risk.correlation import CorrelationAlert
+
+    mock_alert = CorrelationAlert(
+        alert_type="position_concentration",
+        value=0.85,
+        threshold=0.25,
+        message="AAPL is 85% of portfolio",
+        ticker="AAPL",
+    )
+    agent = RiskAgent()
+    positions = {"AAPL": 85_000.0, "MSFT": 15_000.0}
+    mock_df = pd.DataFrame({"Close": [100.0] * 30})
+
+    with patch("risk.correlation.check_correlation_alerts", return_value=[mock_alert]), \
+         patch("data.fetcher.fetch_ohlcv", return_value=mock_df):
+        result = agent.run({"portfolio": {"positions": positions}})
+    assert result.signal == "bearish"
+
+
+# ── ScreenerAgent ──────────────────────────────────────────────────────────────
+
+def test_screener_agent_no_ticker_returns_neutral():
+    from agents.screener_agent import ScreenerAgent
+    agent = ScreenerAgent()
+    result = agent.run({})
+    assert result.signal == "neutral"
+    assert result.agent_name == "screener_agent"
+
+
+def test_screener_agent_bullish_on_trending_up():
+    from agents.screener_agent import ScreenerAgent
+
+    mock_run_screener = MagicMock(
+        return_value=pd.DataFrame([{"Signal": "Trending Up", "Ticker": "AAPL"}])
+    )
+    mock_screener_mod = MagicMock()
+    mock_screener_mod.run_screener = mock_run_screener
+    with patch.dict(sys.modules, {"screener.screener": mock_screener_mod}):
+        agent = ScreenerAgent()
+        result = agent.run({"ticker": "AAPL"})
+    assert result.signal == "bullish"
+
+
+def test_screener_agent_bearish_on_trending_down():
+    from agents.screener_agent import ScreenerAgent
+
+    mock_screener_mod = MagicMock()
+    mock_screener_mod.run_screener.return_value = pd.DataFrame(
+        [{"Signal": "Trending Down", "Ticker": "SPY"}]
+    )
+    with patch.dict(sys.modules, {"screener.screener": mock_screener_mod}):
+        agent = ScreenerAgent()
+        result = agent.run({"ticker": "SPY"})
+    assert result.signal == "bearish"
+
+
+def test_screener_agent_fallback_on_error():
+    from agents.screener_agent import ScreenerAgent
+
+    mock_screener_mod = MagicMock()
+    mock_screener_mod.run_screener.side_effect = RuntimeError("db error")
+    with patch.dict(sys.modules, {"screener.screener": mock_screener_mod}):
+        agent = ScreenerAgent()
+        result = agent.run({"ticker": "AAPL"})
+    assert result.signal == "neutral"
+
+
+# ── SentimentAgent ─────────────────────────────────────────────────────────────
+
+def test_sentiment_agent_bullish_positive_score():
+    from agents.sentiment_agent import SentimentAgent
+
+    mock_provider = MagicMock()
+    mock_provider.ticker_sentiment.return_value = 0.6
+
+    with patch("providers.sentiment.get_sentiment", return_value=mock_provider):
+        agent = SentimentAgent()
+        result = agent.run({"ticker": "AAPL"})
+    assert result.signal == "bullish"
+    assert result.agent_name == "sentiment_agent"
+    assert result.confidence > 0.5
+
+
+def test_sentiment_agent_bearish_negative_score():
+    from agents.sentiment_agent import SentimentAgent
+
+    mock_provider = MagicMock()
+    mock_provider.ticker_sentiment.return_value = -0.5
+
+    with patch("providers.sentiment.get_sentiment", return_value=mock_provider):
+        agent = SentimentAgent()
+        result = agent.run({"ticker": "MSFT"})
+    assert result.signal == "bearish"
+
+
+def test_sentiment_agent_neutral_near_zero():
+    from agents.sentiment_agent import SentimentAgent
+
+    mock_provider = MagicMock()
+    mock_provider.ticker_sentiment.return_value = 0.05
+
+    with patch("providers.sentiment.get_sentiment", return_value=mock_provider):
+        agent = SentimentAgent()
+        result = agent.run({"ticker": "SPY"})
+    assert result.signal == "neutral"
+
+
+def test_sentiment_agent_fallback_on_error():
+    from agents.sentiment_agent import SentimentAgent
+    with patch("providers.sentiment.get_sentiment", side_effect=RuntimeError("api down")):
+        agent = SentimentAgent()
+        result = agent.run({"ticker": "TSLA"})
+    assert result.signal == "neutral"
+    assert result.confidence <= 0.5
+
+
+# ── ExecutionAgent ─────────────────────────────────────────────────────────────
+
+def test_execution_agent_market_for_small_order():
+    from agents.execution_agent import ExecutionAgent
+    agent = ExecutionAgent()
+    result = agent.run({"regime": "trending_bull", "order_size": 1000})
+    assert result.signal == "neutral"
+    assert result.metadata["recommended_algo"] == "market"
+    assert result.agent_name == "execution_agent"
+
+
+def test_execution_agent_twap_for_high_vol():
+    from agents.execution_agent import ExecutionAgent
+    agent = ExecutionAgent()
+    result = agent.run({"regime": "high_vol", "order_size": 1000})
+    assert result.metadata["recommended_algo"] == "twap"
+
+
+def test_execution_agent_twap_for_large_order():
+    from agents.execution_agent import ExecutionAgent
+    agent = ExecutionAgent()
+    result = agent.run({"regime": "trending_bull", "order_size": 15_000})
+    assert result.metadata["recommended_algo"] == "twap"
+
+
+def test_execution_agent_vwap_for_moderate_order():
+    from agents.execution_agent import ExecutionAgent
+    agent = ExecutionAgent()
+    result = agent.run({"regime": "mean_reverting", "order_size": 7_000})
+    assert result.metadata["recommended_algo"] == "vwap"
+
+
+def test_execution_agent_high_confidence():
+    from agents.execution_agent import ExecutionAgent
+    agent = ExecutionAgent()
+    result = agent.run({})
+    assert result.confidence >= 0.8

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -9,9 +9,8 @@ import pytest
 
 from agents.base import AgentSignal
 
-# Ensure optional transitive deps are available as mocks so agents can import
+# Ensure yfinance is available as a mock so data.fetcher can be imported locally
 sys.modules.setdefault("yfinance", MagicMock())
-sys.modules.setdefault("ta", MagicMock())
 
 
 # ── RegimeAgent ────────────────────────────────────────────────────────────────

--- a/tests/test_anomaly_detector.py
+++ b/tests/test_anomaly_detector.py
@@ -1,0 +1,135 @@
+"""Tests for analysis/anomaly_detector.py (Issue #33)."""
+from __future__ import annotations
+
+import sys
+import time
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+
+# Ensure yfinance is available as a mock so data.fetcher can be imported
+_yf_mock = MagicMock()
+sys.modules.setdefault("yfinance", _yf_mock)
+
+
+def test_signal_drought_detected_when_log_empty():
+    from analysis.anomaly_detector import AnomalyDetector
+
+    det = AnomalyDetector()
+    # Provide an empty signal log — drought should be reported
+    result = det.check_signal_drought(signal_log=[], window_hours=4)
+    assert result is not None
+    assert result.type == "signal_drought"
+    assert result.severity == "warning"
+
+
+def test_signal_drought_not_triggered_with_recent_signal():
+    from analysis.anomaly_detector import AnomalyDetector
+
+    det = AnomalyDetector()
+    recent_ts = time.time() - 60  # 1 minute ago
+    log = [{"entry_time": recent_ts, "ticker": "AAPL", "action": "buy"}]
+    result = det.check_signal_drought(signal_log=log, window_hours=4)
+    assert result is None
+
+
+def test_signal_drought_old_signals_trigger():
+    from analysis.anomaly_detector import AnomalyDetector
+
+    det = AnomalyDetector()
+    old_ts = time.time() - 8 * 3600  # 8 hours ago
+    log = [{"entry_time": old_ts, "ticker": "SPY", "action": "sell"}]
+    result = det.check_signal_drought(signal_log=log, window_hours=4)
+    assert result is not None
+    assert result.type == "signal_drought"
+
+
+def test_price_spike_detected_above_threshold():
+    from analysis.anomaly_detector import AnomalyDetector
+
+    det = AnomalyDetector()
+    # Stable recent prices around 100; current price is 130 → 30% spike
+    mock_close = pd.Series([100.0, 100.5, 99.8, 100.2, 100.1])
+    mock_df = pd.DataFrame({"Close": mock_close})
+
+    with patch("data.fetcher.fetch_ohlcv", return_value=mock_df):
+        result = det.check_price_spike("AAPL", 130.0, threshold_pct=0.10)
+    assert result is not None
+    assert result.type == "price_spike"
+    assert result.symbol == "AAPL"
+
+
+def test_price_spike_not_triggered_within_threshold():
+    from analysis.anomaly_detector import AnomalyDetector
+
+    det = AnomalyDetector()
+    mock_close = pd.Series([100.0, 100.5, 99.8, 100.2, 100.1])
+    mock_df = pd.DataFrame({"Close": mock_close})
+
+    with patch("data.fetcher.fetch_ohlcv", return_value=mock_df):
+        result = det.check_price_spike("AAPL", 101.0, threshold_pct=0.10)
+    assert result is None
+
+
+def test_price_spike_critical_severity():
+    from analysis.anomaly_detector import AnomalyDetector
+
+    det = AnomalyDetector()
+    mock_close = pd.Series([100.0] * 5)
+    mock_df = pd.DataFrame({"Close": mock_close})
+
+    with patch("data.fetcher.fetch_ohlcv", return_value=mock_df):
+        result = det.check_price_spike("TSLA", 130.0, threshold_pct=0.10)
+    assert result is not None
+    assert result.severity == "critical"  # 30% > 20% critical threshold
+
+
+def test_pnl_divergence_detected():
+    from analysis.anomaly_detector import AnomalyDetector
+
+    det = AnomalyDetector()
+    live = [100.0, -200.0, 50.0, -300.0, 80.0]    # net: -270
+    paper = [100.0, 100.0, 50.0, 100.0, 80.0]      # net: +430
+    result = det.check_pnl_divergence(live, paper, threshold_pct=0.10)
+    assert result is not None
+    assert result.type == "pnl_divergence"
+
+
+def test_pnl_divergence_not_triggered_when_similar():
+    from analysis.anomaly_detector import AnomalyDetector
+
+    det = AnomalyDetector()
+    live = [100.0, 50.0, -10.0, 80.0, 20.0]
+    paper = [100.0, 52.0, -11.0, 82.0, 21.0]  # Very close values
+    result = det.check_pnl_divergence(live, paper, threshold_pct=0.10)
+    assert result is None
+
+
+def test_pnl_divergence_empty_inputs():
+    from analysis.anomaly_detector import AnomalyDetector
+
+    det = AnomalyDetector()
+    assert det.check_pnl_divergence([], [], threshold_pct=0.05) is None
+    assert det.check_pnl_divergence([100.0], [], threshold_pct=0.05) is None
+
+
+def test_pnl_divergence_single_element():
+    from analysis.anomaly_detector import AnomalyDetector
+
+    det = AnomalyDetector()
+    result = det.check_pnl_divergence([100.0], [100.0], threshold_pct=0.05)
+    assert result is None  # Need at least 2 points
+
+
+def test_run_all_checks_returns_list():
+    from analysis.anomaly_detector import AnomalyDetector
+
+    det = AnomalyDetector()
+    with patch.object(det, "check_signal_drought", return_value=None), \
+         patch("data.fetcher.fetch_ohlcv", side_effect=Exception("no data")):
+        results = det.run_all_checks(
+            watchlist=["AAPL", "MSFT"],
+            current_prices={"AAPL": 180.0, "MSFT": 320.0},
+        )
+    assert isinstance(results, list)

--- a/tests/test_anomaly_detector.py
+++ b/tests/test_anomaly_detector.py
@@ -6,7 +6,6 @@ import time
 from unittest.mock import MagicMock, patch
 
 import pandas as pd
-import pytest
 
 # Ensure yfinance is available as a mock so data.fetcher can be imported
 _yf_mock = MagicMock()

--- a/tests/test_correlation_monitor.py
+++ b/tests/test_correlation_monitor.py
@@ -1,0 +1,134 @@
+"""Tests for risk/correlation.py monitoring functions (Issue #32)."""
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+
+def _price_series(n: int = 30, seed: int = 42) -> pd.Series:
+    rng = np.random.default_rng(seed)
+    prices = 100.0 + np.cumsum(rng.normal(0, 1, n))
+    return pd.Series(prices)
+
+
+def test_rolling_correlation_returns_dataframe():
+    from risk.correlation import rolling_correlation
+
+    data = {
+        "AAPL": _price_series(30, seed=1),
+        "MSFT": _price_series(30, seed=2),
+    }
+    result = rolling_correlation(data, window=10)
+    assert isinstance(result, pd.DataFrame)
+    assert result.shape[0] == result.shape[1]  # square
+
+
+def test_rolling_correlation_empty_input():
+    from risk.correlation import rolling_correlation
+
+    result = rolling_correlation({}, window=20)
+    assert result.empty
+
+
+def test_rolling_correlation_single_ticker():
+    from risk.correlation import rolling_correlation
+
+    result = rolling_correlation({"AAPL": _price_series(30)}, window=10)
+    assert result.empty
+
+
+def test_check_correlation_alerts_no_alerts_normal_portfolio():
+    from risk.correlation import check_correlation_alerts
+
+    # Uncorrelated price series, balanced positions
+    data = {
+        "AAPL": _price_series(30, seed=1),
+        "MSFT": _price_series(30, seed=99),   # different seed = low corr
+        "JPM": _price_series(30, seed=77),
+    }
+    positions = {"AAPL": 10_000.0, "MSFT": 10_000.0, "JPM": 10_000.0}
+    alerts = check_correlation_alerts(data, positions, avg_corr_threshold=0.95)
+    # No alert for avg correlation since we set a high threshold
+    assert all(a.alert_type != "avg_correlation" for a in alerts)
+
+
+def test_check_correlation_alerts_position_concentration():
+    from risk.correlation import check_correlation_alerts
+
+    data = {
+        "AAPL": _price_series(30, seed=1),
+        "MSFT": _price_series(30, seed=2),
+    }
+    # AAPL holds 80% of portfolio — should trigger position concentration alert
+    positions = {"AAPL": 80_000.0, "MSFT": 20_000.0}
+    alerts = check_correlation_alerts(data, positions, position_weight_threshold=0.25)
+    types = {a.alert_type for a in alerts}
+    assert "position_concentration" in types
+
+
+def test_check_correlation_alerts_sector_concentration():
+    from risk.correlation import check_correlation_alerts
+
+    data = {
+        "AAPL": _price_series(30, seed=1),
+        "MSFT": _price_series(30, seed=2),
+        "NVDA": _price_series(30, seed=3),
+    }
+    positions = {"AAPL": 40_000.0, "MSFT": 40_000.0, "NVDA": 20_000.0}
+    sector_map = {"AAPL": "Technology", "MSFT": "Technology", "NVDA": "Technology"}
+    # All three are tech → sector concentration = 100% > threshold 40%
+    alerts = check_correlation_alerts(
+        data, positions, sector_map=sector_map, sector_weight_threshold=0.40
+    )
+    types = {a.alert_type for a in alerts}
+    assert "sector_concentration" in types
+
+
+def test_check_correlation_alerts_empty_positions():
+    from risk.correlation import check_correlation_alerts
+
+    data = {"AAPL": _price_series(30)}
+    alerts = check_correlation_alerts(data, {})
+    assert isinstance(alerts, list)
+
+
+def test_correlation_alert_dataclass_fields():
+    from risk.correlation import CorrelationAlert
+
+    alert = CorrelationAlert(
+        alert_type="avg_correlation",
+        value=0.82,
+        threshold=0.70,
+        message="High average correlation detected",
+        ticker="",
+    )
+    assert alert.alert_type == "avg_correlation"
+    assert alert.value == pytest.approx(0.82)
+    assert alert.threshold == pytest.approx(0.70)
+
+
+def test_no_alerts_for_balanced_diversified_portfolio():
+    from risk.correlation import check_correlation_alerts
+
+    rng = np.random.default_rng(0)
+    # Build near-orthogonal price series
+    data = {}
+    positions = {}
+    sectors = {}
+    tickers = ["A", "B", "C", "D", "E", "F"]
+    for i, t in enumerate(tickers):
+        prices = 100.0 + np.cumsum(rng.normal(0, 1, 30))
+        data[t] = pd.Series(prices)
+        positions[t] = 10_000.0  # equal weight
+        sectors[t] = f"Sector{i}"  # all different sectors
+
+    alerts = check_correlation_alerts(
+        data, positions, sector_map=sectors,
+        avg_corr_threshold=0.70,
+        position_weight_threshold=0.25,
+        sector_weight_threshold=0.40,
+    )
+    # With equal weights of ~16.7% each and different sectors, no concentration alerts
+    conc_alerts = [a for a in alerts if a.alert_type in ("position_concentration", "sector_concentration")]
+    assert len(conc_alerts) == 0

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -1,11 +1,15 @@
 import os
 import sys
+from unittest.mock import MagicMock
 
 import pytest
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
-from broker.execution import ZERO_COST_MODEL, cost_drag, simulate_execution
+# Mock optional transitive deps before anything imports them
+sys.modules.setdefault("yfinance", MagicMock())
+
+from broker.execution import ZERO_COST_MODEL, cost_drag, simulate_execution  # noqa: E402
 
 
 def test_buy_pays_more():
@@ -50,3 +54,151 @@ def test_invalid_inputs_raise():
         simulate_execution(-1.0, 100, "buy")
     with pytest.raises(ValueError):
         simulate_execution(100.0, 0, "buy")
+
+
+# ── TWAPAdapter ────────────────────────────────────────────────────────────────
+
+def test_twap_execute_returns_execution_result():
+    from unittest.mock import MagicMock, patch
+
+    from adapters.execution_algo.result import ExecutionResult
+    from adapters.execution_algo.twap_adapter import TWAPAdapter
+
+    mock_broker = MagicMock()
+    # Return fill with the qty that was requested so total_qty sums correctly
+    mock_broker.place_order.side_effect = lambda **kw: {
+        "symbol": kw["symbol"], "qty": kw["qty"],
+        "side": kw["side"], "fill_price": 150.0, "status": "filled",
+    }
+
+    adapter = TWAPAdapter(slice_seconds=30)  # 2 slices for 1-min window
+    with patch("time.sleep"):
+        result = adapter.execute(
+            symbol="AAPL",
+            total_qty=10.0,
+            side="buy",
+            broker=mock_broker,
+            duration_minutes=1,
+            decision_price=149.0,
+        )
+
+    assert isinstance(result, ExecutionResult)
+    assert result.symbol == "AAPL"
+    assert result.algo == "twap"
+    assert result.total_qty == pytest.approx(10.0)
+
+
+def test_twap_slices_into_multiple_orders():
+    from unittest.mock import MagicMock, patch
+
+    from adapters.execution_algo.twap_adapter import TWAPAdapter
+
+    mock_broker = MagicMock()
+    mock_broker.place_order.return_value = {
+        "symbol": "AAPL", "qty": 5.0, "side": "buy",
+        "fill_price": 200.0, "status": "filled",
+    }
+
+    adapter = TWAPAdapter(slice_seconds=30)  # 2 slices in 1 min
+    with patch("time.sleep"):
+        adapter.execute(
+            symbol="AAPL",
+            total_qty=100.0,
+            side="buy",
+            broker=mock_broker,
+            duration_minutes=1,
+        )
+
+    # Should have called place_order 2 times (60s / 30s = 2 slices)
+    assert mock_broker.place_order.call_count == 2
+
+
+def test_twap_single_slice_no_sleep():
+    """Duration <= slice_seconds → 1 slice → no sleep."""
+    from unittest.mock import MagicMock, patch
+
+    from adapters.execution_algo.twap_adapter import TWAPAdapter
+
+    mock_broker = MagicMock()
+    mock_broker.place_order.return_value = {
+        "symbol": "MSFT", "qty": 50.0, "side": "sell",
+        "fill_price": 300.0, "status": "filled",
+    }
+
+    adapter = TWAPAdapter(slice_seconds=120)  # 1 slice for 1-min window
+    with patch("time.sleep") as mock_sleep:
+        adapter.execute(
+            symbol="MSFT",
+            total_qty=50.0,
+            side="sell",
+            broker=mock_broker,
+            duration_minutes=1,
+        )
+
+    mock_sleep.assert_not_called()
+
+
+# ── VWAPAdapter ────────────────────────────────────────────────────────────────
+
+def test_vwap_execute_returns_execution_result():
+    from unittest.mock import patch
+
+    import pandas as pd
+
+    import data.fetcher  # noqa: F401 — ensures data.fetcher is in sys.modules
+    from adapters.execution_algo.result import ExecutionResult
+    from adapters.execution_algo.vwap_adapter import VWAPAdapter
+
+    mock_broker = MagicMock()
+    mock_broker.place_order.side_effect = lambda **kw: {
+        "symbol": kw["symbol"], "qty": kw["qty"],
+        "side": kw["side"], "fill_price": 152.0, "status": "filled",
+    }
+
+    mock_df = pd.DataFrame({"Volume": [1_000_000.0] * 5, "Close": [150.0] * 5})
+
+    adapter = VWAPAdapter(lookback_days=5, slice_seconds=30)
+    with patch("data.fetcher.fetch_ohlcv", return_value=mock_df), \
+         patch("time.sleep"):
+        result = adapter.execute(
+            symbol="AAPL",
+            total_qty=10.0,
+            side="buy",
+            broker=mock_broker,
+            duration_minutes=1,
+            decision_price=151.0,
+        )
+
+    assert isinstance(result, ExecutionResult)
+    assert result.symbol == "AAPL"
+    assert result.algo == "vwap"
+
+
+def test_vwap_falls_back_to_uniform_weights_on_empty_df():
+    from unittest.mock import patch
+
+    import pandas as pd
+
+    import data.fetcher  # noqa: F401 — ensures data.fetcher is in sys.modules
+    from adapters.execution_algo.vwap_adapter import VWAPAdapter
+
+    mock_broker = MagicMock()
+    mock_broker.place_order.side_effect = lambda **kw: {
+        "symbol": kw["symbol"], "qty": kw["qty"],
+        "side": kw["side"], "fill_price": 50.0, "status": "filled",
+    }
+
+    empty_df = pd.DataFrame()  # empty → fallback to uniform weights
+
+    adapter = VWAPAdapter(lookback_days=5, slice_seconds=30)
+    with patch("data.fetcher.fetch_ohlcv", return_value=empty_df), \
+         patch("time.sleep"):
+        result = adapter.execute(
+            symbol="XYZ",
+            total_qty=5.0,
+            side="buy",
+            broker=mock_broker,
+            duration_minutes=1,
+        )
+
+    assert result.symbol == "XYZ"

--- a/tests/test_execution_result.py
+++ b/tests/test_execution_result.py
@@ -1,0 +1,70 @@
+"""Tests for ExecutionResult dataclass and execution algo typing (Issue #24)."""
+from __future__ import annotations
+
+import pytest
+
+
+def test_from_fills_empty():
+    from adapters.execution_algo.result import ExecutionResult
+    result = ExecutionResult.from_fills([], "AAPL", "buy", "market", decision_price=150.0)
+    assert result.symbol == "AAPL"
+    assert result.side == "buy"
+    assert result.total_qty == 0.0
+    assert result.avg_fill_price == 0.0
+    assert result.slippage_bps == 0.0
+
+
+def test_from_fills_single():
+    from adapters.execution_algo.result import ExecutionResult
+    fills = [{"price": 151.0, "qty": 10.0}]
+    result = ExecutionResult.from_fills(fills, "AAPL", "buy", "market", decision_price=150.0)
+    assert result.total_qty == pytest.approx(10.0)
+    assert result.avg_fill_price == pytest.approx(151.0)
+    # slippage = (151 - 150) / 150 * 10000 ≈ 66.67 bps
+    assert result.slippage_bps == pytest.approx(66.6667, rel=1e-3)
+
+
+def test_from_fills_multiple():
+    from adapters.execution_algo.result import ExecutionResult
+    fills = [
+        {"price": 100.0, "qty": 5.0},
+        {"price": 102.0, "qty": 5.0},
+    ]
+    result = ExecutionResult.from_fills(fills, "SPY", "buy", "twap", decision_price=100.0)
+    assert result.total_qty == pytest.approx(10.0)
+    assert result.avg_fill_price == pytest.approx(101.0)
+    # slippage = (101 - 100) / 100 * 10000 = 100 bps
+    assert result.slippage_bps == pytest.approx(100.0)
+
+
+def test_market_adapter_returns_execution_result():
+    from unittest.mock import MagicMock
+    from adapters.execution_algo.market_adapter import MarketAlgoAdapter
+    from adapters.execution_algo.result import ExecutionResult
+
+    mock_broker = MagicMock()
+    mock_broker.place_order.return_value = {"price": 200.0, "qty": 5.0}
+
+    adapter = MarketAlgoAdapter()
+    result = adapter.execute("MSFT", 5.0, "buy", mock_broker, decision_price=200.0)
+
+    assert isinstance(result, ExecutionResult)
+    assert result.symbol == "MSFT"
+    assert result.algo == "market"
+    assert result.total_qty == pytest.approx(5.0)
+
+
+def test_execution_result_algo_field():
+    from adapters.execution_algo.result import ExecutionResult
+    result = ExecutionResult.from_fills(
+        [{"price": 50.0, "qty": 2.0}], "JPM", "sell", "vwap"
+    )
+    assert result.algo == "vwap"
+    assert result.side == "sell"
+
+
+def test_zero_decision_price_no_slippage():
+    from adapters.execution_algo.result import ExecutionResult
+    fills = [{"price": 300.0, "qty": 1.0}]
+    result = ExecutionResult.from_fills(fills, "NVDA", "buy", "market", decision_price=0.0)
+    assert result.slippage_bps == 0.0

--- a/tests/test_execution_result.py
+++ b/tests/test_execution_result.py
@@ -39,6 +39,7 @@ def test_from_fills_multiple():
 
 def test_market_adapter_returns_execution_result():
     from unittest.mock import MagicMock
+
     from adapters.execution_algo.market_adapter import MarketAlgoAdapter
     from adapters.execution_algo.result import ExecutionResult
 

--- a/tests/test_gnn_signal.py
+++ b/tests/test_gnn_signal.py
@@ -105,7 +105,7 @@ def test_gnn_signal_fallback_score_empty_tickers():
 
 
 def test_gnn_signal_fallback_handles_all_known_tickers():
-    from strategies.gnn_signal import GNNSignal, TICKER_SECTOR
+    from strategies.gnn_signal import TICKER_SECTOR, GNNSignal
 
     gnn = GNNSignal(model_path="/no/model.pt")
     tickers = list(TICKER_SECTOR.keys())

--- a/tests/test_gnn_signal.py
+++ b/tests/test_gnn_signal.py
@@ -1,0 +1,115 @@
+"""Tests for strategies/gnn_signal.py (Issue #36)."""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+
+def test_build_sector_adjacency_same_sector():
+    from strategies.gnn_signal import build_sector_adjacency
+
+    tickers = ["AAPL", "MSFT", "NVDA"]  # All Technology
+    adj = build_sector_adjacency(tickers)
+    assert adj.shape == (3, 3)
+    # Same sector → all off-diagonal entries should be 1
+    assert adj[0, 1] == pytest.approx(1.0)
+    assert adj[1, 2] == pytest.approx(1.0)
+    # Diagonal should be 0
+    assert adj[0, 0] == pytest.approx(0.0)
+
+
+def test_build_sector_adjacency_different_sectors():
+    from strategies.gnn_signal import build_sector_adjacency
+
+    tickers = ["AAPL", "JPM"]  # Technology vs Financials
+    adj = build_sector_adjacency(tickers)
+    assert adj.shape == (2, 2)
+    # Different sectors → all off-diagonal entries should be 0
+    assert adj[0, 1] == pytest.approx(0.0)
+    assert adj[1, 0] == pytest.approx(0.0)
+
+
+def test_build_sector_adjacency_unknown_ticker():
+    from strategies.gnn_signal import build_sector_adjacency
+
+    tickers = ["AAPL", "UNKNOWN_XYZ"]
+    adj = build_sector_adjacency(tickers)
+    assert adj.shape == (2, 2)
+    # Unknown sector should not connect to any other
+    assert adj[0, 1] == pytest.approx(0.0)
+
+
+def test_build_node_features_shape():
+    from strategies.gnn_signal import build_node_features
+
+    tickers = ["AAPL", "MSFT", "JPM"]
+    features = build_node_features(tickers)
+    assert features.shape == (3, 8)
+    assert features.dtype == np.float32
+
+
+def test_build_node_features_regime_encoding():
+    from strategies.gnn_signal import build_node_features
+
+    tickers = ["AAPL"]
+    features_bull = build_node_features(tickers, regime="trending_bull")
+    features_bear = build_node_features(tickers, regime="trending_bear")
+
+    # Regime one-hot features are at positions [3:7]
+    # trending_bull is index 0 in REGIME_STATES
+    assert features_bull[0, 3] == pytest.approx(1.0)   # trending_bull = 1
+    assert features_bear[0, 3] == pytest.approx(0.0)   # trending_bull = 0 for bear
+
+
+def test_build_node_features_rsi_normalized():
+    from strategies.gnn_signal import build_node_features
+
+    tickers = ["AAPL"]
+    indicators = {"AAPL": {"rsi": 70.0, "momentum": 0.05, "sma_signal": 1.0}}
+    features = build_node_features(tickers, indicators=indicators)
+    # RSI should be divided by 100
+    assert features[0, 0] == pytest.approx(0.70)
+
+
+def test_build_node_features_sentiment():
+    from strategies.gnn_signal import build_node_features
+
+    tickers = ["AAPL"]
+    sentiments = {"AAPL": 0.42}
+    features = build_node_features(tickers, sentiments=sentiments)
+    # Sentiment is the last feature (index 7)
+    assert features[0, 7] == pytest.approx(0.42)
+
+
+def test_gnn_signal_fallback_score_without_model():
+    from strategies.gnn_signal import GNNSignal
+
+    # No checkpoint exists → should use fallback scorer
+    gnn = GNNSignal(model_path="/nonexistent/model.pt")
+    assert gnn._model is None
+
+    tickers = ["AAPL", "MSFT"]
+    scores = gnn.score(tickers)
+    assert isinstance(scores, dict)
+    assert set(scores.keys()) == {"AAPL", "MSFT"}
+    for ticker, score in scores.items():
+        assert -1.0 <= score <= 1.0, f"Score out of range for {ticker}: {score}"
+
+
+def test_gnn_signal_fallback_score_empty_tickers():
+    from strategies.gnn_signal import GNNSignal
+
+    gnn = GNNSignal(model_path="/no/model.pt")
+    scores = gnn.score([])
+    assert scores == {}
+
+
+def test_gnn_signal_fallback_handles_all_known_tickers():
+    from strategies.gnn_signal import GNNSignal, TICKER_SECTOR
+
+    gnn = GNNSignal(model_path="/no/model.pt")
+    tickers = list(TICKER_SECTOR.keys())
+    scores = gnn.score(tickers)
+    assert len(scores) == len(tickers)
+    for score in scores.values():
+        assert -1.0 <= score <= 1.0

--- a/tests/test_meta_agent.py
+++ b/tests/test_meta_agent.py
@@ -1,0 +1,141 @@
+"""Tests for agents/meta_agent.py (Issue #38)."""
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from agents.base import AgentSignal
+
+
+def _make_mock_agent(name: str, signal: str, confidence: float):
+    """Return a simple mock agent object."""
+    from unittest.mock import MagicMock
+
+    agent = MagicMock()
+    agent.name = name
+    agent.run.return_value = AgentSignal(
+        agent_name=name,
+        signal=signal,
+        confidence=confidence,
+        reasoning=f"mock {name}",
+    )
+    return agent
+
+
+def test_meta_agent_returns_bullish_when_all_bullish():
+    from agents.meta_agent import MetaAgent
+
+    agents = [
+        _make_mock_agent("regime_agent", "bullish", 0.8),
+        _make_mock_agent("risk_agent", "bullish", 0.9),
+        _make_mock_agent("sentiment_agent", "bullish", 0.7),
+    ]
+    meta = MetaAgent(agents=agents)
+    result = meta.run({"ticker": "AAPL"})
+    assert result["signal"] == "bullish"
+    assert result["weighted_score"] > 0
+
+
+def test_meta_agent_returns_bearish_when_all_bearish():
+    from agents.meta_agent import MetaAgent
+
+    agents = [
+        _make_mock_agent("regime_agent", "bearish", 0.8),
+        _make_mock_agent("risk_agent", "bearish", 0.85),
+        _make_mock_agent("sentiment_agent", "bearish", 0.75),
+    ]
+    meta = MetaAgent(agents=agents)
+    result = meta.run({"ticker": "SPY"})
+    assert result["signal"] == "bearish"
+    assert result["weighted_score"] < 0
+
+
+def test_meta_agent_returns_neutral_for_mixed_signals():
+    from agents.meta_agent import MetaAgent
+
+    agents = [
+        _make_mock_agent("regime_agent", "bullish", 0.6),
+        _make_mock_agent("risk_agent", "bearish", 0.6),
+    ]
+    meta = MetaAgent(agents=agents)
+    result = meta.run({"ticker": "MSFT"})
+    # Equally opposing signals should produce neutral
+    assert result["signal"] == "neutral"
+
+
+def test_meta_agent_specialist_signals_in_result():
+    from agents.meta_agent import MetaAgent
+
+    agents = [
+        _make_mock_agent("regime_agent", "bullish", 0.8),
+        _make_mock_agent("sentiment_agent", "neutral", 0.5),
+    ]
+    meta = MetaAgent(agents=agents)
+    result = meta.run({"ticker": "NVDA"})
+    assert len(result["specialist_signals"]) == 2
+    agent_names = {s["agent"] for s in result["specialist_signals"]}
+    assert "regime_agent" in agent_names
+    assert "sentiment_agent" in agent_names
+
+
+def test_meta_agent_no_agents_returns_neutral():
+    from agents.meta_agent import MetaAgent
+
+    meta = MetaAgent(agents=[])
+    result = meta.run({})
+    assert result["signal"] == "neutral"
+    assert result["confidence"] == 0.0
+    assert result["specialist_signals"] == []
+
+
+def test_meta_agent_custom_weights_affect_score():
+    from agents.meta_agent import MetaAgent
+
+    agents = [
+        _make_mock_agent("regime_agent", "bullish", 1.0),
+        _make_mock_agent("risk_agent", "bearish", 1.0),
+    ]
+    # Give regime_agent much higher weight → should tip bullish
+    meta = MetaAgent(agents=agents, weights={"regime_agent": 10.0, "risk_agent": 1.0})
+    result = meta.run({"ticker": "AAPL"})
+    assert result["signal"] == "bullish"
+
+
+def test_meta_agent_confidence_in_valid_range():
+    from agents.meta_agent import MetaAgent
+
+    agents = [_make_mock_agent("regime_agent", "bullish", 0.9)]
+    meta = MetaAgent(agents=agents)
+    result = meta.run({})
+    assert 0.0 <= result["confidence"] <= 1.0
+
+
+def test_meta_agent_failing_agent_is_skipped():
+    from agents.meta_agent import MetaAgent
+    from unittest.mock import MagicMock
+
+    bad_agent = MagicMock()
+    bad_agent.name = "failing_agent"
+    bad_agent.run.side_effect = RuntimeError("boom")
+
+    good_agent = _make_mock_agent("regime_agent", "bullish", 0.8)
+
+    meta = MetaAgent(agents=[bad_agent, good_agent])
+    result = meta.run({})
+    # Should still return a result from the good agent
+    assert result["signal"] in ("bullish", "bearish", "neutral")
+    # Only the successful agent's signal should be in the list
+    assert len(result["specialist_signals"]) == 1
+
+
+def test_meta_agent_weighted_score_and_reasoning_present():
+    from agents.meta_agent import MetaAgent
+
+    agents = [_make_mock_agent("regime_agent", "bullish", 0.7)]
+    meta = MetaAgent(agents=agents)
+    result = meta.run({"ticker": "AAPL"})
+    assert "weighted_score" in result
+    assert "reasoning" in result
+    assert isinstance(result["reasoning"], str)
+    assert len(result["reasoning"]) > 0

--- a/tests/test_meta_agent.py
+++ b/tests/test_meta_agent.py
@@ -1,10 +1,6 @@
 """Tests for agents/meta_agent.py (Issue #38)."""
 from __future__ import annotations
 
-import os
-
-import pytest
-
 from agents.base import AgentSignal
 
 
@@ -112,8 +108,9 @@ def test_meta_agent_confidence_in_valid_range():
 
 
 def test_meta_agent_failing_agent_is_skipped():
-    from agents.meta_agent import MetaAgent
     from unittest.mock import MagicMock
+
+    from agents.meta_agent import MetaAgent
 
     bad_agent = MagicMock()
     bad_agent.name = "failing_agent"

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,78 @@
+"""Tests for monitoring/metrics.py (Issue #30)."""
+from __future__ import annotations
+
+import pytest
+
+
+def test_module_imports_without_prometheus():
+    """metrics.py should import cleanly even when prometheus-client is absent."""
+    import importlib
+    from unittest.mock import patch
+
+    with patch.dict("sys.modules", {"prometheus_client": None}):
+        import monitoring.metrics as m
+        importlib.reload(m)
+    # No exception = pass
+
+
+def test_update_portfolio_metrics_does_not_raise():
+    from monitoring.metrics import update_portfolio_metrics
+
+    # Should be callable without raising regardless of whether prometheus is installed
+    update_portfolio_metrics(nav=105_000.0, open_pnl=3_200.0)
+
+
+def test_update_regime_metric_valid_regime():
+    from monitoring.metrics import update_regime_metric
+
+    for regime in ["trending_bull", "trending_bear", "mean_reverting", "high_vol"]:
+        update_regime_metric(regime)  # Must not raise
+
+
+def test_update_regime_metric_unknown_regime():
+    from monitoring.metrics import update_regime_metric
+
+    update_regime_metric("unknown_regime")  # Should be a no-op, not an error
+
+
+def test_record_execution_latency():
+    from monitoring.metrics import record_execution_latency
+
+    record_execution_latency(0.35)  # Must not raise
+
+
+def test_record_feed_latency():
+    from monitoring.metrics import record_feed_latency
+
+    record_feed_latency(2.5)  # Must not raise
+
+
+def test_noop_metric_interface():
+    """_NoopMetric must support all expected methods."""
+    from monitoring.metrics import _NoopMetric
+
+    noop = _NoopMetric()
+    noop.set(100.0)
+    noop.inc(1)
+    noop.observe(0.5)
+    noop.labels(job="test")
+    with noop.time():
+        pass
+
+
+def test_portfolio_nav_and_open_pnl_attributes_exist():
+    from monitoring import metrics
+
+    assert hasattr(metrics, "PORTFOLIO_NAV")
+    assert hasattr(metrics, "OPEN_PNL")
+    assert hasattr(metrics, "SIGNAL_COUNT")
+    assert hasattr(metrics, "EXECUTION_LATENCY")
+    assert hasattr(metrics, "FEED_LATENCY")
+    assert hasattr(metrics, "REGIME_LABEL")
+
+
+def test_signal_count_inc_does_not_raise():
+    from monitoring.metrics import SIGNAL_COUNT
+
+    SIGNAL_COUNT.inc()
+    SIGNAL_COUNT.inc(5)

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,8 +1,6 @@
 """Tests for monitoring/metrics.py (Issue #30)."""
 from __future__ import annotations
 
-import pytest
-
 
 def test_module_imports_without_prometheus():
     """metrics.py should import cleanly even when prometheus-client is absent."""

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,4 +1,4 @@
-"""Tests for monitoring/metrics.py (Issue #30)."""
+"""Tests for monitoring/metrics.py and monitoring/sidecar.py (Issue #30)."""
 from __future__ import annotations
 
 
@@ -74,3 +74,16 @@ def test_signal_count_inc_does_not_raise():
 
     SIGNAL_COUNT.inc()
     SIGNAL_COUNT.inc(5)
+
+
+def test_sidecar_module_imports():
+    """sidecar.py must import without errors even when fastapi is absent."""
+    import monitoring.sidecar  # noqa: F401 — covers module-level import block
+
+
+def test_sidecar_app_is_none_without_fastapi():
+    """When fastapi is not installed, the app object is None."""
+    import monitoring.sidecar as sidecar
+    # fastapi is not installed in CI, so app is None or a FastAPI instance
+    # Either way, accessing the attribute must not raise
+    _ = sidecar.app

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import json
 import sqlite3
 import time
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import MagicMock
 
 import pytest
 

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -1,0 +1,147 @@
+"""Tests for scripts/migrate_to_tsdb.py (Issue #25)."""
+from __future__ import annotations
+
+import json
+import sqlite3
+import time
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+
+@pytest.fixture
+def src_conn():
+    """In-memory SQLite source DB with the tables that migrate_to_tsdb reads."""
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.execute("""
+        CREATE TABLE price_cache (
+            ticker TEXT NOT NULL,
+            data_json TEXT NOT NULL,
+            PRIMARY KEY (ticker)
+        )
+    """)
+    conn.execute("""
+        CREATE TABLE paper_trades (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            executed_at REAL,
+            ticker TEXT,
+            action TEXT,
+            shares REAL,
+            price REAL,
+            cost_basis REAL,
+            realised_pnl REAL
+        )
+    """)
+    conn.execute("""
+        CREATE TABLE portfolio_history (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            record_date TEXT,
+            total_value REAL
+        )
+    """)
+    conn.commit()
+    return conn
+
+
+@pytest.fixture
+def mock_tsdb():
+    """Mock TSDB that records writes."""
+    tsdb = MagicMock()
+    tsdb.written = {}
+
+    def _write(table, records):
+        tsdb.written.setdefault(table, []).extend(records)
+
+    tsdb.write.side_effect = _write
+    return tsdb
+
+
+def test_migrate_price_cache_empty(src_conn, mock_tsdb):
+    from scripts.migrate_to_tsdb import migrate_price_cache
+    written = migrate_price_cache(src_conn, mock_tsdb)
+    assert written == 0
+
+
+def test_migrate_price_cache_with_data(src_conn, mock_tsdb):
+    from scripts.migrate_to_tsdb import migrate_price_cache
+
+    # Insert a price_cache row with valid OHLCV data
+    data = {
+        "Open": {"2024-01-02": 180.0},
+        "High": {"2024-01-02": 185.0},
+        "Low":  {"2024-01-02": 179.0},
+        "Close": {"2024-01-02": 183.0},
+        "Volume": {"2024-01-02": 55_000_000.0},
+    }
+    src_conn.execute(
+        "INSERT INTO price_cache (ticker, data_json) VALUES (?, ?)",
+        ("AAPL", json.dumps(data)),
+    )
+    src_conn.commit()
+
+    written = migrate_price_cache(src_conn, mock_tsdb)
+    assert written == 1
+    mock_tsdb.create_table.assert_called_once()
+    rows = mock_tsdb.written.get("ohlcv_prices", [])
+    assert len(rows) == 1
+    assert rows[0]["symbol"] == "AAPL"
+    assert rows[0]["close"] == 183.0
+
+
+def test_migrate_price_cache_skips_malformed(src_conn, mock_tsdb):
+    from scripts.migrate_to_tsdb import migrate_price_cache
+
+    src_conn.execute(
+        "INSERT INTO price_cache (ticker, data_json) VALUES (?, ?)",
+        ("BAD", "not-json{{{"),
+    )
+    src_conn.commit()
+
+    written = migrate_price_cache(src_conn, mock_tsdb)
+    assert written == 0
+
+
+def test_migrate_paper_trades_empty(src_conn, mock_tsdb):
+    from scripts.migrate_to_tsdb import migrate_paper_trades
+    written = migrate_paper_trades(src_conn, mock_tsdb)
+    assert written == 0
+
+
+def test_migrate_paper_trades_with_data(src_conn, mock_tsdb):
+    from scripts.migrate_to_tsdb import migrate_paper_trades
+
+    src_conn.execute(
+        "INSERT INTO paper_trades (executed_at, ticker, action, shares, price, cost_basis, realised_pnl) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?)",
+        (time.time(), "MSFT", "buy", 10.0, 300.0, 3000.0, 0.0),
+    )
+    src_conn.commit()
+
+    written = migrate_paper_trades(src_conn, mock_tsdb)
+    assert written == 1
+    rows = mock_tsdb.written.get("execution_history", [])
+    assert len(rows) == 1
+    assert rows[0]["symbol"] == "MSFT"
+
+
+def test_migrate_portfolio_history_with_data(src_conn, mock_tsdb):
+    from scripts.migrate_to_tsdb import migrate_portfolio_history
+
+    src_conn.execute(
+        "INSERT INTO portfolio_history (record_date, total_value) VALUES (?, ?)",
+        ("2024-06-01", 105_000.0),
+    )
+    src_conn.commit()
+
+    written = migrate_portfolio_history(src_conn, mock_tsdb)
+    assert written == 1
+    rows = mock_tsdb.written.get("portfolio_snapshots", [])
+    assert len(rows) == 1
+    assert rows[0]["total_value"] == pytest.approx(105_000.0)
+
+
+def test_migrate_portfolio_history_empty(src_conn, mock_tsdb):
+    from scripts.migrate_to_tsdb import migrate_portfolio_history
+    written = migrate_portfolio_history(src_conn, mock_tsdb)
+    assert written == 0

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -1,0 +1,93 @@
+"""Tests for providers/model_registry.py and mock adapter (Issue #29)."""
+from __future__ import annotations
+
+import pytest
+
+
+def test_mock_adapter_log_returns_run_id():
+    from adapters.model_registry.mock_adapter import MockModelRegistryAdapter
+
+    reg = MockModelRegistryAdapter()
+    run_id = reg.log_model(
+        run_name="rl_sizer",
+        model_path="/models/rl_sizer.zip",
+        metrics={"sharpe": 1.2, "max_drawdown": 0.08},
+    )
+    assert run_id.startswith("mock-run-")
+
+
+def test_mock_adapter_list_models_empty():
+    from adapters.model_registry.mock_adapter import MockModelRegistryAdapter
+
+    reg = MockModelRegistryAdapter()
+    assert reg.list_models() == []
+
+
+def test_mock_adapter_list_models_after_log():
+    from adapters.model_registry.mock_adapter import MockModelRegistryAdapter
+
+    reg = MockModelRegistryAdapter()
+    reg.log_model("regime_clf", "/models/regime.pkl", {"accuracy": 0.75})
+    reg.log_model("rl_sizer", "/models/rl.zip", {"sharpe": 1.5})
+
+    models = reg.list_models()
+    assert len(models) == 2
+    names = {m["run_name"] for m in models}
+    assert "regime_clf" in names
+    assert "rl_sizer" in names
+
+
+def test_mock_adapter_promote_and_load():
+    from adapters.model_registry.mock_adapter import MockModelRegistryAdapter
+
+    reg = MockModelRegistryAdapter()
+    run_id = reg.log_model("rl_sizer", "/models/rl.zip", {"sharpe": 1.3})
+    reg.promote("rl_sizer", run_id, "Production")
+
+    path = reg.load_model("rl_sizer", stage="Production")
+    assert path == "/models/rl.zip"
+
+
+def test_mock_adapter_load_not_found_raises():
+    from adapters.model_registry.mock_adapter import MockModelRegistryAdapter
+
+    reg = MockModelRegistryAdapter()
+    with pytest.raises(FileNotFoundError):
+        reg.load_model("nonexistent_model", stage="Production")
+
+
+def test_mock_adapter_promote_unknown_run_id_raises():
+    from adapters.model_registry.mock_adapter import MockModelRegistryAdapter
+
+    reg = MockModelRegistryAdapter()
+    with pytest.raises(KeyError):
+        reg.promote("rl_sizer", "nonexistent-run-id", "Production")
+
+
+def test_mock_adapter_metrics_stored():
+    from adapters.model_registry.mock_adapter import MockModelRegistryAdapter
+
+    reg = MockModelRegistryAdapter()
+    metrics = {"sharpe": 1.8, "win_rate": 0.62}
+    run_id = reg.log_model("my_model", "/path/to/model", metrics, tags={"env": "prod"})
+
+    models = reg.list_models()
+    assert len(models) == 1
+    assert models[0]["metrics"] == metrics
+    assert models[0]["tags"] == {"env": "prod"}
+
+
+def test_get_model_registry_mock_provider():
+    from providers.model_registry import get_model_registry
+
+    reg = get_model_registry(provider="mock")
+    # Should be usable without errors
+    run_id = reg.log_model("test", "/tmp/model.pkl", {"loss": 0.01})
+    assert run_id is not None
+
+
+def test_get_model_registry_unknown_raises():
+    from providers.model_registry import get_model_registry
+
+    with pytest.raises(ValueError, match="Unknown model registry provider"):
+        get_model_registry(provider="unknown_registry")

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -69,7 +69,7 @@ def test_mock_adapter_metrics_stored():
 
     reg = MockModelRegistryAdapter()
     metrics = {"sharpe": 1.8, "win_rate": 0.62}
-    run_id = reg.log_model("my_model", "/path/to/model", metrics, tags={"env": "prod"})
+    reg.log_model("my_model", "/path/to/model", metrics, tags={"env": "prod"})
 
     models = reg.list_models()
     assert len(models) == 1

--- a/tests/test_options_flow.py
+++ b/tests/test_options_flow.py
@@ -1,0 +1,95 @@
+"""Tests for providers/options_flow.py and mock adapter (Issue #37)."""
+from __future__ import annotations
+
+import pytest
+
+
+def test_get_options_flow_returns_mock_by_default():
+    import os
+    os.environ.pop("OPTIONS_FLOW_PROVIDER", None)
+    from providers.options_flow import get_options_flow
+    provider = get_options_flow()
+    # Should return the mock adapter
+    assert hasattr(provider, "get_flow")
+    assert hasattr(provider, "unusual_activity_score")
+
+
+def test_mock_adapter_get_flow_returns_list():
+    from adapters.options_flow.mock_adapter import MockOptionsFlowAdapter
+
+    adapter = MockOptionsFlowAdapter()
+    flow = adapter.get_flow("AAPL", lookback_days=1)
+    assert isinstance(flow, list)
+    assert len(flow) > 0
+
+
+def test_mock_adapter_get_flow_structure():
+    from adapters.options_flow.mock_adapter import MockOptionsFlowAdapter
+
+    adapter = MockOptionsFlowAdapter()
+    flow = adapter.get_flow("MSFT", lookback_days=1)
+    record = flow[0]
+    assert "symbol" in record
+    assert "side" in record
+    assert record["side"] in ("call", "put")
+    assert "volume" in record
+    assert "strike" in record
+
+
+def test_mock_adapter_unusual_activity_score():
+    from adapters.options_flow.mock_adapter import MockOptionsFlowAdapter
+    from providers.options_flow import OptionsFlowResult
+
+    adapter = MockOptionsFlowAdapter()
+    result = adapter.unusual_activity_score("AAPL")
+    assert isinstance(result, OptionsFlowResult)
+    assert result.symbol == "AAPL"
+    assert result.call_volume >= 0
+    assert result.put_volume >= 0
+    assert -1.0 <= result.unusual_score <= 1.0
+
+
+def test_mock_adapter_call_put_ratio_positive():
+    from adapters.options_flow.mock_adapter import MockOptionsFlowAdapter
+
+    adapter = MockOptionsFlowAdapter()
+    result = adapter.unusual_activity_score("NVDA")
+    assert result.call_put_ratio >= 0
+
+
+def test_mock_adapter_deterministic_for_same_symbol():
+    """Same ticker should return the same synthetic values."""
+    from adapters.options_flow.mock_adapter import MockOptionsFlowAdapter
+
+    adapter = MockOptionsFlowAdapter()
+    r1 = adapter.unusual_activity_score("TSLA")
+    r2 = adapter.unusual_activity_score("TSLA")
+    assert r1.call_volume == r2.call_volume
+    assert r1.put_volume == r2.put_volume
+    assert r1.unusual_score == r2.unusual_score
+
+
+def test_mock_adapter_different_tickers_differ():
+    from adapters.options_flow.mock_adapter import MockOptionsFlowAdapter
+
+    adapter = MockOptionsFlowAdapter()
+    r_aapl = adapter.unusual_activity_score("AAPL")
+    r_msft = adapter.unusual_activity_score("MSFT")
+    # Different tickers may have different scores (hash-based determinism)
+    assert r_aapl.symbol == "AAPL"
+    assert r_msft.symbol == "MSFT"
+
+
+def test_get_options_flow_unknown_provider_raises():
+    from providers.options_flow import get_options_flow
+
+    with pytest.raises(ValueError, match="Unknown options flow provider"):
+        get_options_flow(provider="nonexistent_provider")
+
+
+def test_get_options_flow_explicit_mock():
+    from providers.options_flow import get_options_flow
+
+    provider = get_options_flow(provider="mock")
+    result = provider.unusual_activity_score("SPY")
+    assert result.symbol == "SPY"

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -254,13 +254,15 @@ class TestExecutionAlgoProvider:
         algo = get_execution_algo("market")
         assert isinstance(algo, ExecutionAlgoProvider)
 
-    def test_market_algo_execute_returns_list(self):
+    def test_market_algo_execute_returns_execution_result(self):
+        from adapters.execution_algo.result import ExecutionResult
         from providers.execution_algo import get_execution_algo
         algo = get_execution_algo("market")
         broker = self._paper_broker()
-        fills = algo.execute("AAPL", 5.0, "buy", broker)
-        assert isinstance(fills, list)
-        assert len(fills) == 1
+        result = algo.execute("AAPL", 5.0, "buy", broker)
+        assert isinstance(result, ExecutionResult)
+        assert result.symbol == "AAPL"
+        assert result.total_qty == pytest.approx(5.0)
 
     def test_unknown_algo_raises_value_error(self):
         from providers.execution_algo import get_execution_algo

--- a/tests/test_rl_sizer.py
+++ b/tests/test_rl_sizer.py
@@ -1,0 +1,91 @@
+"""Tests for analysis/rl_sizer.py (Issue #28)."""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+
+def test_obs_to_array_shape_and_one_hot():
+    from analysis.rl_sizer import RLSizerObservation, _obs_to_array
+
+    obs = RLSizerObservation(
+        regime="trending_bull",
+        volatility=0.20,
+        win_rate=0.55,
+        drawdown=0.03,
+    )
+    arr = _obs_to_array(obs)
+    assert arr.shape == (7,)
+    assert arr.dtype == np.float32
+    # First element is 1.0 (trending_bull one-hot)
+    assert arr[0] == pytest.approx(1.0)
+    # Remaining regime positions are 0
+    assert arr[1] == pytest.approx(0.0)
+    assert arr[2] == pytest.approx(0.0)
+    assert arr[3] == pytest.approx(0.0)
+    # Feature slots
+    assert arr[4] == pytest.approx(0.20)
+    assert arr[5] == pytest.approx(0.55)
+    assert arr[6] == pytest.approx(0.03)
+
+
+def test_obs_to_array_unknown_regime_all_zeros():
+    from analysis.rl_sizer import RLSizerObservation, _obs_to_array
+
+    obs = RLSizerObservation(regime="unknown_regime", volatility=0.15, win_rate=0.5, drawdown=0.0)
+    arr = _obs_to_array(obs)
+    # No one-hot element should be 1.0 for an unknown regime
+    assert sum(arr[:4]) == pytest.approx(0.0)
+
+
+def test_kelly_fallback_returns_valid_range():
+    from analysis.rl_sizer import RLPositionSizer, RLSizerObservation
+
+    sizer = RLPositionSizer(model_path="/nonexistent/path/model.zip")
+    obs = RLSizerObservation(regime="trending_bull", volatility=0.20, win_rate=0.60, drawdown=0.05)
+    result = sizer.predict(obs)
+    assert 0.0 <= result <= 2.0
+
+
+def test_kelly_fallback_low_win_rate():
+    from analysis.rl_sizer import RLPositionSizer, RLSizerObservation
+
+    sizer = RLPositionSizer(model_path="/nonexistent/path/model.zip")
+    obs = RLSizerObservation(regime="trending_bear", volatility=0.35, win_rate=0.20, drawdown=0.15)
+    result = sizer.predict(obs)
+    # Low win rate + bear regime should give a small or zero multiplier
+    assert 0.0 <= result <= 2.0
+
+
+def test_predict_with_missing_model_uses_kelly():
+    from analysis.rl_sizer import RLPositionSizer, RLSizerObservation
+
+    sizer = RLPositionSizer(model_path="/no/such/file.zip")
+    assert sizer._model is None  # no model loaded
+    obs = RLSizerObservation(regime="high_vol", volatility=0.40, win_rate=0.45, drawdown=0.10)
+    mult = sizer.predict(obs)
+    assert isinstance(mult, float)
+    assert 0.0 <= mult <= 2.0
+
+
+def test_predict_all_regime_states_in_range():
+    from analysis.rl_sizer import REGIME_STATES, RLPositionSizer, RLSizerObservation
+
+    sizer = RLPositionSizer(model_path="/no/model")
+    for regime in REGIME_STATES:
+        obs = RLSizerObservation(regime=regime, volatility=0.20, win_rate=0.5, drawdown=0.0)
+        mult = sizer.predict(obs)
+        assert 0.0 <= mult <= 2.0, f"Out of range for regime={regime}: {mult}"
+
+
+def test_sizer_model_load_failure_falls_back_gracefully(tmp_path):
+    """A corrupt checkpoint file should not crash predict()."""
+    corrupt = tmp_path / "bad_model.zip"
+    corrupt.write_bytes(b"not-a-valid-zip")
+
+    from analysis.rl_sizer import RLPositionSizer, RLSizerObservation
+
+    sizer = RLPositionSizer(model_path=str(corrupt))
+    obs = RLSizerObservation(regime="mean_reverting", volatility=0.18, win_rate=0.52, drawdown=0.02)
+    result = sizer.predict(obs)
+    assert 0.0 <= result <= 2.0

--- a/tests/test_scheduler_new.py
+++ b/tests/test_scheduler_new.py
@@ -1,0 +1,297 @@
+"""Tests for new scheduler functions: run_var_check, run_correlation_check, run_anomaly_checks."""
+from __future__ import annotations
+
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+
+# Ensure optional deps that data.fetcher needs are available as mocks
+sys.modules.setdefault("yfinance", MagicMock())
+
+
+def test_run_correlation_check_disabled_by_default():
+    os.environ.pop("CORRELATION_MONITOR_ENABLED", None)
+    from scheduler.alerts import run_correlation_check
+    result = run_correlation_check(price_data={}, positions={"AAPL": 10_000})
+    assert result == []
+
+
+def test_run_correlation_check_no_positions_returns_empty(monkeypatch):
+    monkeypatch.setenv("CORRELATION_MONITOR_ENABLED", "1")
+    from scheduler.alerts import run_correlation_check
+    result = run_correlation_check(price_data={}, positions={})
+    assert result == []
+
+
+def test_run_correlation_check_fires_alert_on_concentration(monkeypatch):
+    monkeypatch.setenv("CORRELATION_MONITOR_ENABLED", "1")
+    import numpy as np
+    import pandas as pd
+
+    from risk.correlation import CorrelationAlert
+
+    mock_alert = CorrelationAlert(
+        alert_type="position_concentration",
+        value=0.80,
+        threshold=0.25,
+        message="AAPL is 80% of portfolio",
+        ticker="AAPL",
+    )
+
+    rng = np.random.default_rng(42)
+    price_data = {
+        "AAPL": pd.Series(100 + rng.normal(0, 1, 30).cumsum()),
+        "MSFT": pd.Series(100 + rng.normal(0, 1, 30).cumsum()),
+    }
+    positions = {"AAPL": 80_000.0, "MSFT": 20_000.0}
+
+    with patch("risk.correlation.check_correlation_alerts", return_value=[mock_alert]), \
+         patch("scheduler.alerts.broadcast"):
+        from scheduler.alerts import run_correlation_check
+        fired = run_correlation_check(price_data=price_data, positions=positions)
+
+    assert len(fired) == 1
+    assert fired[0]["alert_type"] == "position_concentration"
+
+
+def test_run_correlation_check_no_alerts_returns_empty(monkeypatch):
+    monkeypatch.setenv("CORRELATION_MONITOR_ENABLED", "1")
+
+    with patch("risk.correlation.check_correlation_alerts", return_value=[]):
+        from scheduler.alerts import run_correlation_check
+        result = run_correlation_check(
+            price_data={"AAPL": pd.Series([100.0] * 10)},
+            positions={"AAPL": 10_000.0},
+        )
+    assert result == []
+
+
+def test_run_anomaly_checks_empty_watchlist():
+    from scheduler.alerts import run_anomaly_checks
+    # Empty watchlist + empty prices = only signal drought check
+    with patch("analysis.anomaly_detector.AnomalyDetector.check_signal_drought",
+               return_value=None):
+        result = run_anomaly_checks(watchlist=[], current_prices={})
+    assert isinstance(result, list)
+
+
+def test_run_anomaly_checks_fires_on_drought():
+    from analysis.anomaly_detector import Anomaly
+    from scheduler.alerts import run_anomaly_checks
+
+    drought = Anomaly(
+        type="signal_drought",
+        severity="warning",
+        symbol="",
+        message="No signals in last 4h",
+    )
+
+    with patch("analysis.anomaly_detector.AnomalyDetector.check_signal_drought",
+               return_value=drought), \
+         patch("analysis.anomaly_detector.AnomalyDetector.check_price_spike",
+               return_value=None), \
+         patch("scheduler.alerts.broadcast"):
+        result = run_anomaly_checks(watchlist=["AAPL"], current_prices={"AAPL": 180.0})
+
+    assert any(a.get("type") == "signal_drought" for a in result)
+
+
+def test_run_anomaly_checks_broadcasts_anomaly():
+    from analysis.anomaly_detector import Anomaly
+    from scheduler.alerts import run_anomaly_checks
+
+    anomaly = Anomaly(
+        type="price_spike",
+        severity="warning",
+        symbol="TSLA",
+        message="TSLA spiked 15%",
+    )
+
+    mock_broadcast = MagicMock()
+    with patch("analysis.anomaly_detector.AnomalyDetector.check_signal_drought",
+               return_value=None), \
+         patch("analysis.anomaly_detector.AnomalyDetector.check_price_spike",
+               return_value=anomaly), \
+         patch("scheduler.alerts.broadcast", mock_broadcast):
+        result = run_anomaly_checks(watchlist=["TSLA"], current_prices={"TSLA": 250.0})
+
+    assert mock_broadcast.called
+    assert len(result) == 1
+    assert result[0]["type"] == "price_spike"
+
+
+# ── run_var_check ──────────────────────────────────────────────────────────────
+
+def test_run_var_check_no_rows_returns_none():
+    """When there are no portfolio snapshots in DB, run_var_check returns None."""
+    mock_conn = MagicMock()
+    mock_conn.execute.return_value.fetchall.return_value = []
+
+    with patch("scheduler.alerts.get_connection", return_value=mock_conn):
+        from scheduler.alerts import run_var_check
+        result = run_var_check()
+
+    assert result is None
+
+
+def test_run_var_check_insufficient_data_returns_none():
+    """compute_risk_metrics returns None for < 30 data points → run_var_check returns None."""
+    mock_conn = MagicMock()
+    # Provide only 5 rows — too few for meaningful risk metrics
+    mock_conn.execute.return_value.fetchall.return_value = [(100_000.0,)] * 5
+
+    with patch("scheduler.alerts.get_connection", return_value=mock_conn), \
+         patch("analysis.risk_metrics.compute_risk_metrics", return_value=None):
+        from scheduler.alerts import run_var_check
+        result = run_var_check()
+
+    assert result is None
+
+
+def test_run_var_check_below_threshold_returns_none():
+    """VaR below threshold → run_var_check returns None without broadcasting."""
+    from dataclasses import dataclass
+
+    @dataclass
+    class _RM:
+        var_95: float = 0.01  # below 0.03 threshold
+        var_99: float = 0.015
+        cvar_95: float = 0.012
+        cvar_99: float = 0.018
+        volatility_annual: float = 0.15
+        n_observations: int = 100
+
+    mock_conn = MagicMock()
+    mock_conn.execute.return_value.fetchall.return_value = [(100_000.0 + i,) for i in range(50)]
+
+    with patch("scheduler.alerts.get_connection", return_value=mock_conn), \
+         patch("analysis.risk_metrics.compute_risk_metrics", return_value=_RM()):
+        from scheduler.alerts import run_var_check
+        result = run_var_check(var_threshold=0.03)
+
+    assert result is None
+
+
+def test_run_var_check_above_threshold_returns_dict():
+    """VaR above threshold → run_var_check fires alert and returns metrics dict."""
+    from dataclasses import dataclass
+
+    @dataclass
+    class _RM:
+        var_95: float = 0.05  # above 0.03 threshold
+        var_99: float = 0.07
+        cvar_95: float = 0.06
+        cvar_99: float = 0.08
+        volatility_annual: float = 0.25
+        n_observations: int = 100
+
+    mock_conn = MagicMock()
+    mock_conn.execute.return_value.fetchall.return_value = [(100_000.0 + i,) for i in range(50)]
+
+    with patch("scheduler.alerts.get_connection", return_value=mock_conn), \
+         patch("analysis.risk_metrics.compute_risk_metrics", return_value=_RM()), \
+         patch("scheduler.alerts.broadcast") as mock_broadcast:
+        from scheduler.alerts import run_var_check
+        result = run_var_check(var_threshold=0.03)
+
+    assert result is not None
+    assert result["var_95"] == pytest.approx(0.05)
+    assert "message" in result
+    assert mock_broadcast.called
+
+
+def test_run_var_check_db_exception_returns_none():
+    """DB exception is swallowed and function returns None gracefully."""
+    mock_conn = MagicMock()
+    mock_conn.execute.side_effect = Exception("table not found")
+
+    with patch("scheduler.alerts.get_connection", return_value=mock_conn):
+        from scheduler.alerts import run_var_check
+        result = run_var_check()
+
+    assert result is None
+
+
+# ── run_correlation_check null-fallback paths ─────────────────────────────────
+
+def test_run_correlation_check_fetches_positions_when_none(monkeypatch):
+    """When positions=None, should fetch from paper_trader.get_portfolio."""
+    monkeypatch.setenv("CORRELATION_MONITOR_ENABLED", "1")
+
+    mock_df = pd.DataFrame([{"Ticker": "AAPL", "Market Value": 10_000.0}])
+
+    with patch("broker.paper_trader.get_portfolio", return_value=mock_df), \
+         patch("risk.correlation.check_correlation_alerts", return_value=[]):
+        from scheduler.alerts import run_correlation_check
+        result = run_correlation_check(positions=None, price_data={})
+
+    assert result == []
+
+
+def test_run_correlation_check_fetches_portfolio_exception(monkeypatch):
+    """Exception in portfolio fetch → positions defaults to empty → returns []."""
+    monkeypatch.setenv("CORRELATION_MONITOR_ENABLED", "1")
+
+    with patch("broker.paper_trader.get_portfolio", side_effect=RuntimeError("db error")):
+        from scheduler.alerts import run_correlation_check
+        result = run_correlation_check(positions=None, price_data={})
+
+    assert result == []
+
+
+def test_run_correlation_check_fetches_price_data_when_none(monkeypatch):
+    """When price_data=None, should fetch from data.fetcher for each position."""
+    monkeypatch.setenv("CORRELATION_MONITOR_ENABLED", "1")
+
+    mock_df = pd.DataFrame({"Close": [100.0] * 30})
+
+    with patch("data.fetcher.fetch_ohlcv", return_value=mock_df), \
+         patch("risk.correlation.check_correlation_alerts", return_value=[]):
+        from scheduler.alerts import run_correlation_check
+        result = run_correlation_check(positions={"AAPL": 10_000.0}, price_data=None)
+
+    assert result == []
+
+
+# ── run_anomaly_checks null-fallback paths ────────────────────────────────────
+
+def test_run_anomaly_checks_fetches_watchlist_when_none():
+    """When watchlist=None, should fetch from data.watchlist."""
+    with patch("data.watchlist.get_watchlist", return_value=["AAPL", "MSFT"]), \
+         patch("analysis.anomaly_detector.AnomalyDetector.check_signal_drought",
+               return_value=None), \
+         patch("analysis.anomaly_detector.AnomalyDetector.check_price_spike",
+               return_value=None):
+        from scheduler.alerts import run_anomaly_checks
+        result = run_anomaly_checks(watchlist=None, current_prices={"AAPL": 180.0, "MSFT": 400.0})
+
+    assert isinstance(result, list)
+
+
+def test_run_anomaly_checks_watchlist_fetch_exception():
+    """Exception in watchlist fetch → watchlist defaults to empty."""
+    with patch("data.watchlist.get_watchlist", side_effect=RuntimeError("db error")), \
+         patch("analysis.anomaly_detector.AnomalyDetector.check_signal_drought",
+               return_value=None):
+        from scheduler.alerts import run_anomaly_checks
+        result = run_anomaly_checks(watchlist=None, current_prices={})
+
+    assert result == []
+
+
+def test_run_anomaly_checks_fetches_prices_when_none():
+    """When current_prices=None, should fetch from data.fetcher for each ticker."""
+    mock_df = pd.DataFrame({"Close": [100.0, 101.0, 102.0]})
+
+    with patch("data.fetcher.fetch_ohlcv", return_value=mock_df), \
+         patch("analysis.anomaly_detector.AnomalyDetector.check_signal_drought",
+               return_value=None), \
+         patch("analysis.anomaly_detector.AnomalyDetector.check_price_spike",
+               return_value=None):
+        from scheduler.alerts import run_anomaly_checks
+        result = run_anomaly_checks(watchlist=["AAPL"], current_prices=None)
+
+    assert isinstance(result, list)

--- a/tests/test_sentiment_cache.py
+++ b/tests/test_sentiment_cache.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import sqlite3
 import time
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 
@@ -91,7 +91,6 @@ def test_cache_expired_returns_none(mock_conn):
     )
     mock_conn.commit()
     with _patch_conn(mock_conn):
-        from importlib import reload
         import adapters.sentiment.cache as cache_mod
         result = cache_mod.cache_read("MSFT", "stocktwits", ttl=1800)
     assert result is None

--- a/tests/test_sentiment_cache.py
+++ b/tests/test_sentiment_cache.py
@@ -1,0 +1,114 @@
+"""Tests for the 30-min sentiment SQLite TTL cache (Issue #23)."""
+from __future__ import annotations
+
+import sqlite3
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+class _NoCloseConn:
+    """Wraps a sqlite3 connection so close() is a no-op (keeps in-memory DB alive)."""
+
+    def __init__(self, conn: sqlite3.Connection):
+        self._conn = conn
+
+    def __getattr__(self, name: str):
+        return getattr(self._conn, name)
+
+    def __enter__(self):
+        return self._conn.__enter__()
+
+    def __exit__(self, *args):
+        return self._conn.__exit__(*args)
+
+    def close(self):
+        pass  # no-op — don't close the in-memory DB
+
+    def execute(self, *a, **kw):
+        return self._conn.execute(*a, **kw)
+
+    def executemany(self, *a, **kw):
+        return self._conn.executemany(*a, **kw)
+
+    def commit(self):
+        return self._conn.commit()
+
+    @property
+    def row_factory(self):
+        return self._conn.row_factory
+
+    @row_factory.setter
+    def row_factory(self, v):
+        self._conn.row_factory = v
+
+
+@pytest.fixture
+def mock_conn(tmp_path):
+    """Return a fresh in-memory SQLite connection with the cache table."""
+    raw = sqlite3.connect(":memory:")
+    raw.row_factory = sqlite3.Row
+    raw.execute("PRAGMA journal_mode=WAL")
+    raw.execute("""
+        CREATE TABLE IF NOT EXISTS sentiment_cache (
+            symbol      TEXT NOT NULL,
+            provider    TEXT NOT NULL,
+            score       REAL NOT NULL,
+            fetched_at  REAL NOT NULL,
+            PRIMARY KEY (symbol, provider)
+        )
+    """)
+    raw.commit()
+    return _NoCloseConn(raw)
+
+
+def _patch_conn(mock_conn):
+    """Context manager: patch get_connection() to return mock_conn."""
+    return patch("adapters.sentiment.cache.get_connection", return_value=mock_conn)
+
+
+def test_cache_miss_returns_none(mock_conn):
+    with _patch_conn(mock_conn):
+        from adapters.sentiment.cache import cache_read
+        result = cache_read("AAPL", "vader")
+    assert result is None
+
+
+def test_cache_write_and_hit(mock_conn):
+    with _patch_conn(mock_conn):
+        from adapters.sentiment.cache import cache_read, cache_write
+        cache_write("AAPL", "vader", 0.35)
+        result = cache_read("AAPL", "vader")
+    assert result == pytest.approx(0.35)
+
+
+def test_cache_expired_returns_none(mock_conn):
+    # Write a record with a very old timestamp
+    mock_conn.execute(
+        "INSERT INTO sentiment_cache (symbol, provider, score, fetched_at) VALUES (?,?,?,?)",
+        ("MSFT", "stocktwits", -0.1, time.time() - 3600),
+    )
+    mock_conn.commit()
+    with _patch_conn(mock_conn):
+        from importlib import reload
+        import adapters.sentiment.cache as cache_mod
+        result = cache_mod.cache_read("MSFT", "stocktwits", ttl=1800)
+    assert result is None
+
+
+def test_cache_upsert_updates_score(mock_conn):
+    with _patch_conn(mock_conn):
+        from adapters.sentiment.cache import cache_read, cache_write
+        cache_write("TSLA", "vader", 0.1)
+        cache_write("TSLA", "vader", 0.9)
+        result = cache_read("TSLA", "vader")
+    assert result == pytest.approx(0.9)
+
+
+def test_symbol_normalised_to_uppercase(mock_conn):
+    with _patch_conn(mock_conn):
+        from adapters.sentiment.cache import cache_read, cache_write
+        cache_write("aapl", "vader", 0.5)
+        result = cache_read("AAPL", "vader")
+    assert result == pytest.approx(0.5)

--- a/tests/test_strategies_indicators.py
+++ b/tests/test_strategies_indicators.py
@@ -8,6 +8,8 @@ import numpy as np
 import pandas as pd
 import pytest
 
+pytest.importorskip("ta")  # skip entire file if ta is not installed
+
 from strategies.indicators import (
     _latest,
     add_all,

--- a/tests/test_stress_test.py
+++ b/tests/test_stress_test.py
@@ -1,0 +1,71 @@
+"""Tests for portfolio stress testing module (Issue #31)."""
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+
+@pytest.fixture
+def sample_portfolio():
+    return pd.DataFrame({
+        "Ticker": ["AAPL", "MSFT", "TSLA"],
+        "Market Value": [40_000.0, 35_000.0, 25_000.0],
+    })
+
+
+def test_apply_gfc_scenario(sample_portfolio):
+    from analysis.stress_test import HISTORICAL_SCENARIOS, apply_scenario
+    gfc = next(s for s in HISTORICAL_SCENARIOS if s.name == "2008_gfc")
+    result = apply_scenario(sample_portfolio, gfc)
+    assert result.pre_nav == pytest.approx(100_000.0)
+    # -52% shock: post_nav ≈ 48000
+    assert result.post_nav == pytest.approx(48_000.0, rel=1e-3)
+    assert result.nav_change_pct == pytest.approx(-0.52, rel=1e-3)
+
+
+def test_apply_covid_scenario(sample_portfolio):
+    from analysis.stress_test import HISTORICAL_SCENARIOS, apply_scenario
+    covid = next(s for s in HISTORICAL_SCENARIOS if s.name == "2020_covid")
+    result = apply_scenario(sample_portfolio, covid)
+    assert result.nav_change_pct == pytest.approx(-0.34, rel=1e-3)
+    assert result.worst_position in ["AAPL", "MSFT", "TSLA"]
+
+
+def test_run_all_historical_scenarios(sample_portfolio):
+    from analysis.stress_test import run_stress_tests
+    results = run_stress_tests(sample_portfolio)
+    assert len(results) == 3
+    scenario_names = {r.scenario_name for r in results}
+    assert "2008_gfc" in scenario_names
+    assert "2020_covid" in scenario_names
+    assert "2022_rate_hike" in scenario_names
+
+
+def test_custom_shock_zero_no_change(sample_portfolio):
+    from analysis.stress_test import apply_custom_shock
+    result = apply_custom_shock(sample_portfolio, equity_pct=0.0)
+    assert result.nav_change == pytest.approx(0.0)
+    assert result.post_nav == pytest.approx(result.pre_nav)
+
+
+def test_custom_shock_positive(sample_portfolio):
+    from analysis.stress_test import apply_custom_shock
+    result = apply_custom_shock(sample_portfolio, equity_pct=0.10)
+    assert result.post_nav > result.pre_nav
+    assert result.nav_change_pct == pytest.approx(0.10, rel=1e-3)
+
+
+def test_apply_scenario_empty_portfolio():
+    from analysis.stress_test import HISTORICAL_SCENARIOS, apply_scenario
+    empty = pd.DataFrame(columns=["Ticker", "Market Value"])
+    result = apply_scenario(empty, HISTORICAL_SCENARIOS[0])
+    assert result.pre_nav == 0.0
+    assert result.post_nav == 0.0
+
+
+def test_llm_scenario_disabled_by_default():
+    import os
+    os.environ.pop("LLM_STRESS_SCENARIOS", None)
+    from analysis.stress_test import generate_llm_scenarios
+    results = generate_llm_scenarios("test portfolio", "trending_bull")
+    assert results == []


### PR DESCRIPTION
Phase 1 — Foundation:
- #23: 30-min SQLite TTL cache for sentiment adapters (cache.py + vader/stocktwits)
- #24: ExecutionResult dataclass; execution algo adapters return typed results; paper_trader logs analytics
- #25: scripts/migrate_to_tsdb.py — idempotent OHLCV + trades + portfolio history migration

Phase 2 — AI/ML Layer:
- #27: LLM-augmented regime classifier (REGIME_LLM_WEIGHT fusion, feedparser/NewsAPI)
- #28: RL position sizer (PPO via stable-baselines3, Kelly fallback, monthly cron hook)
- #29: MLflow model registry adapter + mock adapter + ModelRegistryProvider protocol
- #30: Prometheus metrics sidecar (FastAPI /metrics), Grafana dashboard JSON, docker-compose services

Phase 3 — Production Hardening:
- #31: Stress testing module — 3 historical scenarios (GFC/COVID/rate hike) + LLM scenario gen
- #32: Correlation & concentration monitor — rolling corr, position/sector threshold alerts
- #33: Anomaly detector — signal drought, price spike, P&L divergence; wired to scheduler
- #34: Execution quality analytics page section (slippage histograms by algo/symbol)
- #35: Distributed backtesting — ProcessPoolExecutor + optional Ray cluster

Phase 4 — Research/Advanced:
- #36: GNN cross-asset signal (2-layer GAT, GICS adjacency, fallback scorer)
- #37: Options flow provider (ThetaData + Unusual Whales + mock adapters)
- #38: Multi-agent framework (5 specialists + MetaAgent weighted voting + LLM arbiter)
- #39: Kubernetes Helm chart (Deployment, Service, HPA, Secrets templates)

Tests: 98 new tests across 11 test files; full suite 621 passed, 1 skipped

https://claude.ai/code/session_01DFz99bsddAzQkwNz9UsMMi