### PR TITLE
security+perf: fix critical and high-priority findings from review

### DIFF
--- a/adapters/execution_algo/result.py
+++ b/adapters/execution_algo/result.py
@@ -6,8 +6,13 @@ fill details, slippage metrics, and the algorithm used.
 """
 from __future__ import annotations
 
+import logging
 import time
 from dataclasses import dataclass, field
+
+logger = logging.getLogger(__name__)
+
+_SLIPPAGE_WARN_BPS = 100.0  # warn when slippage exceeds 1%
 
 
 @dataclass
@@ -59,6 +64,12 @@ class ExecutionResult:
             slippage_bps = (avg_fill - decision_price) / decision_price * 1e4
         else:
             slippage_bps = 0.0
+
+        if abs(slippage_bps) > _SLIPPAGE_WARN_BPS:
+            logger.warning(
+                "High slippage detected: %s %s %.4f bps (decision=%.4f avg_fill=%.4f)",
+                side.upper(), symbol, slippage_bps, decision_price, avg_fill,
+            )
 
         return cls(
             symbol=symbol.upper(),

--- a/adapters/options_flow/thetadata_adapter.py
+++ b/adapters/options_flow/thetadata_adapter.py
@@ -20,22 +20,28 @@ from utils.logger import get_logger
 
 logger = get_logger(__name__)
 
-_BASE_URL = os.environ.get("THETADATA_BASE_URL", "https://api.thetadata.us/v2")
-_API_KEY = os.environ.get("THETADATA_API_KEY", "")
+_DEFAULT_BASE_URL = "https://api.thetadata.us/v2"
 
 
 class ThetaDataAdapter:
     """OptionsFlowProvider backed by ThetaData REST API."""
 
+    def __init__(self) -> None:
+        # Read credentials at instantiation time so the env is fully loaded
+        self._base_url = os.environ.get("THETADATA_BASE_URL", _DEFAULT_BASE_URL)
+        self._api_key = os.environ.get("THETADATA_API_KEY", "")
+        if not self._api_key:
+            logger.warning("THETADATA_API_KEY is not set; requests will be unauthenticated")
+
     def _get(self, path: str, params: dict | None = None) -> Any:
-        url = f"{_BASE_URL}{path}"
+        url = f"{self._base_url}{path}"
         if params:
             qs = "&".join(f"{k}={v}" for k, v in params.items())
             url = f"{url}?{qs}"
         req = urllib.request.Request(
             url,
             headers={
-                "Authorization": f"Bearer {_API_KEY}",
+                "Authorization": f"Bearer {self._api_key}",
                 "Accept": "application/json",
                 "User-Agent": "quant-platform/1.0",
             },

--- a/adapters/options_flow/unusual_whales_adapter.py
+++ b/adapters/options_flow/unusual_whales_adapter.py
@@ -19,19 +19,25 @@ from utils.logger import get_logger
 
 logger = get_logger(__name__)
 
-_BASE_URL = os.environ.get("UNUSUAL_WHALES_BASE_URL", "https://api.unusualwhales.com")
-_TOKEN = os.environ.get("UNUSUAL_WHALES_TOKEN", "")
+_DEFAULT_BASE_URL = "https://api.unusualwhales.com"
 
 
 class UnusualWhalesAdapter:
     """OptionsFlowProvider backed by the Unusual Whales API."""
 
+    def __init__(self) -> None:
+        # Read credentials at instantiation time so the env is fully loaded
+        self._base_url = os.environ.get("UNUSUAL_WHALES_BASE_URL", _DEFAULT_BASE_URL)
+        self._token = os.environ.get("UNUSUAL_WHALES_TOKEN", "")
+        if not self._token:
+            logger.warning("UNUSUAL_WHALES_TOKEN is not set; requests will be unauthenticated")
+
     def _get(self, path: str) -> dict:
-        url = f"{_BASE_URL}{path}"
+        url = f"{self._base_url}{path}"
         req = urllib.request.Request(
             url,
             headers={
-                "Authorization": f"Bearer {_TOKEN}",
+                "Authorization": f"Bearer {self._token}",
                 "Accept": "application/json",
                 "User-Agent": "quant-platform/1.0",
             },

--- a/agents/meta_agent.py
+++ b/agents/meta_agent.py
@@ -14,11 +14,15 @@ from __future__ import annotations
 
 import json
 import os
+import re
 
 from agents.base import AgentProvider, AgentSignal
 from utils.logger import get_logger
 
 logger = get_logger(__name__)
+
+# Valid ticker: 1-6 uppercase letters/digits, optionally with a dot suffix (e.g. BRK.B)
+_TICKER_RE = re.compile(r"^[A-Z0-9]{1,6}(\.[A-Z]{1,2})?$")
 
 _DEFAULT_WEIGHTS: dict[str, float] = {
     "regime_agent": 1.5,
@@ -157,7 +161,9 @@ class MetaAgent:
             f"- {s.agent_name}: {s.signal} ({s.confidence:.2f}) — {s.reasoning}"
             for s in signals
         )
-        ticker = context.get("ticker", "unknown")
+        raw_ticker = str(context.get("ticker", "")).upper().strip()
+        # Validate ticker to prevent prompt injection
+        ticker = raw_ticker if _TICKER_RE.match(raw_ticker) else "UNKNOWN"
         prompt = (
             f"You are a quant portfolio manager. The following specialist agents have "
             f"analysed {ticker} and disagree (weighted score: {weighted_score:+.3f}):\n\n"

--- a/analysis/rl_sizer.py
+++ b/analysis/rl_sizer.py
@@ -16,6 +16,7 @@ Optional dependencies (guarded):
 """
 from __future__ import annotations
 
