### PR TITLE
feat: add ML alpha-generation pipeline based on ML for Algorithmic Trading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,4 @@ coverage.xml
 coverage-integration.xml
 htmlcov/
 .pytest_cache/
+.coverage

--- a/analysis/factor_ic.py
+++ b/analysis/factor_ic.py
@@ -1,0 +1,184 @@
+"""
+analysis/factor_ic.py — Information Coefficient (IC) analysis for alpha factors.
+
+Evaluates whether each feature in a feature matrix has statistically
+significant predictive power over forward returns, using the standard
+Spearman-rank IC methodology from factor research.
+
+Key metrics
+-----------
+    IC      : Spearman rank correlation of feature vs forward return,
+              computed cross-sectionally per date then averaged
+    IC Std  : Standard deviation of the per-date IC series
+    ICIR    : IC Information Ratio = IC Mean / IC Std
+              Values > 0.5 (or < -0.5) indicate a consistent signal
+    p-value : One-sample t-test on the IC series (H₀: mean = 0)
+
+Usage
+-----
+    from data.features import build_feature_matrix
+    from analysis.factor_ic import compute_ic
+
+    fm = build_feature_matrix(["AAPL", "MSFT", "GOOGL"], period="2y")
+    results = compute_ic(fm)
+    for feature, stats in results.items():
+        print(feature, stats)
+"""
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+from utils.logger import get_logger
+
+log = get_logger(__name__)
+
+# ICIR threshold above which a factor is considered meaningfully consistent
+MEANINGFUL_ICIR = 0.5
+
+# Minimum number of ticker observations per date to compute a valid IC
+_MIN_OBS_PER_DATE = 5
+
+
+def _spearman_corr(x: np.ndarray, y: np.ndarray) -> float:
+    """Spearman rank correlation without scipy dependency."""
+    n = len(x)
+    if n < 2:
+        return np.nan
+    rx = pd.Series(x).rank()
+    ry = pd.Series(y).rank()
+    # Pearson on ranks == Spearman
+    mx, my = rx.mean(), ry.mean()
+    num = ((rx - mx) * (ry - my)).sum()
+    den = np.sqrt(((rx - mx) ** 2).sum() * ((ry - my) ** 2).sum())
+    if den == 0:
+        return np.nan
+    return float(num / den)
+
+
+def _ttest_1samp_pvalue(series: np.ndarray) -> float:
+    """Two-sided p-value for H₀: mean = 0, no scipy required."""
+    clean = series[~np.isnan(series)]
+    n = len(clean)
+    if n < 2:
+        return np.nan
+    mean = clean.mean()
+    std = clean.std(ddof=1)
+    if std == 0:
+        return 0.0
+    t_stat = mean * np.sqrt(n) / std
+    # Approximate p-value using normal distribution (valid for n >= 30)
+    # |t| → Φ(-|t|) × 2
+    from math import erfc, sqrt
+    p = float(erfc(abs(t_stat) / sqrt(2)))
+    return p
+
+
+def compute_ic(
+    feature_matrix: pd.DataFrame,
+    forward_return_col: str = "fwd_ret_5d",
+    feature_cols: list[str] | None = None,
+) -> dict[str, dict]:
+    """
+    Compute IC statistics for each feature column.
+
+    Parameters
+    ----------
+    feature_matrix     : MultiIndex (date, ticker) DataFrame from build_feature_matrix
+    forward_return_col : name of the target forward-return column
+    feature_cols       : subset of features to evaluate; None = all non-fwd_ret columns
+
+    Returns
+    -------
+    dict mapping feature_name → {
+        "ic_mean" : float  — mean IC across dates
+        "ic_std"  : float  — std of per-date IC series
+        "icir"    : float  — ic_mean / ic_std (0 if ic_std == 0)
+        "p_value" : float  — two-sided p-value (H₀: mean IC = 0)
+        "n_dates" : int    — number of dates with ≥ _MIN_OBS_PER_DATE observations
+    }
+    """
+    if feature_matrix.empty:
+        log.warning("compute_ic: empty feature matrix")
+        return {}
+
+    if forward_return_col not in feature_matrix.columns:
+        log.warning("compute_ic: target column missing", col=forward_return_col)
+        return {}
+
+    all_cols = list(feature_matrix.columns)
+    if feature_cols is None:
+        feature_cols = [c for c in all_cols if not c.startswith("fwd_ret_")]
+    else:
+        feature_cols = [c for c in feature_cols if c in all_cols]
+
+    if not feature_cols:
+        log.warning("compute_ic: no valid feature columns found")
+        return {}
+
+    results: dict[str, dict] = {}
+
+    for feat in feature_cols:
+        ic_series: list[float] = []
+        valid_dates = 0
+
+        for _date, group in feature_matrix.groupby(level="date"):
+            sub = group[[feat, forward_return_col]].dropna()
+            if len(sub) < _MIN_OBS_PER_DATE:
+                continue
+            ic = _spearman_corr(sub[feat].values, sub[forward_return_col].values)
+            if not np.isnan(ic):
+                ic_series.append(ic)
+                valid_dates += 1
+
+        if not ic_series:
+            results[feat] = {"ic_mean": np.nan, "ic_std": np.nan, "icir": np.nan,
+                             "p_value": np.nan, "n_dates": 0}
+            continue
+
+        arr = np.array(ic_series)
+        ic_mean = float(arr.mean())
+        ic_std = float(arr.std(ddof=1)) if len(arr) > 1 else 0.0
+        icir = ic_mean / ic_std if ic_std != 0 else 0.0
+        p_value = _ttest_1samp_pvalue(arr)
+
+        results[feat] = {
+            "ic_mean": ic_mean,
+            "ic_std": ic_std,
+            "icir": icir,
+            "p_value": p_value,
+            "n_dates": valid_dates,
+        }
+
+    log.info("compute_ic: complete", features=len(results), target=forward_return_col)
+    return results
+
+
+def compute_ic_decay(
+    feature_matrix: pd.DataFrame,
+    feature_col: str,
+    horizons: list[int] | None = None,
+) -> dict[int, dict]:
+    """
+    Compute IC at multiple forward-return horizons to measure signal decay.
+
+    Parameters
+    ----------
+    feature_matrix : MultiIndex (date, ticker) frame containing fwd_ret_{h}d columns
+    feature_col    : the single feature column to analyse
+    horizons       : list of horizon days (default: [1, 5, 10, 21])
+
+    Returns
+    -------
+    dict mapping horizon_days → compute_ic() result dict
+    """
+    if horizons is None:
+        horizons = [1, 5, 10, 21]
+
+    decay: dict[int, dict] = {}
+    for h in horizons:
+        col = f"fwd_ret_{h}d"
+        result = compute_ic(feature_matrix, forward_return_col=col, feature_cols=[feature_col])
+        decay[h] = result.get(feature_col, {"ic_mean": np.nan, "ic_std": np.nan,
+                                             "icir": np.nan, "p_value": np.nan, "n_dates": 0})
+    return decay

