### PR TITLE
security+perf: resolve issues #50–#58 + fix CI docker compose command

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,9 +47,9 @@ jobs:
 
       - name: Validate docker-compose config
         run: |
-          # Create a stub .env so docker-compose config doesn't warn about missing file
+          # Create a stub .env so docker compose config doesn't warn about missing file
           touch .env
-          docker-compose config --quiet
+          docker compose config --quiet
 
       - name: Upload test results and coverage
         uses: actions/upload-artifact@v4

--- a/adapters/execution_algo/twap_adapter.py
+++ b/adapters/execution_algo/twap_adapter.py
@@ -4,6 +4,11 @@ adapters/execution_algo/twap_adapter.py — Time-Weighted Average Price executio
 Slices *total_qty* into equal child orders placed every TWAP_SLICE_SECONDS over
 the *duration_minutes* window.
 
+NOTE: execute() blocks the calling thread for the full execution window. Never
+call this directly from a Streamlit render function or an async event loop.
+Use a background thread (e.g. concurrent.futures.ThreadPoolExecutor) at the
+call site. Call stop() to interrupt an in-progress execution early.
+
 ENV vars
 --------
     TWAP_SLICE_SECONDS   seconds between child orders (default: 60)
@@ -13,7 +18,7 @@ from __future__ import annotations
 import logging
 import math
 import os
-import time
+import threading
 from typing import Any
 
 from adapters.execution_algo.result import ExecutionResult
@@ -28,6 +33,11 @@ class TWAPAdapter:
         self._slice_seconds = slice_seconds or int(
             os.environ.get("TWAP_SLICE_SECONDS", "60")
         )
+        self._stop_event = threading.Event()
+
+    def stop(self) -> None:
+        """Signal any in-progress execute() to abort after the current slice."""
+        self._stop_event.set()
 
     def execute(
         self,
@@ -40,6 +50,7 @@ class TWAPAdapter:
         decision_price: float = 0.0,
         **kwargs: Any,
     ) -> ExecutionResult:
+        self._stop_event.clear()
         duration_seconds = duration_minutes * 60
         n_slices = max(1, math.ceil(duration_seconds / self._slice_seconds))
         slice_qty = total_qty / n_slices
@@ -54,6 +65,9 @@ class TWAPAdapter:
         fills: list[dict] = []
         placed = 0.0
         for i in range(n_slices):
+            if self._stop_event.is_set():
+                logger.warning("TWAP: execution aborted after %d/%d slices", i, n_slices)
+                break
             is_last = i == n_slices - 1
             qty = round(total_qty - placed, 4) if is_last else slice_qty
             if qty <= 0:
@@ -67,7 +81,8 @@ class TWAPAdapter:
             fills.append(fill)
             placed = round(placed + qty, 4)
             if not is_last:
-                time.sleep(self._slice_seconds)
+                # Interruptible sleep: wakes immediately if stop() is called
+                self._stop_event.wait(timeout=self._slice_seconds)
 
         return ExecutionResult.from_fills(
             fills=fills,

--- a/adapters/execution_algo/vwap_adapter.py
+++ b/adapters/execution_algo/vwap_adapter.py
@@ -4,6 +4,11 @@ adapters/execution_algo/vwap_adapter.py — Volume-Weighted Average Price execut
 Sizes each child order proportionally to the historical intraday volume profile
 over *VWAP_LOOKBACK_DAYS* trading days, then places them on a per-slice schedule.
 
+NOTE: execute() blocks the calling thread for the full execution window. Never
+call this directly from a Streamlit render function or an async event loop.
+Use a background thread (e.g. concurrent.futures.ThreadPoolExecutor) at the
+call site. Call stop() to interrupt an in-progress execution early.
+
 ENV vars
 --------
     VWAP_LOOKBACK_DAYS   days of history to build volume profile (default: 5)
@@ -14,7 +19,7 @@ from __future__ import annotations
 import logging
 import math
 import os
-import time
+import threading
 from typing import Any
 
 from adapters.execution_algo.result import ExecutionResult
@@ -41,6 +46,11 @@ class VWAPAdapter:
         self._slice_seconds = slice_seconds or int(
             os.environ.get("TWAP_SLICE_SECONDS", "60")
         )
+        self._stop_event = threading.Event()
+
+    def stop(self) -> None:
+        """Signal any in-progress execute() to abort after the current slice."""
+        self._stop_event.set()
 
     def _get_volume_weights(self, symbol: str, n_slices: int) -> list[float]:
         """
@@ -75,6 +85,7 @@ class VWAPAdapter:
         decision_price: float = 0.0,
         **kwargs: Any,
     ) -> ExecutionResult:
+        self._stop_event.clear()
         duration_seconds = duration_minutes * 60
         n_slices = max(1, math.ceil(duration_seconds / self._slice_seconds))
         weights = self._get_volume_weights(symbol, n_slices)
@@ -87,6 +98,9 @@ class VWAPAdapter:
         fills: list[dict] = []
         placed = 0.0
         for i, weight in enumerate(weights):
+            if self._stop_event.is_set():
+                logger.warning("VWAP: execution aborted after %d/%d slices", i, n_slices)
+                break
             is_last = i == n_slices - 1
             if is_last:
                 qty = round(total_qty - placed, 4)
@@ -103,7 +117,8 @@ class VWAPAdapter:
             fills.append(fill)
             placed = round(placed + qty, 4)
             if not is_last:
-                time.sleep(self._slice_seconds)
+                # Interruptible sleep: wakes immediately if stop() is called
+                self._stop_event.wait(timeout=self._slice_seconds)
 
         return ExecutionResult.from_fills(
             fills=fills,

--- a/adapters/sentiment/cache.py
+++ b/adapters/sentiment/cache.py
@@ -10,8 +10,14 @@ from __future__ import annotations
 import time
 
 from data.db import get_connection
+from utils.logger import get_logger
+
+logger = get_logger(__name__)
 
 _DEFAULT_TTL = 1800  # 30 minutes
+
+# Allow up to 60 s of clock-skew between writer and reader before rejecting entry
+_CLOCK_SKEW_TOLERANCE = 60.0
 
 
 def cache_read(symbol: str, provider: str, ttl: int = _DEFAULT_TTL) -> float | None:
@@ -39,8 +45,16 @@ def cache_read(symbol: str, provider: str, ttl: int = _DEFAULT_TTL) -> float | N
 
     if row is None:
         return None
-    age = time.time() - float(row["fetched_at"])
-    if age > ttl:
+    now = time.time()
+    fetched_at = float(row["fetched_at"])
+    # Reject entries with implausible timestamps (zero/negative or far future)
+    if not (0 < fetched_at <= now + _CLOCK_SKEW_TOLERANCE):
+        logger.warning(
+            "Sentiment cache: discarding entry with invalid timestamp %.0f for %s/%s",
+            fetched_at, symbol, provider,
+        )
+        return None
+    if now - fetched_at > ttl:
         return None
     return float(row["score"])
 

--- a/agents/meta_agent.py
+++ b/agents/meta_agent.py
@@ -131,6 +131,7 @@ class MetaAgent:
                 reasoning = self._llm_arbitrate(signals, context, weighted_score, reasoning)
             except Exception as exc:
                 logger.warning("LLM arbiter failed: %s", exc)
+                reasoning = reasoning + " [LLM arbiter unavailable]"
 
         return {
             "signal": consensus,

--- a/agents/regime_agent.py
+++ b/agents/regime_agent.py
@@ -16,8 +16,8 @@ class RegimeAgent:
         regime = context.get("regime")
         if regime is None:
             try:
-                from analysis.regime import get_live_regime_with_llm
-                data = get_live_regime_with_llm()
+                from analysis.regime import get_cached_live_regime
+                data = get_cached_live_regime(use_llm=True)
                 regime = data["regime"]
             except Exception as exc:
                 logger.warning("RegimeAgent: regime fetch failed: %s", exc)

--- a/agents/risk_agent.py
+++ b/agents/risk_agent.py
@@ -1,6 +1,8 @@
 """agents/risk_agent.py — Specialist agent wrapping correlation & VaR checks."""
 from __future__ import annotations
 
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
 from agents.base import AgentSignal
 from utils.logger import get_logger
 
@@ -23,11 +25,24 @@ class RiskAgent:
             try:
                 from data.fetcher import fetch_ohlcv
                 from risk.correlation import check_correlation_alerts
-                price_data = {}
-                for ticker in list(positions.keys())[:10]:
-                    df = fetch_ohlcv(ticker, period="3mo")
-                    if not df.empty and "Close" in df.columns:
-                        price_data[ticker] = df["Close"]
+
+                tickers = list(positions.keys())[:10]
+
+                # Fetch all OHLCV series in parallel to avoid N+1 serial calls
+                price_data: dict = {}
+                with ThreadPoolExecutor(max_workers=min(5, len(tickers))) as pool:
+                    future_to_ticker = {
+                        pool.submit(fetch_ohlcv, t, "3mo"): t for t in tickers
+                    }
+                    for future in as_completed(future_to_ticker):
+                        t = future_to_ticker[future]
+                        try:
+                            df = future.result()
+                            if not df.empty and "Close" in df.columns:
+                                price_data[t] = df["Close"]
+                        except Exception as exc:
+                            logger.debug("RiskAgent: fetch failed for %s: %s", t, exc)
+
                 alerts = check_correlation_alerts(price_data, positions)
                 for alert in alerts:
                     warnings.append(alert.message)

--- a/analysis/regime.py
+++ b/analysis/regime.py
@@ -15,12 +15,17 @@ from __future__ import annotations
 
 import json
 import os
+import time
 
 import pandas as pd
 
 from utils.logger import get_logger
 
 logger = get_logger(__name__)
+
+# ── Module-level TTL cache for live regime (avoids repeated yfinance + LLM calls) ─
+_REGIME_CACHE_TTL: int = int(os.environ.get("REGIME_CACHE_TTL", "300"))  # 5 min default
+_regime_cache: dict = {"data": None, "expires_at": 0.0}
 
 REGIME_STATES: list[str] = [
     "trending_bull",
@@ -215,10 +220,14 @@ def _parse_llm_regime(llm_response: str) -> tuple[str, float]:
         data = json.loads(text)
         regime = str(data.get("regime", "")).strip()
         if regime not in REGIME_STATES:
-            logger.warning("LLM returned unknown regime %r; falling back", regime)
+            logger.warning(
+                "LLM returned invalid regime %r (must be one of %s); "
+                "forcing fallback to 'high_vol'",
+                regime, REGIME_STATES,
+            )
             return _FALLBACK
-        confidence = float(data.get("confidence", 0.5))
-        confidence = max(0.0, min(1.0, confidence))
+        raw_conf = data.get("confidence", 0.5)
+        confidence = max(0.0, min(1.0, float(raw_conf)))
         return regime, confidence
     except Exception as exc:
         logger.warning("Failed to parse LLM regime response: %s  raw=%r", exc, llm_response[:200])
@@ -316,4 +325,28 @@ def get_live_regime_with_llm(llm_weight: float | None = None) -> dict:
     except Exception as exc:
         logger.warning("LLM regime fusion failed, using quant regime: %s", exc)
 
+    return result
+
+
+def get_cached_live_regime(use_llm: bool = False) -> dict:
+    """
+    Return the current live regime, re-fetching only when the TTL has expired.
+
+    Uses a module-level cache (default TTL: REGIME_CACHE_TTL env var, 300 s).
+    This prevents redundant yfinance + optional LLM calls when multiple agents
+    (or the monitoring sidecar) ask for the regime within the same window.
+
+    Parameters
+    ----------
+    use_llm : if True, calls get_live_regime_with_llm(); otherwise get_live_regime().
+    """
+    now = time.time()
+    if _regime_cache["data"] is not None and now < _regime_cache["expires_at"]:
+        return _regime_cache["data"]  # type: ignore[return-value]
+
+    fetch = get_live_regime_with_llm if use_llm else get_live_regime
+    result = fetch()
+    _regime_cache["data"] = result
+    _regime_cache["expires_at"] = now + _REGIME_CACHE_TTL
+    logger.debug("Regime cache refreshed (ttl=%ds): %s", _REGIME_CACHE_TTL, result.get("regime"))
     return result

--- a/broker/paper_trader.py
+++ b/broker/paper_trader.py
@@ -356,7 +356,18 @@ def get_portfolio(current_prices: Optional[dict[str, float]] = None) -> pd.DataF
 
         cur_price = None
         if current_prices is not None:
-            cur_price = current_prices.get(ticker)
+            raw_price = current_prices.get(ticker)
+            if raw_price is not None:
+                try:
+                    p = float(raw_price)
+                    if math.isnan(p) or math.isinf(p) or p <= 0:
+                        raise ValueError(f"non-positive or non-finite price: {p}")
+                    cur_price = p
+                except (TypeError, ValueError) as exc:
+                    logger.warning(
+                        "get_portfolio: invalid price for %s (%s); skipping P&L enrichment",
+                        ticker, exc,
+                    )
 
         if cur_price is not None:
             market_val    = round(shares * cur_price, 2)

--- a/pages/journal_tab.py
+++ b/pages/journal_tab.py
@@ -153,9 +153,15 @@ def render() -> None:
         )
         try:
             from data.db import get_connection
+            _PAGE_SIZE = 50
+            _exec_page = st.session_state.get("exec_analytics_page", 0)
             conn = get_connection()
+            total_exec = conn.execute(
+                "SELECT COUNT(*) FROM execution_analytics"
+            ).fetchone()[0]
             rows = conn.execute(
-                "SELECT * FROM execution_analytics ORDER BY executed_at DESC LIMIT 500"
+                "SELECT * FROM execution_analytics ORDER BY executed_at DESC LIMIT ? OFFSET ?",
+                (_PAGE_SIZE, _exec_page * _PAGE_SIZE),
             ).fetchall()
             conn.close()
             if not rows:
@@ -226,8 +232,22 @@ def render() -> None:
                     exec_df[[
                         "executed_at", "symbol", "side", "algo",
                         "total_qty", "decision_price", "avg_fill_price", "slippage_bps",
-                    ]].head(20),
+                    ]],
                     use_container_width=True,
                 )
+
+                # Pagination controls
+                total_pages = max(1, (total_exec + _PAGE_SIZE - 1) // _PAGE_SIZE)
+                pg_col1, pg_col2, pg_col3 = st.columns([1, 2, 1])
+                with pg_col1:
+                    if st.button("← Prev", disabled=_exec_page == 0, key="exec_prev"):
+                        st.session_state["exec_analytics_page"] = _exec_page - 1
+                        st.rerun()
+                with pg_col2:
+                    st.caption(f"Page {_exec_page + 1} of {total_pages} ({total_exec} fills)")
+                with pg_col3:
+                    if st.button("Next →", disabled=_exec_page >= total_pages - 1, key="exec_next"):
+                        st.session_state["exec_analytics_page"] = _exec_page + 1
+                        st.rerun()
         except Exception as exc:
             st.warning(f"Could not load execution analytics: {exc}")

--- a/risk/correlation.py
+++ b/risk/correlation.py
@@ -11,6 +11,12 @@ from dataclasses import dataclass
 import pandas as pd
 import plotly.graph_objects as go
 
+from utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+_MIN_PERIODS = 20  # minimum trading-day observations for a reliable correlation matrix
+
 # Alert thresholds (overridable by callers)
 CORR_ALERT_AVG_THRESHOLD: float = 0.7
 POSITION_WEIGHT_THRESHOLD: float = 0.25
@@ -46,6 +52,12 @@ def rolling_correlation(
     if not price_data or len(price_data) < 2:
         return pd.DataFrame()
     df = pd.DataFrame(price_data).pct_change().dropna()
+    if len(df) < _MIN_PERIODS:
+        logger.warning(
+            "rolling_correlation skipped: only %d periods available (min %d).",
+            len(df), _MIN_PERIODS,
+        )
+        return pd.DataFrame()
     if len(df) < window:
         return df.corr()
     return df.rolling(window).corr().iloc[-len(price_data):]
@@ -142,10 +154,21 @@ def check_correlation_alerts(
 
 
 def compute_correlation_matrix(price_data: dict[str, pd.Series]) -> pd.DataFrame:
-    """Compute pairwise correlation of returns from a dict of price series."""
+    """Compute pairwise correlation of returns from a dict of price series.
+
+    Returns an empty DataFrame when fewer than _MIN_PERIODS observations are
+    available, since the matrix would be statistically unreliable.
+    """
     if not price_data or len(price_data) < 2:
         return pd.DataFrame()
     df = pd.DataFrame(price_data).pct_change().dropna()
+    if len(df) < _MIN_PERIODS:
+        logger.warning(
+            "Correlation matrix skipped: only %d periods available (min %d). "
+            "Results would be unreliable.",
+            len(df), _MIN_PERIODS,
+        )
+        return pd.DataFrame()
     return df.corr()
 
 

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -56,7 +56,7 @@ def test_regime_agent_unknown_regime_neutral():
 def test_regime_agent_fetches_regime_when_absent():
     from agents.regime_agent import RegimeAgent
     agent = RegimeAgent()
-    with patch("analysis.regime.get_live_regime_with_llm",
+    with patch("analysis.regime.get_cached_live_regime",
                return_value={"regime": "trending_bull"}):
         result = agent.run({})
     assert result.signal == "bullish"
@@ -65,7 +65,7 @@ def test_regime_agent_fetches_regime_when_absent():
 def test_regime_agent_fallback_on_fetch_error():
     from agents.regime_agent import RegimeAgent
     agent = RegimeAgent()
-    with patch("analysis.regime.get_live_regime_with_llm",
+    with patch("analysis.regime.get_cached_live_regime",
                side_effect=RuntimeError("no data")):
         result = agent.run({})
     assert result.signal == "neutral"

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import threading
 from unittest.mock import MagicMock
 
 import pytest
@@ -72,7 +73,7 @@ def test_twap_execute_returns_execution_result():
     }
 
     adapter = TWAPAdapter(slice_seconds=30)  # 2 slices for 1-min window
-    with patch("time.sleep"):
+    with patch.object(threading.Event, "wait", return_value=False):
         result = adapter.execute(
             symbol="AAPL",
             total_qty=10.0,
@@ -100,7 +101,7 @@ def test_twap_slices_into_multiple_orders():
     }
 
     adapter = TWAPAdapter(slice_seconds=30)  # 2 slices in 1 min
-    with patch("time.sleep"):
+    with patch.object(threading.Event, "wait", return_value=False):
         adapter.execute(
             symbol="AAPL",
             total_qty=100.0,
@@ -126,7 +127,7 @@ def test_twap_single_slice_no_sleep():
     }
 
     adapter = TWAPAdapter(slice_seconds=120)  # 1 slice for 1-min window
-    with patch("time.sleep") as mock_sleep:
+    with patch.object(threading.Event, "wait", return_value=False) as mock_wait:
         adapter.execute(
             symbol="MSFT",
             total_qty=50.0,
@@ -135,7 +136,7 @@ def test_twap_single_slice_no_sleep():
             duration_minutes=1,
         )
 
-    mock_sleep.assert_not_called()
+    mock_wait.assert_not_called()
 
 
 # ── VWAPAdapter ────────────────────────────────────────────────────────────────
@@ -159,7 +160,7 @@ def test_vwap_execute_returns_execution_result():
 
     adapter = VWAPAdapter(lookback_days=5, slice_seconds=30)
     with patch("data.fetcher.fetch_ohlcv", return_value=mock_df), \
-         patch("time.sleep"):
+         patch.object(threading.Event, "wait", return_value=False):
         result = adapter.execute(
             symbol="AAPL",
             total_qty=10.0,
@@ -192,7 +193,7 @@ def test_vwap_falls_back_to_uniform_weights_on_empty_df():
 
     adapter = VWAPAdapter(lookback_days=5, slice_seconds=30)
     with patch("data.fetcher.fetch_ohlcv", return_value=empty_df), \
-         patch("time.sleep"):
+         patch.object(threading.Event, "wait", return_value=False):
         result = adapter.execute(
             symbol="XYZ",
             total_qty=5.0,


### PR DESCRIPTION
## Summary

Two commits on top of the previously merged security/perf PR (#49):

### security+perf: resolve issues #50–#58

Security (medium severity):
- **#50** `analysis/regime.py`: log full `REGIME_STATES` list with invalid LLM label before forcing `high_vol` fallback
- **#51** `adapters/sentiment/cache.py`: reject cache entries with zero/negative/far-future timestamps; 60 s clock-skew tolerance
- **#52** `agents/meta_agent.py`: append `[LLM arbiter unavailable]` to `reasoning` on LLM failure so callers can distinguish fallback from consensus
- **#53** `broker/paper_trader.py`: validate each `current_prices` entry is a finite positive float before computing unrealised P&L

Performance:
- **#54** `twap_adapter.py` + `vwap_adapter.py`: replace `time.sleep()` with `threading.Event.wait()` — interruptible via new `stop()` method; add threading warning to docstring
- **#55** `agents/risk_agent.py`: parallelise per-ticker `fetch_ohlcv()` calls with `ThreadPoolExecutor(max_workers=5)`
- **#56** `analysis/regime.py` + `agents/regime_agent.py`: add `get_cached_live_regime()` with 5-min TTL (`REGIME_CACHE_TTL` env var); `RegimeAgent` uses cache instead of fetching on every `run()`
- **#57** `pages/journal_tab.py`: replace `LIMIT 500` with 50-row offset pagination + Prev/Next controls
- **#58** `risk/correlation.py`: skip and warn when fewer than 20 trading-day observations are available

### ci: fix docker compose command for GitHub Actions V2 runner

`docker-compose` (V1 hyphenated CLI) is no longer present on GitHub Actions runners. Replaces `docker-compose config` with `docker compose config` in `build.yml`, fixing the exit-127 failure seen after every merge to main.

## Test plan

- [ ] CI unit tests pass (`Test (Python 3.11)`)
- [ ] `build.yml` "Validate docker-compose config" step no longer exits 127
- [ ] All 9 linked issues (#50–#58) closed

https://claude.ai/code/session_01XjAxfqAmLFWAbn8QpaNQA9