+import math
 import os
 from dataclasses import dataclass
 from pathlib import Path
@@ -105,6 +106,9 @@ class RLPositionSizer:
             arr = _obs_to_array(obs)
             action, _ = self._model.predict(arr, deterministic=True)
             multiplier = float(np.clip(action, _ACTION_LOW, _ACTION_HIGH))
+            if math.isnan(multiplier):
+                logger.warning("RL sizer: model returned NaN; using Kelly fallback")
+                return self._kelly_fallback(obs)
             logger.debug("RL sizer: obs=%s → multiplier=%.3f", obs, multiplier)
             return multiplier
         except Exception as exc:

--- a/broker/paper_trader.py
+++ b/broker/paper_trader.py
@@ -18,6 +18,7 @@ Public API
 """
 from __future__ import annotations
 
+import math
 import os
 import sqlite3
 import time
@@ -132,10 +133,10 @@ def buy(ticker: str, shares: float, price: float) -> dict:
     shares = float(shares)
     price  = float(price)
 
-    if shares <= 0:
-        raise ValueError("Shares must be greater than 0.")
-    if price <= 0:
-        raise ValueError("Price must be greater than 0.")
+    if math.isnan(shares) or math.isinf(shares) or shares <= 0:
+        raise ValueError("Shares must be a finite positive number.")
+    if math.isnan(price) or math.isinf(price) or price <= 0:
+        raise ValueError("Price must be a finite positive number.")
 
     total_cost = round(shares * price, 4)
 
@@ -245,10 +246,10 @@ def sell(ticker: str, shares: float, price: float) -> dict:
     shares  = float(shares)
     price   = float(price)
 
-    if shares <= 0:
-        raise ValueError("Shares must be greater than 0.")
-    if price <= 0:
-        raise ValueError("Price must be greater than 0.")
+    if math.isnan(shares) or math.isinf(shares) or shares <= 0:
+        raise ValueError("Shares must be a finite positive number.")
+    if math.isnan(price) or math.isinf(price) or price <= 0:
+        raise ValueError("Price must be a finite positive number.")
 
     conn = get_connection()
     try:

--- a/monitoring/sidecar.py
+++ b/monitoring/sidecar.py
@@ -8,24 +8,28 @@ Or via docker-compose (see docker-compose.yml metrics service).
 
 ENV vars
 --------
-    METRICS_PORT   port to listen on (default: 9090)
+    METRICS_PORT    port to listen on (default: 9090)
+    METRICS_TOKEN   bearer token required to scrape /metrics (optional but recommended)
 
 Requires (optional): pip install fastapi>=0.110.0 uvicorn>=0.29.0 prometheus-client>=0.19.0
 """
 from __future__ import annotations
 
 import os
+import secrets
+
+from utils.logger import get_logger
 
 try:
-    from fastapi import FastAPI  # type: ignore[import]
+    from fastapi import FastAPI, HTTPException, Request  # type: ignore[import]
     from fastapi.responses import PlainTextResponse  # type: ignore[import]  # pragma: no cover
     _FASTAPI_AVAILABLE = True  # pragma: no cover
 except ImportError:
     _FASTAPI_AVAILABLE = False
 
-from utils.logger import get_logger
-
 logger = get_logger(__name__)
+
+_METRICS_TOKEN: str = os.environ.get("METRICS_TOKEN", "")
 
 app = FastAPI(title="quant-platform metrics", docs_url=None, redoc_url=None) \
     if _FASTAPI_AVAILABLE else None  # type: ignore[assignment]
@@ -65,8 +69,13 @@ def _get_metrics_text() -> str:  # pragma: no cover
 
 if _FASTAPI_AVAILABLE and app is not None:  # pragma: no cover
     @app.get("/metrics", response_class=PlainTextResponse)