--- a/app.py
+++ b/app.py
@@ -15,6 +15,7 @@ from pages import (
     efficient_frontier,
     greeks,
     journal_tab,
+    ml_signals,
     portfolio,
     screener,
     shared,
@@ -37,8 +38,10 @@ st.set_page_config(
 
 shared.render_sidebar()
 
-tab1, tab2, tab3, tab4, tab5, tab6, tab7, tab8 = st.tabs([
-    "📈 Chart", "🔬 Backtest", "🔍 Screener", "💼 Portfolio", "🔔 Alerts", "📓 Journal", "📐 Efficient Frontier", "🧮 Greeks"
+tab1, tab2, tab3, tab4, tab5, tab6, tab7, tab8, tab9 = st.tabs([
+    "📈 Chart", "🔬 Backtest", "🔍 Screener", "💼 Portfolio",
+    "🔔 Alerts", "📓 Journal", "📐 Efficient Frontier", "🧮 Greeks",
+    "🤖 ML Signals",
 ])
 with tab1:
     chart.render()
@@ -56,3 +59,5 @@ with tab7:
     efficient_frontier.render()
 with tab8:
     greeks.render()
+with tab9:
+    ml_signals.render()

--- a/backtester/walk_forward.py
+++ b/backtester/walk_forward.py
@@ -196,6 +196,140 @@ def walk_forward_parallel(
     )
 
 
+def purged_walk_forward(
+    strategy_fn,
+    feature_matrix: pd.DataFrame,
+    n_splits: int = 5,
+    embargo_pct: float = 0.01,
+) -> WalkForwardResult:
+    """
+    Purged walk-forward cross-validation with an embargo gap.
+
+    Prevents label leakage from overlapping forward-return labels by inserting
+    an embargo gap between the end of each training period and the start of
+    the corresponding test period.
+
+    Parameters
+    ----------
+    strategy_fn    : callable(segment: pd.DataFrame) -> pd.Series
+                     Accepts a MultiIndex (date, ticker) feature matrix segment
+                     and returns a pd.Series of daily portfolio returns indexed
+                     by date.
+    feature_matrix : MultiIndex (date, ticker) DataFrame from build_feature_matrix
+    n_splits       : number of train/test folds (default: 5)
+    embargo_pct    : fraction of total date count used as the embargo gap
+                     (default: 0.01 = 1% of total bars ≈ ~5 trading days on 2y data)
+
+    Returns
+    -------
+    WalkForwardResult (same structure as walk_forward())
+
+    Notes
+    -----
+    For fold k (0-indexed) of n_splits:
+        train_end  = dates[int(total * (k + 1) / n_splits)]
+        gap_end    = train_end + embargo_bars
+        test_start = dates[gap_end]
+        test_end   = dates[int(total * (k + 2) / n_splits)] or last date
+    Fold k=0 uses the first (1/n_splits) of dates as training.
+    """
+    if feature_matrix.empty:
+        logger.warning("purged_walk_forward: empty feature matrix")
+        return WalkForwardResult()
+
+    all_dates = sorted(feature_matrix.index.get_level_values(0).unique())
+    total = len(all_dates)
+    embargo_bars = max(1, int(embargo_pct * total))
+
+    results: list[BacktestResult] = []
+
+    for k in range(n_splits - 1):
+        train_end_idx = int(total * (k + 1) / n_splits)
+        test_start_idx = min(train_end_idx + embargo_bars, total - 1)
+        test_end_idx = min(int(total * (k + 2) / n_splits), total)
+
+        if test_start_idx >= test_end_idx:
+            logger.warning("purged_walk_forward: fold %d has empty test window — skipped", k)
+            continue
+
+        train_dates = set(all_dates[:train_end_idx])
+        test_dates = set(all_dates[test_start_idx:test_end_idx])
+
+        train_seg = feature_matrix[feature_matrix.index.get_level_values(0).isin(train_dates)]
+        test_seg = feature_matrix[feature_matrix.index.get_level_values(0).isin(test_dates)]
+
+        if train_seg.empty or test_seg.empty:
+            continue
+
+        try:
+            # strategy_fn receives (train_seg, test_seg); returns a returns Series
+            daily_returns = strategy_fn(train_seg, test_seg)
+            if daily_returns is None or daily_returns.empty:
+                continue
+
+            # Compute backtest-compatible metrics from the returns Series
+            rets = daily_returns.dropna()
+            if len(rets) < 2:
+                continue
+
+            total_return = float((1 + rets).prod() - 1)
+            ann_vol = float(rets.std() * np.sqrt(252))
+            sharpe = float(rets.mean() / rets.std() * np.sqrt(252)) if rets.std() > 0 else 0.0
+
+            # Sortino: downside deviation
+            neg = rets[rets < 0]
+            downside_std = float(neg.std() * np.sqrt(252)) if len(neg) > 1 else ann_vol
+            sortino = float(rets.mean() * 252 / downside_std) if downside_std > 0 else 0.0
+
+            # Max drawdown from equity curve
+            equity = (1 + rets).cumprod()
+            roll_max = equity.cummax()
+            drawdown = (equity - roll_max) / roll_max
+            max_dd = float(drawdown.min())
+
+            calmar = float(total_return / abs(max_dd)) if max_dd != 0 else 0.0
+
+            # Wrap in a BacktestResult for compatibility with WalkForwardResult
+            result = BacktestResult(
+                ticker="portfolio",
+                strategy="purged_wf",
+                start_date=rets.index[0],
+                end_date=rets.index[-1],
+                total_return_pct=total_return,
+                buy_hold_return_pct=0.0,
+                sharpe_ratio=sharpe,
+                sortino_ratio=sortino,
+                calmar_ratio=calmar,
+                max_drawdown_pct=max_dd,
+                num_trades=0,
+                win_rate_pct=float((rets > 0).mean() * 100),
+                avg_trade_pct=float(rets.mean()),
+                stop_losses_triggered=0,
+            )
+            results.append(result)
+
+        except Exception as exc:
+            logger.warning("purged_walk_forward: fold %d failed — skipped: %s", k, exc)
+
+    if not results:
+        return WalkForwardResult()
+
+    returns = [r.total_return_pct for r in results]
+    sharpes = [r.sharpe_ratio for r in results]
+    sortinos = [r.sortino_ratio for r in results]
+    drawdowns = [r.max_drawdown_pct for r in results]
+
+    return WalkForwardResult(
+        windows=results,
+        avg_return=float(np.mean(returns)),
+        avg_sharpe=float(np.mean(sharpes)),
+        avg_sortino=float(np.mean(sortinos)),
+        avg_max_drawdown=float(np.mean(drawdowns)),
+        total_trades=0,
+        consistency_score=float(np.mean([1 if r > 0 else 0 for r in returns])),
+    )
+
+
 def build_walk_forward_chart(wf_result: WalkForwardResult):
     """Bar chart of per-window returns."""
     import plotly.graph_objects as go

--- a/data/db.py
+++ b/data/db.py
@@ -110,6 +110,19 @@ def init_db() -> None:
             )
         """)
 
+        # ----- ML model metadata -----
+        conn.execute("""
+            CREATE TABLE IF NOT EXISTS model_metadata (
+                model_name   TEXT    NOT NULL,
+                trained_at   REAL    NOT NULL,   -- Unix timestamp
+                train_ic     REAL,
+                test_ic      REAL,
+                n_tickers    INTEGER,
+                period       TEXT,
+                PRIMARY KEY (model_name, trained_at)
+            )
+        """)
+
         # Seed paper_account if absent
         import os
         starting_cash = float(os.getenv("PAPER_STARTING_CASH", "100000"))

--- a/data/features.py
+++ b/data/features.py
@@ -1,0 +1,137 @@
+"""
+data/features.py — Financial feature engineering for ML alpha models.
+
+Builds a MultiIndex (date, ticker) feature matrix from OHLCV data suitable
+for supervised learning.  All data is fetched via fetch_ohlcv() to benefit
+from the SQLite cache layer.
+
+Feature columns produced
+------------------------
+Input features (cross-sectionally z-scored across tickers per date):
+    ret_1d, ret_5d, ret_10d, ret_21d      — lookback price returns
+    skew_21d                               — 21-day rolling skewness of daily returns
+    kurt_21d                               — 21-day rolling excess kurtosis
+    autocorr_1                             — lag-1 autocorrelation over 21-day window
+    realised_vol_21d                       — annualised realised volatility (21d)
+    vol_ratio_20d                          — Volume / 20-day rolling mean Volume
+    vol_zscore_20d                         — (Volume − mean) / std over 20-day window
+
+Forward return targets (NOT z-scored; NaN for last n rows of each ticker):
+    fwd_ret_1d, fwd_ret_5d, fwd_ret_10d, fwd_ret_21d
+"""
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+from data.fetcher import fetch_ohlcv
+from utils.logger import get_logger
+
+log = get_logger(__name__)
+
+# Minimum rows required to compute any features for a ticker
+_MIN_ROWS = 50
+
+_FEATURE_COLS = [
+    "ret_1d", "ret_5d", "ret_10d", "ret_21d",
+    "skew_21d", "kurt_21d", "autocorr_1", "realised_vol_21d",
+    "vol_ratio_20d", "vol_zscore_20d",
+]
+_FWD_COLS = ["fwd_ret_1d", "fwd_ret_5d", "fwd_ret_10d", "fwd_ret_21d"]
+
+
+def _single_ticker_features(ticker: str, period: str) -> pd.DataFrame | None:
+    """
+    Compute raw (un-z-scored) features for one ticker.
+
+    Returns a date-indexed DataFrame, or None if insufficient data.
+    """
+    df = fetch_ohlcv(ticker, period)
+    if df is None or df.empty or len(df) < _MIN_ROWS:
+        log.warning("features: skipping ticker — insufficient data", ticker=ticker, rows=len(df) if df is not None else 0)
+        return None
+
+    close = df["Close"].astype(float)
+    volume = df["Volume"].astype(float)
+    daily_ret = close.pct_change()
+
+    out = pd.DataFrame(index=df.index)
+
+    # ── Lookback return features ──────────────────────────────────────────────
+    for n in (1, 5, 10, 21):
+        out[f"ret_{n}d"] = close.pct_change(n)
+
+    # ── Rolling statistics on daily returns ───────────────────────────────────
+    roll21 = daily_ret.rolling(21)
+    out["skew_21d"] = roll21.skew()
+    # pandas rolling().kurt() returns excess kurtosis
+    out["kurt_21d"] = roll21.kurt()
+    # Vectorised lag-1 autocorrelation: corr(r_t, r_{t-1}) over 21-day window
+    out["autocorr_1"] = daily_ret.rolling(21).corr(daily_ret.shift(1))
+    out["realised_vol_21d"] = roll21.std() * np.sqrt(252)
+
+    # ── Volume features ───────────────────────────────────────────────────────
+    vol_mean = volume.rolling(20).mean()
+    vol_std = volume.rolling(20).std()
+    out["vol_ratio_20d"] = volume / vol_mean
+    out["vol_zscore_20d"] = (volume - vol_mean) / vol_std.replace(0, np.nan)
+
+    # ── Forward return labels (shift(-n) so label sits on the entry date) ─────
+    for n in (1, 5, 10, 21):
+        out[f"fwd_ret_{n}d"] = close.pct_change(n).shift(-n)
+
+    return out
+
+
+def build_feature_matrix(
+    tickers: list[str],
+    period: str = "2y",
+) -> pd.DataFrame:
+    """
+    Build a MultiIndex (date, ticker) feature matrix.
+
+    Parameters
+    ----------
+    tickers : list of ticker symbols to include
+    period  : yfinance-style period string passed to fetch_ohlcv
+
+    Returns
+    -------
+    pd.DataFrame with MultiIndex(date, ticker).
+    Input features are cross-sectionally z-scored across tickers per date.
+    Forward return columns (fwd_ret_*) are NOT z-scored.
+    """
+    frames: dict[str, pd.DataFrame] = {}
+    for ticker in tickers:
+        feat = _single_ticker_features(ticker, period)
+        if feat is not None and not feat.empty:
+            frames[ticker] = feat
+
+    if not frames:
+        log.warning("build_feature_matrix: no usable tickers", requested=len(tickers))
+        return pd.DataFrame()
+
+    # Stack into MultiIndex (date, ticker) — concat along ticker axis
+    combined = pd.concat(frames, names=["ticker", "date"])
+    # Swap so that (date, ticker) is the natural order
+    combined = combined.swaplevel().sort_index()
+
+    # ── Cross-sectional z-score on input features only ────────────────────────
+    feature_cols_present = [c for c in _FEATURE_COLS if c in combined.columns]
+
+    if len(frames) > 1:
+        # Vectorised approach avoids pandas version issues with transform + function
+        for col in feature_cols_present:
+            col_mean = combined.groupby(level="date")[col].transform("mean")
+            col_std = combined.groupby(level="date")[col].transform("std")
+            # Where std == 0 (all values identical on that date), leave as 0
+            combined[col] = ((combined[col] - col_mean) / col_std.replace(0, np.nan)).fillna(0)
+    # If only 1 ticker, z-score is undefined — leave features unscaled
+
+    log.info(
+        "build_feature_matrix: complete",
+        tickers=len(frames),
+        rows=len(combined),
+        period=period,
+    )
+    return combined

--- a/pages/ml_signals.py
+++ b/pages/ml_signals.py
@@ -1,0 +1,223 @@
+"""
+pages/ml_signals.py — ML Alpha Signals tab.
+
+Exposes the LightGBM alpha model pipeline:
+  - Train / retrain the model on a selected ticker universe
+  - Display training IC / ICIR metrics
+  - Show current alpha scores per ticker (colour-coded bar chart)
+  - Feature importance chart (top 20)
+  - Information Coefficient table for each feature
+
+All heavy computation is wrapped in st.spinner() to avoid blocking the UI.
+Optional-dep imports (lightgbm, etc.) are performed inside button blocks so
+that a missing package does not crash the entire Streamlit app at startup.
+"""
+from __future__ import annotations
+
+import streamlit as st
+import pandas as pd
+import plotly.graph_objects as go
+
+# Reuse the existing 32-ticker universe defined in the screener
+from screener.screener import TICKERS
+
+
+def render() -> None:
+    st.subheader("ML Alpha Signals")
+    st.caption(
+        "LightGBM gradient-boosting model trained cross-sectionally to predict "
+        "5-day forward returns.  Signals are ranked and normalised to [−1, 1] across "
+        "the universe.  Falls back to momentum score when no model has been trained."
+    )
+
+    # ── Universe & period selectors ───────────────────────────────────────────
+    selected_tickers = st.multiselect(
+        "Ticker universe",
+        options=TICKERS,
+        default=TICKERS,
+        key="ml_tickers",
+    )
+    period = st.selectbox(
+        "Training data period",
+        options=["1y", "2y", "5y"],
+        index=1,
+        key="ml_period",
+    )
+
+    if not selected_tickers:
+        st.warning("Select at least one ticker.")
+        return
+
+    # ── Train / Retrain ───────────────────────────────────────────────────────
+    col_btn, col_status = st.columns([2, 3])
+    with col_btn:
+        do_train = st.button("Train / Retrain Model", type="primary", key="ml_train_btn")
+
+    if do_train:
+        with st.spinner("Building feature matrix and training LightGBM alpha model…"):
+            try:
+                from strategies.ml_signal import MLSignal, _LGBM_AVAILABLE
+                if not _LGBM_AVAILABLE:
+                    st.error(
+                        "lightgbm is not installed. "
+                        "Run `pip install lightgbm>=4.0.0` and restart the app."
+                    )
+                else:
+                    model = MLSignal()
+                    metrics = model.train(selected_tickers, period=period)
+                    st.session_state["ml_model_instance"] = model
+                    st.session_state["ml_train_metrics"] = metrics
+                    st.success("Model trained successfully.")
+            except Exception as exc:
+                st.error(f"Training failed: {exc}")
+
+    # ── Training metrics ──────────────────────────────────────────────────────
+    if "ml_train_metrics" in st.session_state:
+        m = st.session_state["ml_train_metrics"]
+        mc1, mc2, mc3, mc4 = st.columns(4)
+        mc1.metric("Train IC",   f"{m.get('train_ic', 0):.4f}")
+        mc2.metric("Test IC",    f"{m.get('test_ic', 0):.4f}")
+        mc3.metric("Train ICIR", f"{m.get('train_icir', 0):.3f}")
+        mc4.metric("Test ICIR",  f"{m.get('test_icir', 0):.3f}")
+
+    st.divider()
+
+    # ── Alpha scores ──────────────────────────────────────────────────────────
+    st.markdown("#### Current Alpha Scores")
+    if st.button("Compute Alpha Scores", key="ml_predict_btn"):
+        with st.spinner("Scoring tickers…"):
+            try:
+                from strategies.ml_signal import MLSignal
+                model = st.session_state.get("ml_model_instance") or MLSignal()
+                scores = model.predict(selected_tickers, period="6mo")
+                st.session_state["ml_scores"] = scores
+            except Exception as exc:
+                st.error(f"Prediction failed: {exc}")
+
+    if "ml_scores" in st.session_state:
+        _render_alpha_chart(st.session_state["ml_scores"])
+
+    st.divider()
+
+    # ── Feature Importance ────────────────────────────────────────────────────
+    st.markdown("#### Feature Importance (Top 20)")
+    with st.spinner("Loading feature importances…"):
+        try:
+            from strategies.ml_signal import MLSignal
+            model = st.session_state.get("ml_model_instance") or MLSignal()
+            fi_df = model.feature_importance()
+        except Exception:
+            fi_df = pd.DataFrame(columns=["feature", "importance"])
+
+    if fi_df.empty:
+        st.info("No trained model found. Click **Train / Retrain Model** to train one.")
+    else:
+        _render_feature_importance(fi_df.head(20))
+
+    st.divider()
+
+    # ── IC / ICIR Table ───────────────────────────────────────────────────────
+    st.markdown("#### Information Coefficient Analysis")
+    st.caption(
+        "IC = Spearman correlation of each feature vs 5-day forward return, averaged "
+        "across dates.  ICIR > 0.5 indicates a consistent signal."
+    )
+    if st.button("Compute IC Table", key="ml_ic_btn"):
+        with st.spinner("Computing IC statistics — this may take a moment…"):
+            try:
+                from data.features import build_feature_matrix
+                from analysis.factor_ic import compute_ic
+                fm = build_feature_matrix(selected_tickers, period=period)
+                if fm.empty:
+                    st.warning("Feature matrix is empty — check tickers and period.")
+                else:
+                    ic_results = compute_ic(fm)
+                    st.session_state["ml_ic_results"] = ic_results
+            except Exception as exc:
+                st.error(f"IC computation failed: {exc}")
+
+    if "ml_ic_results" in st.session_state:
+        _render_ic_table(st.session_state["ml_ic_results"])
+
+
+# ── Private rendering helpers ─────────────────────────────────────────────────
+
+def _render_alpha_chart(scores: dict[str, float]) -> None:
+    """Colour-coded horizontal bar chart of alpha scores."""
+    if not scores:
+        st.info("No scores available.")
+        return
+
+    sorted_items = sorted(scores.items(), key=lambda kv: kv[1], reverse=True)
+    tickers = [t for t, _ in sorted_items]
+    values = [v for _, v in sorted_items]
+    colors = ["#2ecc71" if v >= 0 else "#e74c3c" for v in values]
+
+    fig = go.Figure(go.Bar(
+        x=values,
+        y=tickers,
+        orientation="h",
+        marker_color=colors,
+        text=[f"{v:.3f}" for v in values],
+        textposition="outside",
+    ))
+    fig.update_layout(
+        title="Alpha Scores (ranked, 5-day forward return prediction)",
+        xaxis_title="Score",
+        yaxis_title="Ticker",
+        xaxis=dict(range=[-1.1, 1.1]),
+        height=max(300, len(tickers) * 22),
+        margin=dict(l=80, r=40, t=50, b=40),
+    )
+    st.plotly_chart(fig, use_container_width=True)
+
+
+def _render_feature_importance(fi_df: pd.DataFrame) -> None:
+    """Horizontal bar chart of feature importances."""
+    fig = go.Figure(go.Bar(
+        x=fi_df["importance"].values,
+        y=fi_df["feature"].values,
+        orientation="h",
+        marker_color="#3498db",
+    ))
+    fig.update_layout(
+        title="LightGBM Feature Importances",
+        xaxis_title="Importance (split count)",
+        yaxis_title="Feature",
+        height=max(300, len(fi_df) * 28),
+        margin=dict(l=140, r=40, t=50, b=40),
+        yaxis=dict(autorange="reversed"),
+    )
+    st.plotly_chart(fig, use_container_width=True)
+
+
+def _render_ic_table(ic_results: dict[str, dict]) -> None:
+    """Styled DataFrame: Feature | IC Mean | IC Std | ICIR | p-value | N Dates."""
+    if not ic_results:
+        st.info("No IC results to display.")
+        return
+
+    rows = []
+    for feat, stats in ic_results.items():
+        rows.append({
+            "Feature": feat,
+            "IC Mean": round(stats.get("ic_mean", float("nan")), 4),
+            "IC Std": round(stats.get("ic_std", float("nan")), 4),
+            "ICIR": round(stats.get("icir", float("nan")), 3),
+            "p-value": round(stats.get("p_value", float("nan")), 4),
+            "N Dates": stats.get("n_dates", 0),
+        })
+
+    df = pd.DataFrame(rows).sort_values("ICIR", ascending=False)
+
+    def _colour_icir(val: float) -> str:
+        if pd.isna(val):
+            return ""
+        if val > 0.5:
+            return "background-color: #d5f5e3"
+        if val < -0.5:
+            return "background-color: #fadbd8"
+        return ""
+
+    styled = df.style.applymap(_colour_icir, subset=["ICIR"])
+    st.dataframe(styled, use_container_width=True, hide_index=True)

--- a/pages/ml_signals.py
+++ b/pages/ml_signals.py
@@ -14,9 +14,9 @@ that a missing package does not crash the entire Streamlit app at startup.
 """
 from __future__ import annotations
 
-import streamlit as st
 import pandas as pd
 import plotly.graph_objects as go
+import streamlit as st
 
 # Reuse the existing 32-ticker universe defined in the screener
 from screener.screener import TICKERS
@@ -56,7 +56,7 @@ def render() -> None:
     if do_train:
         with st.spinner("Building feature matrix and training LightGBM alpha model…"):
             try:
-                from strategies.ml_signal import MLSignal, _LGBM_AVAILABLE
+                from strategies.ml_signal import _LGBM_AVAILABLE, MLSignal
                 if not _LGBM_AVAILABLE:
                     st.error(
                         "lightgbm is not installed. "
@@ -125,8 +125,8 @@ def render() -> None:
     if st.button("Compute IC Table", key="ml_ic_btn"):
         with st.spinner("Computing IC statistics — this may take a moment…"):
             try:
-                from data.features import build_feature_matrix
                 from analysis.factor_ic import compute_ic
+                from data.features import build_feature_matrix
                 fm = build_feature_matrix(selected_tickers, period=period)
                 if fm.empty:
                     st.warning("Feature matrix is empty — check tickers and period.")

--- a/requirements.txt
+++ b/requirements.txt
@@ -60,3 +60,5 @@ websockets==16.0
 yfinance==1.2.1
 ccxt>=4.0.0
 structlog>=24.0.0
+lightgbm>=4.0.0
+scipy>=1.11.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -61,4 +61,5 @@ yfinance==1.2.1
 ccxt>=4.0.0
 structlog>=24.0.0
 lightgbm>=4.0.0
+scikit-learn>=1.3.0
 scipy>=1.11.0

--- a/strategies/indicators.py
+++ b/strategies/indicators.py
@@ -8,7 +8,13 @@ Uses the `ta` library (https://github.com/bukosabino/ta) which wraps pandas
 and requires no compiled extensions.
 """
 import pandas as pd
-import ta
+
+try:
+    import ta
+    _TA_AVAILABLE = True
+except ImportError:  # pragma: no cover
+    ta = None  # type: ignore[assignment]
+    _TA_AVAILABLE = False
 
 # ── Individual indicator functions ────────────────────────────────────────────
 

--- a/strategies/ml_signal.py
+++ b/strategies/ml_signal.py
@@ -1,0 +1,337 @@
+"""
+strategies/ml_signal.py — LightGBM alpha model for cross-sectional return prediction.
+
+Trains a gradient-boosting regressor to predict 5-day forward returns across
+a ticker universe.  Produces a ranked signal in [-1, 1] per ticker, suitable
+for long/short or momentum-overlay strategies.
+
+Falls back to a momentum-composite score when lightgbm is not installed or
+no trained model checkpoint is present.
+
+ENV vars
+--------
+    LGBM_ALPHA_MODEL_PATH   path to pickle checkpoint (default: models/lgbm_alpha.pkl)
+
+Optional dependencies (guarded — app loads without them):
+    lightgbm >= 4.0.0
+"""
+from __future__ import annotations
+
+import os
+import pickle
+import time
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+from data.features import build_feature_matrix, _FEATURE_COLS
+from utils.logger import get_logger
+
+log = get_logger(__name__)
+
+# ── Optional LightGBM import ──────────────────────────────────────────────────
+try:
+    import lightgbm as lgb  # type: ignore[import]
+    _LGBM_AVAILABLE = True
+except ImportError:
+    lgb = None  # type: ignore[assignment]
+    _LGBM_AVAILABLE = False
+
+_DEFAULT_MODEL_PATH = os.environ.get("LGBM_ALPHA_MODEL_PATH", "models/lgbm_alpha.pkl")
+_TARGET_COL = "fwd_ret_5d"
+
+_DEFAULT_LGBM_PARAMS: dict = {
+    "n_estimators": 300,
+    "learning_rate": 0.05,
+    "num_leaves": 31,
+    "min_child_samples": 20,
+    "subsample": 0.8,
+    "colsample_bytree": 0.8,
+    "random_state": 42,
+    "verbose": -1,
+}
+
+
+class MLSignal:
+    """
+    LightGBM cross-sectional alpha model.
+
+    Falls back to momentum score when lightgbm is unavailable or no
+    checkpoint has been trained yet.
+
+    Attributes
+    ----------
+    _model      : fitted LGBMRegressor or None
+    _model_path : filesystem path for checkpoint persistence
+    """
+
+    def __init__(self, model_path: str | None = None) -> None:
+        self._model_path: str = model_path or _DEFAULT_MODEL_PATH
+        self._model = None
+        self._load_if_available()
+
+    # ── Model loading ─────────────────────────────────────────────────────────
+
+    def _load_if_available(self) -> None:
+        """Load a persisted model checkpoint if it exists (mirrors rl_sizer.py pattern)."""
+        path = Path(self._model_path)
+        if not path.exists():
+            log.info("ml_signal: no checkpoint found, will use fallback", path=str(path))
+            return
+        try:
+            if not _LGBM_AVAILABLE:
+                log.info("ml_signal: lightgbm not installed, using momentum fallback")
+                return
+            with open(path, "rb") as f:
+                self._model = pickle.load(f)
+            log.info("ml_signal: loaded model checkpoint", path=str(path))
+        except Exception as exc:
+            log.warning("ml_signal: failed to load checkpoint", path=str(path), error=str(exc))
+
+    # ── Training ──────────────────────────────────────────────────────────────
+
+    def train(
+        self,
+        tickers: list[str],
+        period: str = "2y",
+        test_size: float = 0.2,
+        lgbm_params: dict | None = None,
+    ) -> dict[str, float]:
+        """
+        Build feature matrix, train LightGBM, evaluate on held-out test split,
+        persist the model, and write metadata to quant.db.
+
+        Parameters
+        ----------
+        tickers    : universe of tickers to train on
+        period     : yfinance period string for data fetching
+        test_size  : fraction of time series reserved for out-of-sample eval
+                     (chronological split — latest test_size of dates)
+        lgbm_params : override default LGBMRegressor parameters
+
+        Returns
+        -------
+        dict with: train_ic, test_ic, train_icir, test_icir,
+                   n_train_samples, n_test_samples
+
+        Raises
+        ------
+        RuntimeError if lightgbm is not installed
+        """
+        if not _LGBM_AVAILABLE:
+            raise RuntimeError(
+                "lightgbm is not installed. Run: pip install lightgbm>=4.0.0"
+            )
+
+        log.info("ml_signal: building feature matrix", tickers=len(tickers), period=period)
+        fm = build_feature_matrix(tickers, period=period)
+
+        if fm.empty:
+            raise ValueError("Feature matrix is empty — check tickers and period")
+
+        # Drop rows with missing target
+        fm = fm.dropna(subset=[_TARGET_COL])
+        if fm.empty:
+            raise ValueError(f"No rows with non-NaN target '{_TARGET_COL}'")
+
+        # Chronological train/test split on unique dates
+        all_dates = sorted(fm.index.get_level_values("date").unique())
+        split_idx = int(len(all_dates) * (1 - test_size))
+        train_dates = set(all_dates[:split_idx])
+        test_dates = set(all_dates[split_idx:])
+
+        feature_cols = [c for c in _FEATURE_COLS if c in fm.columns]
+
+        train_df = fm[fm.index.get_level_values("date").isin(train_dates)]
+        test_df = fm[fm.index.get_level_values("date").isin(test_dates)]
+
+        X_train = train_df[feature_cols].values
+        y_train = train_df[_TARGET_COL].values
+        X_test = test_df[feature_cols].values
+        y_test = test_df[_TARGET_COL].values
+
+        log.info(
+            "ml_signal: training",
+            n_train=len(X_train),
+            n_test=len(X_test),
+            features=len(feature_cols),
+        )
+
+        params = {**_DEFAULT_LGBM_PARAMS, **(lgbm_params or {})}
+        model = lgb.LGBMRegressor(**params)
+        model.fit(
+            X_train, y_train,
+            callbacks=[lgb.log_evaluation(period=-1)],
+        )
+        self._model = model
+
+        # Evaluate IC on train and test sets
+        train_ic, train_icir = self._eval_ic(model, X_train, y_train)
+        test_ic, test_icir = self._eval_ic(model, X_test, y_test)
+
+        log.info(
+            "ml_signal: training complete",
+            train_ic=round(train_ic, 4),
+            test_ic=round(test_ic, 4),
+        )
+
+        # Persist checkpoint
+        Path(self._model_path).parent.mkdir(parents=True, exist_ok=True)
+        with open(self._model_path, "wb") as f:
+            pickle.dump(model, f)
+        log.info("ml_signal: checkpoint saved", path=self._model_path)
+
+        # Write metadata to quant.db
+        self._write_metadata(
+            n_tickers=len(tickers),
+            period=period,
+            train_ic=train_ic,
+            test_ic=test_ic,
+        )
+
+        return {
+            "train_ic": train_ic,
+            "test_ic": test_ic,
+            "train_icir": train_icir,
+            "test_icir": test_icir,
+            "n_train_samples": int(len(X_train)),
+            "n_test_samples": int(len(X_test)),
+        }
+
+    @staticmethod
+    def _eval_ic(model, X: np.ndarray, y: np.ndarray) -> tuple[float, float]:
+        """Return (IC mean, ICIR) from a predictions array vs actuals."""
+        preds = model.predict(X)
+        # Spearman via rank correlation
+        from analysis.factor_ic import _spearman_corr
+        ic = _spearman_corr(preds, y)
+        # Single-split IC: return IC as mean, ICIR undefined (set to IC)
+        return float(ic), float(ic)
+
+    def _write_metadata(
+        self,
+        n_tickers: int,
+        period: str,
+        train_ic: float,
+        test_ic: float,
+    ) -> None:
+        """Persist training metadata to quant.db model_metadata table."""
+        try:
+            from data.db import get_connection
+            conn = get_connection()
+            with conn:
+                conn.execute(
+                    """
+                    INSERT INTO model_metadata
+                        (model_name, trained_at, train_ic, test_ic, n_tickers, period)
+                    VALUES (?, ?, ?, ?, ?, ?)
+                    """,
+                    ("lgbm_alpha", time.time(), train_ic, test_ic, n_tickers, period),
+                )
+            conn.close()
+        except Exception as exc:
+            log.warning("ml_signal: could not write metadata", error=str(exc))
+
+    # ── Prediction ────────────────────────────────────────────────────────────
+
+    def predict(
+        self,
+        tickers: list[str],
+        period: str = "6mo",
+    ) -> dict[str, float]:
+        """
+        Return ranked alpha scores in [-1, 1] for each ticker.
+
+        Uses the most recent date's rows from the feature matrix.
+        Scores are z-scored raw predictions clipped to [-1, 1].
+
+        Falls back to momentum score when no model is loaded.
+
+        Parameters
+        ----------
+        tickers : universe to score
+        period  : data window for feature computation
+
+        Returns
+        -------
+        dict mapping ticker → score in [-1.0, 1.0]
+        """
+        if self._model is None:
+            return self._momentum_fallback(tickers, period)
+
+        try:
+            fm = build_feature_matrix(tickers, period=period)
+            if fm.empty:
+                return self._momentum_fallback(tickers, period)
+
+            feature_cols = [c for c in _FEATURE_COLS if c in fm.columns]
+
+            # Take the most recent date's rows for each ticker
+            last_date = fm.index.get_level_values("date").max()
+            latest = fm.xs(last_date, level="date")[feature_cols]
+
+            if latest.empty:
+                return self._momentum_fallback(tickers, period)
+
+            raw_preds = self._model.predict(latest.values)
+
+            # Z-score and clip to [-1, 1]
+            std = raw_preds.std()
+            if std == 0:
+                scores = np.zeros(len(raw_preds))
+            else:
+                scores = (raw_preds - raw_preds.mean()) / std
+
+            scores = np.clip(scores, -1.0, 1.0)
+            return {ticker: float(scores[i]) for i, ticker in enumerate(latest.index)}
+
+        except Exception as exc:
+            log.warning("ml_signal.predict: error, falling back to momentum", error=str(exc))
+            return self._momentum_fallback(tickers, period)
+
+    @staticmethod
+    def _momentum_fallback(tickers: list[str], period: str) -> dict[str, float]:
+        """Score each ticker using composite momentum when the ML model is unavailable."""
+        from data.fetcher import fetch_ohlcv
+        from strategies.momentum import compute_momentum_score
+
+        scores: dict[str, float] = {}
+        for ticker in tickers:
+            try:
+                df = fetch_ohlcv(ticker, period)
+                if df is not None and not df.empty:
+                    mom = compute_momentum_score(df)
+                    last_val = mom.dropna().iloc[-1] if not mom.dropna().empty else 0.0
+                    scores[ticker] = float(np.clip(last_val, -1.0, 1.0))
+                else:
+                    scores[ticker] = 0.0
+            except Exception:
+                scores[ticker] = 0.0
+        return scores
+
+    # ── Feature importance ────────────────────────────────────────────────────
+
+    def feature_importance(self) -> pd.DataFrame:
+        """
+        Return a DataFrame of feature importances sorted descending.
+
+        Returns
+        -------
+        pd.DataFrame with columns: feature, importance
+        Empty DataFrame if no model is loaded.
+        """
+        if self._model is None:
+            return pd.DataFrame(columns=["feature", "importance"])
+
+        try:
+            feature_cols = _FEATURE_COLS
+            importances = self._model.feature_importances_
+            df = pd.DataFrame({
+                "feature": feature_cols[:len(importances)],
+                "importance": importances,
+            })
+            return df.sort_values("importance", ascending=False).reset_index(drop=True)
+        except Exception as exc:
+            log.warning("ml_signal.feature_importance: error", error=str(exc))
+            return pd.DataFrame(columns=["feature", "importance"])

--- a/strategies/ml_signal.py
+++ b/strategies/ml_signal.py
@@ -25,7 +25,7 @@ from pathlib import Path
 import numpy as np
 import pandas as pd
 
-from data.features import build_feature_matrix, _FEATURE_COLS
+from data.features import _FEATURE_COLS, build_feature_matrix
 from utils.logger import get_logger
 
 log = get_logger(__name__)

--- a/strategies/ml_signal.py
+++ b/strategies/ml_signal.py
@@ -160,10 +160,7 @@ class MLSignal:
 
         params = {**_DEFAULT_LGBM_PARAMS, **(lgbm_params or {})}
         model = lgb.LGBMRegressor(**params)
-        model.fit(
-            X_train, y_train,
-            callbacks=[lgb.log_evaluation(period=-1)],
-        )
+        model.fit(X_train, y_train)
         self._model = model
 
         # Evaluate IC on train and test sets

--- a/tests/test_factor_ic.py
+++ b/tests/test_factor_ic.py
@@ -1,0 +1,210 @@
+"""Tests for analysis/factor_ic.py — Information Coefficient analysis."""
+import os
+import sys
+from unittest.mock import patch
+
+import numpy as np
+import pandas as pd
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from analysis.factor_ic import (
+    MEANINGFUL_ICIR,
+    _spearman_corr,
+    _ttest_1samp_pvalue,
+    compute_ic,
+    compute_ic_decay,
+)
+
+
+# ── Helpers ────────────────────────────────────────────────────────────────────
+
+def _make_feature_matrix(n_dates: int = 60, n_tickers: int = 10) -> pd.DataFrame:
+    """Build a synthetic MultiIndex (date, ticker) feature matrix."""
+    np.random.seed(0)
+    dates = pd.date_range("2023-01-01", periods=n_dates, freq="B")
+    tickers = [f"T{i:02d}" for i in range(n_tickers)]
+
+    rows = []
+    for d in dates:
+        for t in tickers:
+            rows.append({
+                "date": d,
+                "ticker": t,
+                "ret_5d": np.random.randn(),
+                "realised_vol_21d": abs(np.random.randn()) * 0.2,
+                "fwd_ret_1d": np.random.randn() * 0.01,
+                "fwd_ret_5d": np.random.randn() * 0.02,
+                "fwd_ret_10d": np.random.randn() * 0.03,
+                "fwd_ret_21d": np.random.randn() * 0.04,
+            })
+
+    df = pd.DataFrame(rows).set_index(["date", "ticker"])
+    return df
+
+
+def _make_perfect_matrix(n_dates: int = 50, n_tickers: int = 10) -> pd.DataFrame:
+    """Feature perfectly predicts fwd_ret_5d → IC ≈ 1."""
+    np.random.seed(1)
+    dates = pd.date_range("2023-01-01", periods=n_dates, freq="B")
+    tickers = [f"T{i:02d}" for i in range(n_tickers)]
+
+    rows = []
+    for d in dates:
+        values = np.random.randn(n_tickers)
+        for i, t in enumerate(tickers):
+            rows.append({
+                "date": d, "ticker": t,
+                "perfect_feature": values[i],
+                "fwd_ret_5d": values[i] + np.random.randn() * 0.001,  # near-perfect
+            })
+
+    return pd.DataFrame(rows).set_index(["date", "ticker"])
+
+
+# ── _spearman_corr ─────────────────────────────────────────────────────────────
+
+def test_spearman_corr_perfect_positive():
+    x = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+    r = _spearman_corr(x, x)
+    assert abs(r - 1.0) < 1e-6
+
+
+def test_spearman_corr_perfect_negative():
+    x = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+    r = _spearman_corr(x, -x)
+    assert abs(r + 1.0) < 1e-6
+
+
+def test_spearman_corr_too_short():
+    r = _spearman_corr(np.array([1.0]), np.array([1.0]))
+    assert np.isnan(r)
+
+
+# ── _ttest_1samp_pvalue ────────────────────────────────────────────────────────
+
+def test_ttest_pvalue_near_zero_for_strong_signal():
+    """Large consistent IC series should yield very small p-value."""
+    ic_series = np.ones(100) * 0.3  # constant non-zero mean
+    p = _ttest_1samp_pvalue(ic_series)
+    assert p < 0.01
+
+
+def test_ttest_pvalue_near_one_for_noise():
+    """Near-zero mean IC series should have high p-value."""
+    np.random.seed(99)
+    ic_series = np.random.randn(200) * 0.001  # mean ≈ 0
+    p = _ttest_1samp_pvalue(ic_series)
+    assert p > 0.3
+
+
+# ── compute_ic ─────────────────────────────────────────────────────────────────
+
+def test_compute_ic_returns_dict_keys():
+    fm = _make_feature_matrix()
+    results = compute_ic(fm, feature_cols=["ret_5d"])
+    assert "ret_5d" in results
+    result = results["ret_5d"]
+    for key in ("ic_mean", "ic_std", "icir", "p_value", "n_dates"):
+        assert key in result, f"Missing key: {key}"
+
+
+def test_compute_ic_range():
+    """IC mean must lie in [-1, 1]."""
+    fm = _make_feature_matrix()
+    results = compute_ic(fm, feature_cols=["ret_5d", "realised_vol_21d"])
+    for feat, stats in results.items():
+        ic = stats["ic_mean"]
+        if not np.isnan(ic):
+            assert -1.0 <= ic <= 1.0, f"{feat}: IC {ic} out of [-1, 1]"
+
+
+def test_compute_ic_icir_formula():
+    """ICIR = ic_mean / ic_std where ic_std != 0."""
+    fm = _make_feature_matrix(n_dates=80, n_tickers=12)
+    results = compute_ic(fm, feature_cols=["ret_5d"])
+    stats = results["ret_5d"]
+    if stats["ic_std"] != 0 and not np.isnan(stats["ic_std"]):
+        expected_icir = stats["ic_mean"] / stats["ic_std"]
+        assert abs(stats["icir"] - expected_icir) < 1e-9
+
+
+def test_compute_ic_perfect_predictor():
+    """A feature equal to forward returns should have IC ≈ 1."""
+    fm = _make_perfect_matrix(n_dates=60, n_tickers=10)
+    results = compute_ic(fm, forward_return_col="fwd_ret_5d",
+                         feature_cols=["perfect_feature"])
+    ic = results["perfect_feature"]["ic_mean"]
+    assert not np.isnan(ic)
+    assert ic > 0.90, f"Expected IC ≈ 1 for perfect predictor, got {ic:.4f}"
+
+
+def test_compute_ic_random_noise():
+    """A random feature should have IC ≈ 0 and high p-value."""
+    fm = _make_feature_matrix(n_dates=100, n_tickers=15)
+    results = compute_ic(fm, feature_cols=["realised_vol_21d"])
+    stats = results["realised_vol_21d"]
+    if not np.isnan(stats["ic_mean"]):
+        assert abs(stats["ic_mean"]) < 0.4, (
+            f"Random feature IC too large: {stats['ic_mean']:.4f}"
+        )
+
+
+def test_compute_ic_empty_matrix():
+    results = compute_ic(pd.DataFrame())
+    assert results == {}
+
+
+def test_compute_ic_missing_target():
+    fm = _make_feature_matrix()
+    results = compute_ic(fm, forward_return_col="nonexistent_col")
+    assert results == {}
+
+
+def test_compute_ic_skips_dates_with_few_tickers():
+    """Dates with fewer than 5 tickers should not contribute to IC series."""
+    # Build a matrix where most dates have < 5 tickers
+    dates = pd.date_range("2023-01-01", periods=30, freq="B")
+    rows = []
+    for d in dates:
+        for t in ["T1", "T2"]:  # only 2 tickers per date — below threshold
+            rows.append({"date": d, "ticker": t,
+                         "ret_5d": np.random.randn(),
+                         "fwd_ret_5d": np.random.randn()})
+    fm = pd.DataFrame(rows).set_index(["date", "ticker"])
+
+    results = compute_ic(fm, feature_cols=["ret_5d"])
+    # n_dates should be 0 since every date has < 5 tickers
+    assert results["ret_5d"]["n_dates"] == 0
+
+
+def test_compute_ic_default_excludes_fwd_ret_columns():
+    """When feature_cols=None, fwd_ret_* columns should not appear in results."""
+    fm = _make_feature_matrix()
+    results = compute_ic(fm)
+    for key in results:
+        assert not key.startswith("fwd_ret_"), f"fwd_ret column leaked into IC results: {key}"
+
+
+# ── compute_ic_decay ───────────────────────────────────────────────────────────
+
+def test_compute_ic_decay_horizons():
+    fm = _make_feature_matrix(n_dates=80, n_tickers=10)
+    horizons = [1, 5, 10, 21]
+    decay = compute_ic_decay(fm, feature_col="ret_5d", horizons=horizons)
+    assert set(decay.keys()) == set(horizons)
+    for h in horizons:
+        assert "ic_mean" in decay[h]
+
+
+def test_compute_ic_decay_default_horizons():
+    fm = _make_feature_matrix(n_dates=80, n_tickers=10)
+    decay = compute_ic_decay(fm, feature_col="ret_5d")
+    assert set(decay.keys()) == {1, 5, 10, 21}
+
+
+# ── MEANINGFUL_ICIR constant ───────────────────────────────────────────────────
+
+def test_meaningful_icir_constant():
+    assert MEANINGFUL_ICIR == 0.5

--- a/tests/test_factor_ic.py
+++ b/tests/test_factor_ic.py
@@ -1,11 +1,9 @@
 """Tests for analysis/factor_ic.py — Information Coefficient analysis."""
 import os
 import sys
-from unittest.mock import patch
 
 import numpy as np
 import pandas as pd
-import pytest
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
@@ -16,7 +14,6 @@ from analysis.factor_ic import (
     compute_ic,
     compute_ic_decay,
 )
-
 
 # ── Helpers ────────────────────────────────────────────────────────────────────
 

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -1,0 +1,151 @@
+"""Tests for data/features.py — feature engineering framework."""
+import os
+import sys
+from unittest.mock import patch
+
+import numpy as np
+import pandas as pd
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from data.features import build_feature_matrix, _FEATURE_COLS, _FWD_COLS, _MIN_ROWS
+
+
+def _make_ohlcv(n: int = 200, seed: int = 42, start: str = "2022-01-01") -> pd.DataFrame:
+    np.random.seed(seed)
+    close = 100 + np.cumsum(np.random.randn(n) * 0.5)
+    idx = pd.date_range(start, periods=n, freq="B")
+    return pd.DataFrame({
+        "Open": close * 0.99,
+        "High": close * 1.01,
+        "Low": close * 0.98,
+        "Close": close,
+        "Volume": np.random.randint(1_000_000, 5_000_000, n).astype(float),
+    }, index=idx)
+
+
+def _mock_fetch(ticker: str, period: str) -> pd.DataFrame:
+    """Return synthetic OHLCV regardless of ticker/period."""
+    seed = abs(hash(ticker)) % 2**16
+    return _make_ohlcv(n=252, seed=seed)
+
+
+# ── build_feature_matrix ───────────────────────────────────────────────────────
+
+def test_build_feature_matrix_shape():
+    tickers = ["AAPL", "MSFT", "GOOGL"]
+    with patch("data.features.fetch_ohlcv", side_effect=_mock_fetch):
+        fm = build_feature_matrix(tickers, period="2y")
+
+    assert not fm.empty
+    assert fm.index.names == ["date", "ticker"]
+    for col in _FEATURE_COLS:
+        assert col in fm.columns, f"Missing feature column: {col}"
+    for col in _FWD_COLS:
+        assert col in fm.columns, f"Missing forward-return column: {col}"
+
+
+def test_build_feature_matrix_ticker_in_index():
+    tickers = ["AAPL", "MSFT"]
+    with patch("data.features.fetch_ohlcv", side_effect=_mock_fetch):
+        fm = build_feature_matrix(tickers, period="2y")
+
+    index_tickers = set(fm.index.get_level_values("ticker").unique())
+    assert index_tickers == {"AAPL", "MSFT"}
+
+
+def test_forward_return_no_lookahead():
+    """fwd_ret_5d on date t should equal close[t+5] / close[t+1] - 1."""
+    tickers = ["AAPL"]
+    with patch("data.features.fetch_ohlcv", side_effect=_mock_fetch):
+        fm = build_feature_matrix(tickers, period="2y")
+
+    aapl = fm.xs("AAPL", level="ticker")
+
+    # Find a row with a valid fwd_ret_5d
+    valid = aapl["fwd_ret_5d"].dropna()
+    assert len(valid) > 10, "Expected forward returns to exist"
+
+    # The label must be negative or positive but well-formed (not an obviously wrong sign)
+    # Main assertion: fwd_ret_5d is not equal to ret_5d (which would be a lookahead)
+    # (they can occasionally be equal by coincidence, so check overall correlation < 1)
+    overlap = aapl[["ret_5d", "fwd_ret_5d"]].dropna()
+    corr = overlap["ret_5d"].corr(overlap["fwd_ret_5d"])
+    assert corr < 0.99, "fwd_ret_5d appears to be identical to ret_5d (possible lookahead)"
+
+
+def test_cross_sectional_zscore_mean_near_zero():
+    """Mean of any feature across tickers on a given date should be ~0 after z-scoring."""
+    tickers = ["AAPL", "MSFT", "GOOGL", "AMZN", "META"]
+    with patch("data.features.fetch_ohlcv", side_effect=_mock_fetch):
+        fm = build_feature_matrix(tickers, period="2y")
+
+    # Sample a date with all tickers present
+    date_counts = fm.groupby(level="date").size()
+    full_dates = date_counts[date_counts == len(tickers)].index
+    if len(full_dates) == 0:
+        pytest.skip("No date with all tickers — skip z-score check")
+
+    sample_date = full_dates[len(full_dates) // 2]
+    group = fm.xs(sample_date, level="date")
+
+    for col in ["ret_5d", "realised_vol_21d", "vol_ratio_20d"]:
+        if col in group.columns:
+            col_vals = group[col].dropna()
+            if len(col_vals) >= 3:
+                assert abs(col_vals.mean()) < 0.5, (
+                    f"Cross-sectional mean of {col} on {sample_date} = {col_vals.mean():.4f}, "
+                    f"expected near 0 after z-scoring"
+                )
+
+
+def test_insufficient_data_ticker_dropped(caplog):
+    """A ticker returning fewer rows than _MIN_ROWS should be excluded."""
+    def _short_fetch(ticker: str, period: str) -> pd.DataFrame:
+        if ticker == "SHORT":
+            return _make_ohlcv(n=10, seed=1)  # below _MIN_ROWS
+        return _make_ohlcv(n=252, seed=42)
+
+    import logging
+    with patch("data.features.fetch_ohlcv", side_effect=_short_fetch):
+        with caplog.at_level(logging.WARNING, logger="data.features"):
+            fm = build_feature_matrix(["AAPL", "SHORT"], period="2y")
+
+    index_tickers = set(fm.index.get_level_values("ticker").unique())
+    assert "SHORT" not in index_tickers
+    assert "AAPL" in index_tickers
+
+
+def test_all_bad_tickers_returns_empty():
+    """If all tickers fail, build_feature_matrix returns an empty DataFrame."""
+    def _empty_fetch(ticker: str, period: str) -> pd.DataFrame:
+        return pd.DataFrame()
+
+    with patch("data.features.fetch_ohlcv", side_effect=_empty_fetch):
+        fm = build_feature_matrix(["AAPL", "MSFT"], period="2y")
+
+    assert fm.empty
+
+
+def test_volume_ratio_formula():
+    """vol_ratio_20d should be Volume / 20-day rolling mean Volume (un-z-scored for 1 ticker)."""
+    tickers = ["SOLO"]  # single ticker so z-score is skipped
+    with patch("data.features.fetch_ohlcv", side_effect=_mock_fetch):
+        fm = build_feature_matrix(tickers, period="2y")
+
+    solo = fm.xs("SOLO", level="ticker")
+    # Verify non-null and positive (Volume > 0 always)
+    valid = solo["vol_ratio_20d"].dropna()
+    assert len(valid) > 0
+    assert (valid > 0).all(), "vol_ratio_20d should be positive"
+
+
+def test_realised_vol_is_finite():
+    """After cross-sectional z-scoring realised_vol_21d should be finite (not inf/NaN) where present."""
+    tickers = ["AAPL", "MSFT"]
+    with patch("data.features.fetch_ohlcv", side_effect=_mock_fetch):
+        fm = build_feature_matrix(tickers, period="2y")
+
+    valid = fm["realised_vol_21d"].dropna()
+    assert np.isfinite(valid).all(), "Z-scored realised vol contains non-finite values"

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -9,7 +9,7 @@ import pytest
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
-from data.features import build_feature_matrix, _FEATURE_COLS, _FWD_COLS, _MIN_ROWS
+from data.features import _FEATURE_COLS, _FWD_COLS, build_feature_matrix
 
 
 def _make_ohlcv(n: int = 200, seed: int = 42, start: str = "2022-01-01") -> pd.DataFrame:

--- a/tests/test_ml_signal.py
+++ b/tests/test_ml_signal.py
@@ -2,7 +2,7 @@
 import os
 import sys
 import tempfile
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import numpy as np
 import pandas as pd
@@ -84,6 +84,164 @@ def test_feature_importance_no_model_returns_empty_df():
     assert isinstance(fi, pd.DataFrame)
     assert fi.empty
     assert list(fi.columns) == ["feature", "importance"]
+
+
+# ── MLSignal — predict with injected mock model (no LightGBM needed) ─────────
+
+def _make_mock_model(n_features: int | None = None):
+    """Create a mock model that behaves like a fitted LGBMRegressor."""
+    if n_features is None:
+        n_features = len(_FEATURE_COLS)
+    mock = MagicMock()
+    mock.predict.return_value = np.linspace(-0.05, 0.05, 4)
+    mock.feature_importances_ = np.arange(n_features, 0, -1, dtype=float)
+    return mock
+
+
+def test_predict_with_mock_model_returns_scores():
+    """predict() with an injected model should return float scores in [-1, 1]."""
+    fm = _make_feature_matrix(n_dates=20, n_tickers=4)
+    mock_model = _make_mock_model()
+
+    with patch("strategies.ml_signal.build_feature_matrix", return_value=fm):
+        model = MLSignal(model_path="/tmp/nonexistent_mock.pkl")
+        model._model = mock_model
+        tickers = list(fm.index.get_level_values("ticker").unique())
+        scores = model.predict(tickers, period="6mo")
+
+    assert len(scores) > 0
+    for score in scores.values():
+        assert -1.0 <= score <= 1.0
+
+
+def test_predict_with_mock_model_all_equal_predictions():
+    """When all raw predictions are equal, z-score is 0 and scores are all 0."""
+    fm = _make_feature_matrix(n_dates=20, n_tickers=4)
+    mock_model = _make_mock_model()
+    mock_model.predict.return_value = np.ones(4) * 0.03  # all same → std = 0
+
+    with patch("strategies.ml_signal.build_feature_matrix", return_value=fm):
+        model = MLSignal(model_path="/tmp/nonexistent_mock2.pkl")
+        model._model = mock_model
+        tickers = list(fm.index.get_level_values("ticker").unique())
+        scores = model.predict(tickers, period="6mo")
+
+    for score in scores.values():
+        assert score == pytest.approx(0.0)
+
+
+def test_predict_with_mock_model_exception_falls_back():
+    """When model.predict raises, should fall back to momentum."""
+    fm = _make_feature_matrix(n_dates=20, n_tickers=2)
+    mock_model = _make_mock_model()
+    mock_model.predict.side_effect = RuntimeError("model crashed")
+
+    with patch("strategies.ml_signal.build_feature_matrix", return_value=fm), \
+         patch("data.fetcher.fetch_ohlcv", side_effect=_mock_fetch):
+        model = MLSignal(model_path="/tmp/nonexistent_mock3.pkl")
+        model._model = mock_model
+        tickers = list(fm.index.get_level_values("ticker").unique())
+        scores = model.predict(tickers, period="6mo")
+
+    # Falls back to momentum — scores still valid
+    assert set(scores.keys()) == set(tickers)
+    for score in scores.values():
+        assert -1.0 <= score <= 1.0
+
+
+def test_predict_with_mock_model_empty_fm_falls_back():
+    """When feature matrix is empty with a model loaded, falls back to momentum."""
+    with patch("strategies.ml_signal.build_feature_matrix", return_value=pd.DataFrame()), \
+         patch("data.fetcher.fetch_ohlcv", side_effect=_mock_fetch):
+        model = MLSignal(model_path="/tmp/nonexistent_mock4.pkl")
+        model._model = _make_mock_model()
+        scores = model.predict(["AAPL", "MSFT"], period="6mo")
+
+    assert set(scores.keys()) == {"AAPL", "MSFT"}
+
+
+def test_predict_with_mock_model_no_feature_cols_falls_back():
+    """When latest feature slice is empty (no matching feature cols), falls back."""
+    # Build FM without any of the _FEATURE_COLS columns
+    fm = _make_feature_matrix(n_dates=10, n_tickers=2)
+    # Remove all feature columns so feature_cols = [] → latest is empty
+    only_target = fm[[_TARGET_COL]]
+
+    with patch("strategies.ml_signal.build_feature_matrix", return_value=only_target), \
+         patch("data.fetcher.fetch_ohlcv", side_effect=_mock_fetch):
+        model = MLSignal(model_path="/tmp/nonexistent_mock5.pkl")
+        model._model = _make_mock_model()
+        tickers = list(only_target.index.get_level_values("ticker").unique())
+        scores = model.predict(tickers, period="6mo")
+
+    assert set(scores.keys()) == set(tickers)
+    for score in scores.values():
+        assert -1.0 <= score <= 1.0
+
+
+def test_write_metadata_success():
+    """_write_metadata should call conn.close() on the happy path."""
+    model = MLSignal(model_path="/tmp/nonexistent_meta.pkl")
+    with patch("data.db.get_connection") as mock_conn:
+        conn_obj = MagicMock()
+        conn_obj.__enter__ = MagicMock(return_value=conn_obj)
+        conn_obj.__exit__ = MagicMock(return_value=False)
+        mock_conn.return_value = conn_obj
+        model._write_metadata(5, "2y", 0.05, 0.03)
+    conn_obj.close.assert_called_once()
+
+
+def test_write_metadata_handles_missing_table():
+    """_write_metadata should not raise even when the DB table doesn't exist."""
+    model = MLSignal(model_path="/tmp/nonexistent_meta.pkl")
+    with patch("data.db.get_connection") as mock_conn:
+        conn_obj = MagicMock()
+        conn_obj.__enter__ = MagicMock(return_value=conn_obj)
+        conn_obj.__exit__ = MagicMock(return_value=False)
+        conn_obj.execute.side_effect = Exception("no such table: model_metadata")
+        mock_conn.return_value = conn_obj
+        # Should not raise
+        model._write_metadata(5, "2y", 0.05, 0.03)
+
+
+def test_momentum_fallback_with_none_fetch():
+    """Momentum fallback returns 0.0 when fetch_ohlcv returns None."""
+    with patch("data.fetcher.fetch_ohlcv", return_value=None):
+        model = MLSignal(model_path="/tmp/nonexistent_fallback.pkl")
+        scores = model._momentum_fallback(["AAPL", "MSFT"], "6mo")
+    assert set(scores.keys()) == {"AAPL", "MSFT"}
+    for score in scores.values():
+        assert score == 0.0
+
+
+def test_momentum_fallback_with_fetch_exception():
+    """Momentum fallback returns 0.0 when fetch_ohlcv raises."""
+    with patch("data.fetcher.fetch_ohlcv", side_effect=RuntimeError("network error")):
+        model = MLSignal(model_path="/tmp/nonexistent_fallback2.pkl")
+        scores = model._momentum_fallback(["AAPL"], "6mo")
+    assert scores["AAPL"] == 0.0
+
+
+def test_feature_importance_with_mock_model_exception():
+    """feature_importance() returns empty DataFrame when model raises AttributeError."""
+    model = MLSignal(model_path="/tmp/nonexistent_fi2.pkl")
+    # spec=[] causes AttributeError on any attribute access, triggering the except handler
+    mock_model = MagicMock(spec=[])
+    model._model = mock_model
+    fi = model.feature_importance()
+    assert isinstance(fi, pd.DataFrame)
+    assert fi.empty
+
+
+def test_feature_importance_with_mock_model():
+    """feature_importance() returns sorted DataFrame when model is injected."""
+    model = MLSignal(model_path="/tmp/nonexistent_fi.pkl")
+    model._model = _make_mock_model()
+    fi = model.feature_importance()
+    assert not fi.empty
+    assert set(fi.columns) == {"feature", "importance"}
+    assert list(fi["importance"]) == sorted(fi["importance"], reverse=True)
+    assert (fi["importance"] >= 0).all()
 
 
 # ── MLSignal — with LightGBM (skipped if not installed) ───────────────────────

--- a/tests/test_ml_signal.py
+++ b/tests/test_ml_signal.py
@@ -1,0 +1,244 @@
+"""Tests for strategies/ml_signal.py and backtester/walk_forward.purged_walk_forward."""
+import os
+import sys
+import tempfile
+from unittest.mock import patch, MagicMock
+
+import numpy as np
+import pandas as pd
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from strategies.ml_signal import MLSignal, _LGBM_AVAILABLE, _FEATURE_COLS, _TARGET_COL
+from backtester.walk_forward import purged_walk_forward, WalkForwardResult
+
+
+# ── Helpers ────────────────────────────────────────────────────────────────────
+
+def _make_ohlcv(n: int = 252, seed: int = 42) -> pd.DataFrame:
+    np.random.seed(seed)
+    close = 100 + np.cumsum(np.random.randn(n) * 0.5)
+    idx = pd.date_range("2022-01-01", periods=n, freq="B")
+    return pd.DataFrame({
+        "Open": close * 0.99, "High": close * 1.01,
+        "Low": close * 0.98, "Close": close,
+        "Volume": np.random.randint(1_000_000, 5_000_000, n).astype(float),
+    }, index=idx)
+
+
+def _make_feature_matrix(n_dates: int = 120, n_tickers: int = 5,
+                          include_target: bool = True) -> pd.DataFrame:
+    np.random.seed(0)
+    dates = pd.date_range("2022-01-01", periods=n_dates, freq="B")
+    tickers = [f"T{i:02d}" for i in range(n_tickers)]
+    rows = []
+    for d in dates:
+        for t in tickers:
+            row = {"date": d, "ticker": t}
+            for col in _FEATURE_COLS:
+                row[col] = np.random.randn()
+            if include_target:
+                row[_TARGET_COL] = np.random.randn() * 0.02
+            rows.append(row)
+    df = pd.DataFrame(rows).set_index(["date", "ticker"])
+    # Drop last 5 dates' targets to simulate real NaN forward returns
+    if include_target:
+        last_5_dates = sorted(df.index.get_level_values("date").unique())[-5:]
+        df.loc[df.index.get_level_values("date").isin(last_5_dates), _TARGET_COL] = np.nan
+    return df
+
+
+def _mock_fetch(ticker: str, period: str) -> pd.DataFrame:
+    seed = abs(hash(ticker)) % 2**16
+    return _make_ohlcv(252, seed)
+
+
+# ── MLSignal — no-model fallback ───────────────────────────────────────────────
+
+def test_predict_fallback_returns_valid_range():
+    """Without a trained model, predict() should fall back to momentum and return [-1, 1]."""
+    tickers = ["AAPL", "MSFT", "GOOGL"]
+    with patch("strategies.ml_signal.build_feature_matrix") as mock_fm, \
+         patch("data.fetcher.fetch_ohlcv", side_effect=_mock_fetch):
+        # Force model-path to non-existent so no checkpoint loads
+        model = MLSignal(model_path="/tmp/nonexistent_lgbm_test.pkl")
+        mock_fm.return_value = pd.DataFrame()  # empty → triggers fallback
+        scores = model.predict(tickers, period="6mo")
+
+    assert set(scores.keys()) == set(tickers)
+    for t, score in scores.items():
+        assert -1.0 <= score <= 1.0, f"{t}: score {score} out of [-1, 1]"
+
+
+def test_predict_fallback_keys_match_tickers():
+    tickers = ["AAPL", "MSFT"]
+    with patch("data.fetcher.fetch_ohlcv", side_effect=_mock_fetch):
+        model = MLSignal(model_path="/tmp/nonexistent_lgbm_test2.pkl")
+        scores = model.predict(tickers, period="6mo")
+    assert set(scores.keys()) == set(tickers)
+
+
+def test_feature_importance_no_model_returns_empty_df():
+    model = MLSignal(model_path="/tmp/nonexistent_lgbm_test3.pkl")
+    fi = model.feature_importance()
+    assert isinstance(fi, pd.DataFrame)
+    assert fi.empty
+    assert list(fi.columns) == ["feature", "importance"]
+
+
+# ── MLSignal — with LightGBM (skipped if not installed) ───────────────────────
+
+@pytest.mark.skipif(not _LGBM_AVAILABLE, reason="lightgbm not installed")
+def test_train_and_predict_with_lgbm():
+    """Full train → predict cycle with mocked feature matrix."""
+    tickers = [f"T{i}" for i in range(8)]
+    fm = _make_feature_matrix(n_dates=150, n_tickers=8)
+
+    with patch("strategies.ml_signal.build_feature_matrix", return_value=fm), \
+         patch("strategies.ml_signal.MLSignal._write_metadata"):
+        with tempfile.NamedTemporaryFile(suffix=".pkl", delete=False) as f:
+            tmp_path = f.name
+
+        model = MLSignal(model_path=tmp_path)
+        metrics = model.train(tickers, period="2y")
+
+    assert "train_ic" in metrics
+    assert "test_ic" in metrics
+    assert isinstance(metrics["train_ic"], float)
+    assert isinstance(metrics["test_ic"], float)
+    assert metrics["n_train_samples"] > 0
+    assert metrics["n_test_samples"] > 0
+
+
+@pytest.mark.skipif(not _LGBM_AVAILABLE, reason="lightgbm not installed")
+def test_model_persist_and_reload():
+    """train() saves checkpoint; a new MLSignal instance at the same path loads it."""
+    tickers = [f"T{i}" for i in range(6)]
+    fm = _make_feature_matrix(n_dates=120, n_tickers=6)
+
+    with tempfile.NamedTemporaryFile(suffix=".pkl", delete=False) as f:
+        tmp_path = f.name
+
+    with patch("strategies.ml_signal.build_feature_matrix", return_value=fm), \
+         patch("strategies.ml_signal.MLSignal._write_metadata"):
+        model1 = MLSignal(model_path=tmp_path)
+        model1.train(tickers, period="2y")
+
+    # New instance should auto-load the checkpoint
+    model2 = MLSignal(model_path=tmp_path)
+    assert model2._model is not None
+
+    os.unlink(tmp_path)
+
+
+@pytest.mark.skipif(not _LGBM_AVAILABLE, reason="lightgbm not installed")
+def test_feature_importance_after_train():
+    tickers = [f"T{i}" for i in range(6)]
+    fm = _make_feature_matrix(n_dates=120, n_tickers=6)
+
+    with patch("strategies.ml_signal.build_feature_matrix", return_value=fm), \
+         patch("strategies.ml_signal.MLSignal._write_metadata"):
+        with tempfile.NamedTemporaryFile(suffix=".pkl", delete=False) as f:
+            tmp_path = f.name
+        model = MLSignal(model_path=tmp_path)
+        model.train(tickers, period="2y")
+
+    fi = model.feature_importance()
+    assert not fi.empty
+    assert set(fi.columns) == {"feature", "importance"}
+    # Importances should be non-negative and sorted descending
+    assert (fi["importance"] >= 0).all()
+    assert list(fi["importance"]) == sorted(fi["importance"], reverse=True)
+
+    os.unlink(tmp_path)
+
+
+# ── purged_walk_forward ────────────────────────────────────────────────────────
+
+def _make_wf_feature_matrix(n_dates: int = 200, n_tickers: int = 4) -> pd.DataFrame:
+    np.random.seed(7)
+    dates = pd.date_range("2022-01-01", periods=n_dates, freq="B")
+    tickers = [f"T{i}" for i in range(n_tickers)]
+    rows = []
+    for d in dates:
+        for t in tickers:
+            rows.append({"date": d, "ticker": t,
+                         "ret_5d": np.random.randn(),
+                         _TARGET_COL: np.random.randn() * 0.02})
+    return pd.DataFrame(rows).set_index(["date", "ticker"])
+
+
+def _dummy_strategy(train_seg: pd.DataFrame, test_seg: pd.DataFrame) -> pd.Series:
+    """Always returns a flat 0.001 daily return series over test dates."""
+    test_dates = sorted(test_seg.index.get_level_values("date").unique())
+    return pd.Series(0.001, index=pd.DatetimeIndex(test_dates))
+
+
+def test_purged_walk_forward_returns_result():
+    fm = _make_wf_feature_matrix(n_dates=200, n_tickers=4)
+    result = purged_walk_forward(_dummy_strategy, fm, n_splits=5, embargo_pct=0.01)
+    assert isinstance(result, WalkForwardResult)
+
+
+def test_purged_walk_forward_has_windows():
+    fm = _make_wf_feature_matrix(n_dates=200, n_tickers=4)
+    result = purged_walk_forward(_dummy_strategy, fm, n_splits=5, embargo_pct=0.01)
+    assert len(result.windows) > 0
+
+
+def test_purged_walk_forward_embargo_gap():
+    """Train end date should be strictly before test start date by at least embargo_bars."""
+    all_train_ends: list[pd.Timestamp] = []
+    all_test_starts: list[pd.Timestamp] = []
+
+    def _recording_strategy(train_seg: pd.DataFrame, test_seg: pd.DataFrame) -> pd.Series:
+        train_dates = sorted(train_seg.index.get_level_values("date").unique())
+        test_dates = sorted(test_seg.index.get_level_values("date").unique())
+        all_train_ends.append(train_dates[-1])
+        all_test_starts.append(test_dates[0])
+        return pd.Series(0.0, index=pd.DatetimeIndex(test_dates))
+
+    fm = _make_wf_feature_matrix(n_dates=200, n_tickers=4)
+    purged_walk_forward(_recording_strategy, fm, n_splits=5, embargo_pct=0.02)
+
+    for train_end, test_start in zip(all_train_ends, all_test_starts):
+        assert train_end < test_start, (
+            f"Embargo violated: train_end={train_end}, test_start={test_start}"
+        )
+
+
+def test_purged_walk_forward_no_overlap_in_labels():
+    """Dates in the train segment must not appear in the test segment."""
+    def _check_strategy(train_seg: pd.DataFrame, test_seg: pd.DataFrame) -> pd.Series:
+        train_dates = set(train_seg.index.get_level_values("date").unique())
+        test_dates_list = sorted(test_seg.index.get_level_values("date").unique())
+        test_dates = set(test_dates_list)
+        overlap = train_dates & test_dates
+        assert len(overlap) == 0, f"Overlap between train and test dates: {overlap}"
+        return pd.Series(0.0, index=pd.DatetimeIndex(test_dates_list))
+
+    fm = _make_wf_feature_matrix(n_dates=200, n_tickers=4)
+    purged_walk_forward(_check_strategy, fm, n_splits=5, embargo_pct=0.01)
+
+
+def test_purged_walk_forward_empty_on_short_data():
+    """Too few dates to form valid folds should return an empty WalkForwardResult."""
+    fm = _make_wf_feature_matrix(n_dates=5, n_tickers=2)
+    result = purged_walk_forward(_dummy_strategy, fm, n_splits=5, embargo_pct=0.5)
+    assert isinstance(result, WalkForwardResult)
+    # With very short data and large embargo, likely no valid windows
+    # (may or may not have windows depending on split arithmetic; just check type)
+
+
+def test_purged_walk_forward_empty_matrix():
+    result = purged_walk_forward(_dummy_strategy, pd.DataFrame(), n_splits=5)
+    assert isinstance(result, WalkForwardResult)
+    assert len(result.windows) == 0
+
+
+def test_purged_walk_forward_consistency_score_range():
+    fm = _make_wf_feature_matrix(n_dates=200, n_tickers=4)
+    result = purged_walk_forward(_dummy_strategy, fm, n_splits=5, embargo_pct=0.01)
+    if result.windows:
+        assert 0.0 <= result.consistency_score <= 1.0

--- a/tests/test_ml_signal.py
+++ b/tests/test_ml_signal.py
@@ -2,7 +2,7 @@
 import os
 import sys
 import tempfile
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 
 import numpy as np
 import pandas as pd
@@ -10,9 +10,8 @@ import pytest
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
-from strategies.ml_signal import MLSignal, _LGBM_AVAILABLE, _FEATURE_COLS, _TARGET_COL
-from backtester.walk_forward import purged_walk_forward, WalkForwardResult
-
+from backtester.walk_forward import WalkForwardResult, purged_walk_forward
+from strategies.ml_signal import _FEATURE_COLS, _LGBM_AVAILABLE, _TARGET_COL, MLSignal
 
 # ── Helpers ────────────────────────────────────────────────────────────────────
 

--- a/tests/test_pages.py
+++ b/tests/test_pages.py
@@ -117,6 +117,7 @@ import pages.alerts as pg_alerts  # noqa: E402
 import pages.backtest as pg_backtest  # noqa: E402
 import pages.efficient_frontier as pg_ef  # noqa: E402
 import pages.journal_tab as pg_journal  # noqa: E402
+import pages.ml_signals as pg_ml_signals  # noqa: E402
 import pages.portfolio as pg_portfolio  # noqa: E402
 import pages.screener as pg_screener  # noqa: E402
 import pages.shared as pg_shared  # noqa: E402
@@ -597,3 +598,76 @@ class TestPagesAlerts:
              patch("pages.alerts.fetch_ohlcv", return_value=_ohlcv()), \
              patch("pages.alerts.compute_rsi", return_value=55.0):
             pg_alerts.render()
+
+# ── pages/ml_signals.py ───────────────────────────────────────────────────────
+
+class TestPagesMlSignals:
+    """Smoke tests for the ML Alpha Signals page."""
+
+    def _mock_ml_signal(self):
+        mock = MagicMock()
+        mock.feature_importance.return_value = pd.DataFrame(
+            {"feature": ["ret_5d", "vol_ratio_20d"], "importance": [120, 80]}
+        )
+        mock.predict.return_value = {"AAPL": 0.4, "MSFT": -0.2}
+        mock.train.return_value = {
+            "train_ic": 0.05, "test_ic": 0.03,
+            "train_icir": 0.6, "test_icir": 0.4,
+            "n_train_samples": 800, "n_test_samples": 200,
+        }
+        return mock
+
+    def test_render_default_no_buttons(self):
+        """Page renders without any button clicks (default state)."""
+        _reset_session()
+        with patch("strategies.ml_signal.MLSignal", return_value=self._mock_ml_signal()):
+            pg_ml_signals.render()
+
+    def test_render_with_cached_scores(self):
+        """Page renders alpha chart when ml_scores is already in session_state."""
+        _reset_session()
+        _ST.session_state["ml_scores"] = {"AAPL": 0.5, "MSFT": -0.3, "GOOGL": 0.1}
+        with patch("strategies.ml_signal.MLSignal", return_value=self._mock_ml_signal()):
+            pg_ml_signals.render()
+
+    def test_render_with_cached_train_metrics(self):
+        """Page renders metric tiles when ml_train_metrics is in session_state."""
+        _reset_session()
+        _ST.session_state["ml_train_metrics"] = {
+            "train_ic": 0.06, "test_ic": 0.04,
+            "train_icir": 0.7, "test_icir": 0.5,
+        }
+        with patch("strategies.ml_signal.MLSignal", return_value=self._mock_ml_signal()):
+            pg_ml_signals.render()
+
+    def test_render_compute_scores_button(self):
+        """Cover predict path when Compute Alpha Scores button is clicked."""
+        _reset_session()
+        def _btn(label, **kw):
+            return kw.get("key") == "ml_predict_btn"
+        _ST.button.side_effect = _btn
+        mock_model = self._mock_ml_signal()
+        with patch("strategies.ml_signal.MLSignal", return_value=mock_model):
+            pg_ml_signals.render()
+        _ST.button.side_effect = None
+        _ST.button.return_value = False
+
+    def test_render_empty_tickers(self):
+        """Page shows warning and returns early when no tickers are selected."""
+        _reset_session()
+        _ST.multiselect.side_effect = lambda *a, **kw: []
+        with patch("strategies.ml_signal.MLSignal", return_value=self._mock_ml_signal()):
+            pg_ml_signals.render()
+        _ST.multiselect.side_effect = (
+            lambda label, options=(), *a, **kw: list(kw.get("default", list(options)))
+        )
+
+    def test_render_no_trained_model(self):
+        """Page shows info message when feature_importance returns empty DataFrame."""
+        _reset_session()
+        mock_model = self._mock_ml_signal()
+        mock_model.feature_importance.return_value = pd.DataFrame(
+            columns=["feature", "importance"]
+        )
+        with patch("strategies.ml_signal.MLSignal", return_value=mock_model):
+            pg_ml_signals.render()

--- a/tests/test_rl_trainer.py
+++ b/tests/test_rl_trainer.py
@@ -1,0 +1,118 @@
+"""Tests for analysis/rl_trainer.py — _prepare_training_df (pure Python, no gymnasium needed)."""
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from analysis.rl_sizer import REGIME_STATES
+from analysis.rl_trainer import _prepare_training_df
+
+
+def _make_trades(n: int = 30, seed: int = 0) -> pd.DataFrame:
+    """Build a minimal trades DataFrame with realised_pnl column."""
+    np.random.seed(seed)
+    return pd.DataFrame({"realised_pnl": np.random.randn(n) * 100})
+
+
+# ── _prepare_training_df ───────────────────────────────────────────────────────
+
+def test_raises_without_realised_pnl():
+    df = pd.DataFrame({"foo": [1, 2, 3]})
+    with pytest.raises(ValueError, match="realised_pnl"):
+        _prepare_training_df(df)
+
+
+def test_adds_regime_column_when_missing():
+    df = _make_trades()
+    result = _prepare_training_df(df)
+    assert "regime" in result.columns
+    assert (result["regime"] == "trending_bull").all()
+
+
+def test_preserves_existing_regime():
+    df = _make_trades()
+    df["regime"] = "high_vol"
+    result = _prepare_training_df(df)
+    assert (result["regime"] == "high_vol").all()
+
+
+def test_unknown_regimes_replaced_with_default():
+    df = _make_trades(n=5)
+    df["regime"] = ["trending_bull", "invalid_regime", "high_vol", "bogus", "ranging"]
+    result = _prepare_training_df(df)
+    # "invalid_regime" and "bogus" should be replaced with "trending_bull"
+    valid = set(REGIME_STATES)
+    assert all(r in valid for r in result["regime"])
+
+
+def test_adds_volatility_when_missing():
+    df = _make_trades()
+    result = _prepare_training_df(df)
+    assert "volatility" in result.columns
+    assert (result["volatility"] == 0.20).all()
+
+
+def test_preserves_existing_volatility():
+    df = _make_trades()
+    df["volatility"] = 0.30
+    result = _prepare_training_df(df)
+    assert (result["volatility"] == 0.30).all()
+
+
+def test_computes_win_rate_when_missing():
+    df = _make_trades(n=40)
+    result = _prepare_training_df(df)
+    assert "win_rate" in result.columns
+    assert result["win_rate"].between(0, 1).all()
+
+
+def test_preserves_existing_win_rate():
+    df = _make_trades(n=10)
+    df["win_rate"] = 0.55
+    result = _prepare_training_df(df)
+    assert (result["win_rate"] == 0.55).all()
+
+
+def test_computes_drawdown_when_missing():
+    df = _make_trades(n=30)
+    result = _prepare_training_df(df)
+    assert "drawdown" in result.columns
+    assert result["drawdown"].between(0, 1).all()
+
+
+def test_preserves_existing_drawdown():
+    df = _make_trades(n=10)
+    df["drawdown"] = 0.05
+    result = _prepare_training_df(df)
+    assert (result["drawdown"] == 0.05).all()
+
+
+def test_drops_rows_with_nan_realised_pnl():
+    df = _make_trades(n=10)
+    df.loc[2, "realised_pnl"] = float("nan")
+    result = _prepare_training_df(df)
+    assert result["realised_pnl"].notna().all()
+    assert len(result) == 9
+
+
+def test_does_not_mutate_input():
+    df = _make_trades(n=20)
+    original_cols = list(df.columns)
+    _prepare_training_df(df)
+    assert list(df.columns) == original_cols
+
+
+def test_win_rate_rolling_window():
+    """Rolling win_rate should be bounded [0, 1]."""
+    np.random.seed(42)
+    df = pd.DataFrame({"realised_pnl": np.random.randn(60) * 100})
+    result = _prepare_training_df(df)
+    assert result["win_rate"].between(0, 1).all()
+
+
+def test_all_columns_present_in_output():
+    df = _make_trades(n=20)
+    result = _prepare_training_df(df)
+    for col in ("realised_pnl", "regime", "volatility", "win_rate", "drawdown"):
+        assert col in result.columns


### PR DESCRIPTION
Implements the supervised ML signal pipeline that bridges existing technical
indicators with the backtesting/risk infrastructure:

- data/features.py: MultiIndex (date, ticker) feature matrix with lag returns,
  rolling statistics (skew, kurtosis, autocorr, realised vol), volume features,
  and forward return labels; cross-sectional z-scored per date
- analysis/factor_ic.py: Information Coefficient (IC) and ICIR evaluation for
  each feature; compute_ic_decay() for signal horizon analysis; no scipy dep
- strategies/ml_signal.py: MLSignal class with LightGBM regressor predicting
  5-day forward returns; ranked [-1,1] scores; falls back to momentum when
  lightgbm is not installed (mirrors rl_sizer.py optional-dep pattern)
- backtester/walk_forward.py: add purged_walk_forward() with embargo gap to
  prevent label leakage when backtesting ML strategies
- data/db.py: add model_metadata table for training run persistence
- pages/ml_signals.py: new Streamlit tab (train/retrain, alpha scores chart,
  feature importance, IC table); wired into app.py as 9th tab
- requirements.txt: add lightgbm>=4.0.0 and scipy>=1.11.0
- tests: 35 passing tests across test_features.py, test_factor_ic.py,
  test_ml_signal.py (LightGBM tests gated with skipif)

https://claude.ai/code/session_01Es3eKCWkY8QhvHVDCyhsJN