-    async def metrics_endpoint():
-        """Prometheus scrape endpoint."""
+    async def metrics_endpoint(request: Request):
+        """Prometheus scrape endpoint. Protected by METRICS_TOKEN when set."""
+        if _METRICS_TOKEN:
+            auth = request.headers.get("Authorization", "")
+            provided = auth.removeprefix("Bearer ").strip()
+            if not secrets.compare_digest(provided, _METRICS_TOKEN):
+                raise HTTPException(status_code=401, detail="Unauthorized")
         text = _get_metrics_text()
         return PlainTextResponse(
             content=text,

--- a/scheduler/alerts.py
+++ b/scheduler/alerts.py
@@ -215,71 +215,66 @@ def check_alerts(current_data: dict[str, dict[str, Any]]) -> list[dict]:
     structlog.contextvars.bind_contextvars(run_id=str(uuid.uuid4())[:8], component="scheduler")
 
     conn = get_connection()
+    triggered: list[dict] = []
+    now = time.time()
     try:
         rows = conn.execute(
             "SELECT * FROM alerts WHERE enabled=1"
         ).fetchall()
-    finally:
-        conn.close()
 
-    triggered: list[dict] = []
-    now = time.time()
+        for row in rows:
+            ticker     = row["ticker"]
+            alert_type = row["alert_type"]
+            threshold  = float(row["threshold"])
+            alert_id   = row["id"]
 
-    for row in rows:
-        ticker     = row["ticker"]
-        alert_type = row["alert_type"]
-        threshold  = float(row["threshold"])
-        alert_id   = row["id"]
+            data = current_data.get(ticker)
+            if data is None:
+                continue
 
-        data = current_data.get(ticker)
-        if data is None:
-            continue
+            price = data.get("price")
+            rsi   = data.get("rsi")
 
-        price = data.get("price")
-        rsi   = data.get("rsi")
+            fired = False
+            if alert_type == "price_above" and price is not None and price >= threshold:
+                fired = True
+            elif alert_type == "price_below" and price is not None and price <= threshold:
+                fired = True
+            elif alert_type == "rsi_above" and rsi is not None and rsi >= threshold:
+                fired = True
+            elif alert_type == "rsi_below" and rsi is not None and rsi <= threshold:
+                fired = True
 
-        fired = False
-        if alert_type == "price_above" and price is not None and price >= threshold:
-            fired = True
-        elif alert_type == "price_below" and price is not None and price <= threshold:
-            fired = True
-        elif alert_type == "rsi_above" and rsi is not None and rsi >= threshold:
-            fired = True
-        elif alert_type == "rsi_below" and rsi is not None and rsi <= threshold:
-            fired = True
+            if fired:
+                _label = ALERT_TYPES.get(alert_type, alert_type)
+                msg = (
+                    f"{ticker}: {_label} {threshold:.2f} triggered — "
+                    f"price=${price:.2f}" +
+                    (f", RSI={rsi:.1f}" if rsi is not None else "")
+                )
+                logger.info("ALERT FIRED: %s", msg)
+                _notify(f"Alert: {ticker}", msg)
+                broadcast(subject=f"Alert: {ticker}", body=msg)
 
-        if fired:
-            _label = ALERT_TYPES.get(alert_type, alert_type)
-            msg = (
-                f"{ticker}: {_label} {threshold:.2f} triggered — "
-                f"price=${price:.2f}" +
-                (f", RSI={rsi:.1f}" if rsi is not None else "")
-            )
-            logger.info("ALERT FIRED: %s", msg)
-            _notify(f"Alert: {ticker}", msg)
-            broadcast(subject=f"Alert: {ticker}", body=msg)
-
-            # Stamp triggered_at
-            conn2 = get_connection()
-            try:
-                with conn2:
-                    conn2.execute(
+                # Stamp triggered_at — reuse the same connection
+                with conn:
+                    conn.execute(
                         "UPDATE alerts SET triggered_at=? WHERE id=?",
                         (now, alert_id),
                     )
-            finally:
-                conn2.close()
 
-            triggered.append({
-                "id":         alert_id,
-                "ticker":     ticker,
-                "alert_type": alert_type,
-                "threshold":  threshold,
-                "price":      price,
-                "rsi":        rsi,
-                "message":    msg,
-                "fired_at":   pd.Timestamp(now, unit="s").strftime("%Y-%m-%d %H:%M:%S"),
-            })
+                triggered.append({
+                    "id":         alert_id,
+                    "ticker":     ticker,
+                    "alert_type": alert_type,
+                    "threshold":  threshold,
+                    "price":      price,
+                    "rsi":        rsi,
+                    "message":    msg,
+                    "fired_at":   pd.Timestamp(now, unit="s").strftime("%Y-%m-%d %H:%M:%S"),
+                })
+    finally:
+        conn.close()
 
     return triggered
 


### PR DESCRIPTION
Security fixes:
- Move secret loading from module-level to __init__ in ThetaDataAdapter and
  UnusualWhalesAdapter so credentials are read after dotenv is fully loaded
- Sanitize ticker symbol before inserting into LLM prompt in MetaAgent to
  prevent prompt injection (validate against strict regex, fallback to UNKNOWN)
- Guard /metrics endpoint with bearer token auth via METRICS_TOKEN env var
  using secrets.compare_digest to prevent timing attacks
- Add NaN/Inf guards to paper_trader buy() and sell() so accounting logic
  cannot be bypassed with IEEE special values

Performance / reliability fixes:
- Reuse single DB connection across all alert updates in check_alerts() instead
  of opening a new connection per fired alert
- Add slippage warning (>100 bps) in ExecutionResult.from_fills() so extreme
  fills are visible in logs
- Add NaN guard after np.clip in RLPositionSizer.predict(); falls back to Kelly
  if the model outputs NaN

https://claude.ai/code/session_01XjAxfqAmLFWAbn8QpaNQA9