### PR TITLE
feat: wire triple-barrier labels, Optuna tuning, meta-labeling into ML Signals UI (#63, #64, #65)

### DIFF
--- a/cron/monthly_ml_retrain.py
+++ b/cron/monthly_ml_retrain.py
@@ -41,7 +41,16 @@ def main() -> None:
             log.error("ml_retrain: lightgbm is not installed — aborting")
             sys.exit(1)
 
-        result = MLSignal().train(tickers, period=period)
+        # Pick up tuned hyperparameters from the last Optuna run, if any.
+        from strategies.ml_tuning import load_best_params
+
+        best_params = load_best_params("lgbm_alpha")
+        if best_params:
+            log.info("ml_retrain: using tuned params", n_params=len(best_params))
+        else:
+            log.info("ml_retrain: no tuned params found, using defaults")
+
+        result = MLSignal().train(tickers, period=period, lgbm_params=best_params)
 
         log.info(
             "ml_retrain: complete",

--- a/data/db.py
+++ b/data/db.py
@@ -123,6 +123,16 @@ def init_db() -> None:
             )
         """)
 
+        # ----- Tuned hyperparameters (one row per model, upsert on tune) -----
+        conn.execute("""
+            CREATE TABLE IF NOT EXISTS model_best_params (
+                model_name   TEXT    PRIMARY KEY,
+                updated_at   REAL    NOT NULL,
+                params_json  TEXT    NOT NULL,
+                best_ic      REAL
+            )
+        """)
+
         # Seed paper_account if absent
         import os
         starting_cash = float(os.getenv("PAPER_STARTING_CASH", "100000"))

--- a/data/features.py
+++ b/data/features.py
@@ -18,6 +18,11 @@ Input features (cross-sectionally z-scored across tickers per date):
 
 Forward return targets (NOT z-scored; NaN for last n rows of each ticker):
     fwd_ret_1d, fwd_ret_5d, fwd_ret_10d, fwd_ret_21d
+
+Triple-barrier targets (emitted when label_type="triple_barrier"):
+    tb_bin      — label in {-1, 0, +1} (first barrier touched)
+    tb_ret      — realised return from entry to first-touch
+    tb_target   — volatility used to scale the barriers
 """
 from __future__ import annotations
 
@@ -38,9 +43,16 @@ _FEATURE_COLS = [
     "vol_ratio_20d", "vol_zscore_20d",
 ]
 _FWD_COLS = ["fwd_ret_1d", "fwd_ret_5d", "fwd_ret_10d", "fwd_ret_21d"]
+_TB_LABEL_COLS = ["tb_bin", "tb_ret", "tb_target"]
 
 
-def _single_ticker_features(ticker: str, period: str) -> pd.DataFrame | None:
+def _single_ticker_features(
+    ticker: str,
+    period: str,
+    label_type: str = "fwd_ret",
+    pt_sl: tuple[float, float] = (1.0, 1.0),
+    num_days: int = 5,
+) -> pd.DataFrame | None:
     """
     Compute raw (un-z-scored) features for one ticker.
 
@@ -80,30 +92,58 @@ def _single_ticker_features(ticker: str, period: str) -> pd.DataFrame | None:
     for n in (1, 5, 10, 21):
         out[f"fwd_ret_{n}d"] = close.pct_change(n).shift(-n)
 
+    # ── Triple-barrier labels (López de Prado Ch 3) ───────────────────────────
+    if label_type == "triple_barrier":
+        from analysis.triple_barrier import triple_barrier_labels
+
+        tb = triple_barrier_labels(
+            close,
+            events=close.index,
+            pt_sl=pt_sl,
+            num_days=num_days,
+        )
+        if not tb.empty:
+            out["tb_bin"] = tb["bin"].reindex(out.index)
+            out["tb_ret"] = tb["ret"].reindex(out.index)
+            out["tb_target"] = tb["target"].reindex(out.index)
+
     return out
 
 
 def build_feature_matrix(
     tickers: list[str],
     period: str = "2y",
+    label_type: str = "fwd_ret",
+    pt_sl: tuple[float, float] = (1.0, 1.0),
+    num_days: int = 5,
 ) -> pd.DataFrame:
     """
     Build a MultiIndex (date, ticker) feature matrix.
 
     Parameters
     ----------
-    tickers : list of ticker symbols to include
-    period  : yfinance-style period string passed to fetch_ohlcv
+    tickers    : list of ticker symbols to include
+    period     : yfinance-style period string passed to fetch_ohlcv
+    label_type : "fwd_ret" (default) keeps the existing forward-return
+                 targets.  "triple_barrier" additionally emits tb_bin,
+                 tb_ret, tb_target columns from
+                 analysis.triple_barrier.triple_barrier_labels.
+    pt_sl      : (profit-take, stop-loss) multipliers in daily-vol units;
+                 used only when label_type="triple_barrier".
+    num_days   : vertical-barrier horizon in days; triple-barrier only.
 
     Returns
     -------
     pd.DataFrame with MultiIndex(date, ticker).
     Input features are cross-sectionally z-scored across tickers per date.
-    Forward return columns (fwd_ret_*) are NOT z-scored.
+    Forward return and triple-barrier columns are NOT z-scored.
     """
     frames: dict[str, pd.DataFrame] = {}
     for ticker in tickers:
-        feat = _single_ticker_features(ticker, period)
+        feat = _single_ticker_features(
+            ticker, period,
+            label_type=label_type, pt_sl=pt_sl, num_days=num_days,
+        )
         if feat is not None and not feat.empty:
             frames[ticker] = feat
 

--- a/pages/ml_signals.py
+++ b/pages/ml_signals.py
@@ -46,14 +46,53 @@ def render() -> None:
         st.warning("Select at least one ticker.")
         return
 
+    # ── Label type selector (López de Prado Ch 3) ─────────────────────────────
+    label_type = st.selectbox(
+        "Label type",
+        options=["fwd_ret", "triple_barrier"],
+        index=0,
+        key="ml_label_type",
+        help=(
+            "fwd_ret: regressor on 5-day forward return (default). "
+            "triple_barrier: classifier on the {-1, 0, +1} label from the "
+            "first-touched profit-take / stop-loss / vertical barrier."
+        ),
+    )
+    pt_sl: tuple[float, float] = (1.0, 1.0)
+    num_days = 5
+    if label_type == "triple_barrier":
+        lab_pt, lab_sl, lab_nd = st.columns(3)
+        with lab_pt:
+            pt_val = st.number_input(
+                "Profit-take × σ", min_value=0.5, max_value=5.0,
+                value=1.0, step=0.25, key="ml_pt",
+            )
+        with lab_sl:
+            sl_val = st.number_input(
+                "Stop-loss × σ", min_value=0.5, max_value=5.0,
+                value=1.0, step=0.25, key="ml_sl",
+            )
+        with lab_nd:
+            num_days = int(st.number_input(
+                "Vertical barrier (days)", min_value=2, max_value=30,
+                value=5, step=1, key="ml_nd",
+            ))
+        pt_sl = (float(pt_val), float(sl_val))
+
     # ── Train / Retrain ───────────────────────────────────────────────────────
-    col_lgbm, col_regime, col_ridge = st.columns(3)
+    col_lgbm, col_regime, col_ridge, col_tune = st.columns(4)
     with col_lgbm:
         do_train = st.button("Train LGBM Baseline", type="primary", key="ml_train_btn")
     with col_regime:
         do_train_regime = st.button("Train Regime Models", key="ml_train_regime_btn")
     with col_ridge:
         do_train_ridge = st.button("Train Ridge Model", key="ml_train_ridge_btn")
+    with col_tune:
+        tune_trials = int(st.number_input(
+            "Tune trials", min_value=5, max_value=100, value=20, step=5,
+            key="ml_tune_trials",
+        ))
+        do_tune = st.button("Optimize Hyperparameters", key="ml_tune_btn")
 
     if do_train:
         with st.spinner("Building feature matrix and training LightGBM alpha model…"):
@@ -66,7 +105,11 @@ def render() -> None:
                     )
                 else:
                     model = MLSignal()
-                    metrics = model.train(selected_tickers, period=period)
+                    metrics = model.train(
+                        selected_tickers, period=period,
+                        label_type=label_type, pt_sl=pt_sl, num_days=num_days,
+                        lgbm_params=st.session_state.get("ml_best_params"),
+                    )
                     st.session_state["ml_model_instance"] = model
                     st.session_state["ml_train_metrics"] = metrics
                     st.success("LGBM baseline model trained successfully.")
@@ -81,7 +124,11 @@ def render() -> None:
                     st.error("lightgbm is not installed.")
                 else:
                     model = st.session_state.get("ml_model_instance") or MLSignal()
-                    regime_results = model.train_regime_models(selected_tickers, period=period)
+                    regime_results = model.train_regime_models(
+                        selected_tickers, period=period,
+                        label_type=label_type, pt_sl=pt_sl, num_days=num_days,
+                        lgbm_params=st.session_state.get("ml_best_params"),
+                    )
                     st.session_state["ml_model_instance"] = model
                     st.session_state["ml_regime_results"] = regime_results
                     if regime_results:
@@ -113,6 +160,49 @@ def render() -> None:
                     st.success("Ridge model trained successfully.")
             except Exception as exc:
                 st.error(f"Ridge training failed: {exc}")
+
+    if do_tune:
+        with st.spinner(f"Running Optuna TPE search ({tune_trials} trials)…"):
+            try:
+                from strategies.ml_tuning import (
+                    _OPTUNA_AVAILABLE,
+                    save_best_params,
+                    tune_lgbm_hyperparams,
+                )
+                if not _OPTUNA_AVAILABLE:
+                    st.error(
+                        "optuna is not installed. "
+                        "Run `pip install optuna>=3.5.0` and restart the app."
+                    )
+                else:
+                    tune_result = tune_lgbm_hyperparams(
+                        selected_tickers, period=period, n_trials=tune_trials,
+                    )
+                    st.session_state["ml_best_params"] = tune_result["best_params"]
+                    st.session_state["ml_tune_result"] = tune_result
+                    save_best_params(
+                        "lgbm_alpha",
+                        tune_result["best_params"],
+                        tune_result["best_ic"],
+                    )
+                    st.success(
+                        f"Tuning complete — best IC {tune_result['best_ic']:.4f} "
+                        f"over {tune_result['n_trials']} trials."
+                    )
+            except Exception as exc:
+                st.error(f"Hyperparameter tuning failed: {exc}")
+
+    if "ml_tune_result" in st.session_state:
+        tr = st.session_state["ml_tune_result"]
+        st.caption("**Best Hyperparameters (Optuna TPE)**")
+        tm1, tm2 = st.columns(2)
+        tm1.metric("Best IC", f"{tr.get('best_ic', 0):.4f}")
+        tm2.metric("Trials", str(tr.get("n_trials", 0)))
+        params_df = pd.DataFrame(
+            [(k, v) for k, v in tr.get("best_params", {}).items()],
+            columns=["param", "value"],
+        )
+        st.dataframe(params_df, use_container_width=True, hide_index=True)
 
     # ── LGBM training metrics ─────────────────────────────────────────────────
     if "ml_train_metrics" in st.session_state:
@@ -243,10 +333,26 @@ def render() -> None:
             options=selected_tickers,
             key="ml_backtest_ticker",
         )
+        apply_meta = st.checkbox(
+            "Apply meta-labeling",
+            value=False,
+            key="ml_bt_meta",
+            help=(
+                "Wrap the primary LGBM signal with a RandomForest confidence "
+                "filter trained on triple-barrier labels (López de Prado Ch 3)."
+            ),
+        )
+        min_conf = st.slider(
+            "Min confidence",
+            min_value=0.0, max_value=0.9, value=0.5, step=0.05,
+            key="ml_bt_min_conf",
+            disabled=not apply_meta,
+        )
+
         if st.button("Run ML Backtest", key="ml_backtest_btn"):
             with st.spinner(f"Building signals for {focus_ticker} and running backtest…"):
                 try:
-                    from backtester.engine import build_equity_chart, run_signal_backtest
+                    from backtester.engine import run_signal_backtest
                     from data.features import _FEATURE_COLS, build_feature_matrix
                     from data.fetcher import fetch_ohlcv
                     from strategies.ml_signal import MLSignal
@@ -267,7 +373,7 @@ def render() -> None:
                                 ticker_fm = None
 
                             if ticker_fm is not None and not ticker_fm.empty:
-                                raw_preds = model._model.predict(ticker_fm.values)
+                                raw_preds = model.score_features(ticker_fm.values)
                                 signals = pd.Series(raw_preds, index=ticker_fm.index)
 
                                 ohlcv = fetch_ohlcv(focus_ticker, period)
@@ -280,19 +386,26 @@ def render() -> None:
                                         ticker=focus_ticker,
                                     )
                                     st.session_state["ml_backtest_result"] = bt_result
+                                    st.session_state.pop("ml_backtest_result_meta", None)
+
+                                    if apply_meta:
+                                        meta_result = _run_meta_labeled_backtest(
+                                            ohlcv=ohlcv,
+                                            ticker=focus_ticker,
+                                            ticker_fm=ticker_fm,
+                                            raw_preds=raw_preds,
+                                            min_confidence=float(min_conf),
+                                        )
+                                        if meta_result is not None:
+                                            st.session_state["ml_backtest_result_meta"] = meta_result
 
                 except Exception as exc:
                     st.error(f"Backtest failed: {exc}")
 
-    if "ml_backtest_result" in st.session_state:
-        r = st.session_state["ml_backtest_result"]
-        bc1, bc2, bc3, bc4 = st.columns(4)
-        bc1.metric("Total Return", f"{r.total_return_pct:.2f}%")
-        bc2.metric("Sharpe", f"{r.sharpe_ratio:.3f}")
-        bc3.metric("Max DD", f"{r.max_drawdown_pct:.2f}%")
-        bc4.metric("Trades", str(r.num_trades))
-        from backtester.engine import build_equity_chart
-        st.plotly_chart(build_equity_chart(r), use_container_width=True)
+    _render_backtest_results(
+        st.session_state.get("ml_backtest_result"),
+        st.session_state.get("ml_backtest_result_meta"),
+    )
 
     st.divider()
 
@@ -393,6 +506,112 @@ def render() -> None:
 
 
 # ── Private rendering helpers ─────────────────────────────────────────────────
+
+def _run_meta_labeled_backtest(
+    *,
+    ohlcv: pd.DataFrame,
+    ticker: str,
+    ticker_fm: pd.DataFrame,
+    raw_preds,
+    min_confidence: float,
+):
+    """Fit a meta-labeler on triple-barrier bins and backtest the filtered signal.
+
+    Returns a ``BacktestResult`` on success or ``None`` on failure (with a
+    Streamlit warning surfaced inline).  Failures are expected when sklearn
+    isn't installed or when all bins are neutral — in both cases there is
+    nothing meaningful to overlay.
+    """
+    import numpy as np
+
+    from analysis.triple_barrier import triple_barrier_labels
+    from backtester.engine import run_signal_backtest
+    from strategies.meta_label import (
+        MetaLabeler,
+        filter_primary_by_confidence,
+    )
+
+    close = ohlcv["Close"].astype(float)
+    bins = triple_barrier_labels(
+        close, events=close.index, pt_sl=(1.0, 1.0), num_days=5,
+    )["bin"]
+
+    primary = pd.Series(
+        np.sign(np.asarray(raw_preds, dtype=float)),
+        index=ticker_fm.index,
+    )
+
+    try:
+        labeler = MetaLabeler()
+        labeler.fit(primary, bins, ticker_fm)
+        final = labeler.predict(primary, ticker_fm)
+    except (RuntimeError, ValueError) as exc:
+        st.warning(f"Meta-labeling skipped: {exc}")
+        return None
+
+    filtered = filter_primary_by_confidence(
+        primary, final, min_confidence=min_confidence,
+    )
+
+    return run_signal_backtest(
+        ohlcv, filtered,
+        strategy_name="ML Signal (meta)",
+        ticker=ticker,
+    )
+
+
+def _render_backtest_results(raw_result, meta_result) -> None:
+    """Render the raw backtest metrics + optional meta-labeled overlay."""
+    if raw_result is None:
+        return
+
+    from backtester.engine import build_equity_chart
+
+    bc1, bc2, bc3, bc4 = st.columns(4)
+    bc1.metric("Total Return", f"{raw_result.total_return_pct:.2f}%")
+    bc2.metric("Sharpe", f"{raw_result.sharpe_ratio:.3f}")
+    bc3.metric("Max DD", f"{raw_result.max_drawdown_pct:.2f}%")
+    bc4.metric("Trades", str(raw_result.num_trades))
+
+    if meta_result is None:
+        st.plotly_chart(build_equity_chart(raw_result), use_container_width=True)
+        return
+
+    st.caption("**Meta-labeled backtest (RandomForest × primary LGBM)**")
+    mc1, mc2, mc3, mc4 = st.columns(4)
+    mc1.metric("Total Return", f"{meta_result.total_return_pct:.2f}%")
+    mc2.metric("Sharpe", f"{meta_result.sharpe_ratio:.3f}")
+    mc3.metric("Max DD", f"{meta_result.max_drawdown_pct:.2f}%")
+    mc4.metric("Trades", str(meta_result.num_trades))
+
+    fig = go.Figure()
+    raw_eq = getattr(raw_result, "equity_curve", None)
+    if raw_eq is not None and not raw_eq.empty and "Equity" in raw_eq.columns:
+        fig.add_trace(go.Scatter(
+            x=raw_eq.index,
+            y=raw_eq["Equity"],
+            mode="lines",
+            name="Raw LGBM",
+            line=dict(color="#3498db", width=2),
+        ))
+    meta_eq = getattr(meta_result, "equity_curve", None)
+    if meta_eq is not None and not meta_eq.empty and "Equity" in meta_eq.columns:
+        fig.add_trace(go.Scatter(
+            x=meta_eq.index,
+            y=meta_eq["Equity"],
+            mode="lines",
+            name="Meta-labeled",
+            line=dict(color="#e67e22", width=2, dash="dash"),
+        ))
+    fig.update_layout(
+        title="Equity Curve — Raw vs Meta-labeled",
+        xaxis_title="Date",
+        yaxis_title="Equity",
+        height=400,
+        margin=dict(l=60, r=40, t=50, b=40),
+    )
+    st.plotly_chart(fig, use_container_width=True)
+
 
 def _render_alpha_chart(scores: dict[str, float]) -> None:
     """Colour-coded horizontal bar chart of alpha scores."""

--- a/strategies/ml_signal.py
+++ b/strategies/ml_signal.py
@@ -48,6 +48,8 @@ _DEFAULT_REGIME_MODELS_PATH = os.environ.get(
     "LGBM_REGIME_MODELS_PATH", "models/lgbm_regime_models.pkl"
 )
 _TARGET_COL = "fwd_ret_5d"
+_TB_TARGET_COL = "tb_bin"
+_TB_RET_COL = "tb_ret"
 # Minimum (date, ticker) rows per regime required to train a regime-specific model
 _MIN_REGIME_SAMPLES = 100
 
@@ -93,6 +95,7 @@ class MLSignal:
         self._model_path: str = model_path or _DEFAULT_MODEL_PATH
         self._regime_model_path: str = regime_model_path or _DEFAULT_REGIME_MODELS_PATH
         self._model = None
+        self._is_classifier: bool = False
         self._regime_models: dict = {}
         self._load_if_available()
         self._load_regime_models_if_available()
@@ -110,8 +113,20 @@ class MLSignal:
                 log.info("ml_signal: lightgbm not installed, using momentum fallback")
                 return
             with open(path, "rb") as f:
-                self._model = pickle.load(f)
-            log.info("ml_signal: loaded baseline model checkpoint", path=str(path))
+                payload = pickle.load(f)
+            # Newer checkpoints are {"model": model, "is_classifier": bool}.
+            # Older checkpoints are the raw estimator — treat as regressor.
+            if isinstance(payload, dict) and "model" in payload:
+                self._model = payload["model"]
+                self._is_classifier = bool(payload.get("is_classifier", False))
+            else:
+                self._model = payload
+                self._is_classifier = False
+            log.info(
+                "ml_signal: loaded baseline model checkpoint",
+                path=str(path),
+                classifier=self._is_classifier,
+            )
         except Exception as exc:
             log.warning("ml_signal: failed to load baseline checkpoint", path=str(path), error=str(exc))
 
@@ -124,7 +139,16 @@ class MLSignal:
             if not _LGBM_AVAILABLE:
                 return
             with open(path, "rb") as f:
-                self._regime_models = pickle.load(f)
+                payload = pickle.load(f)
+            if isinstance(payload, dict) and "models" in payload:
+                self._regime_models = payload["models"]
+                # Preserve classifier flag if baseline hasn't set it.
+                self._is_classifier = self._is_classifier or bool(
+                    payload.get("is_classifier", False)
+                )
+            else:
+                # Legacy format: bare dict of {regime: model}
+                self._regime_models = payload
             log.info(
                 "ml_signal: loaded regime models",
                 path=str(path),
@@ -141,6 +165,9 @@ class MLSignal:
         period: str = "2y",
         test_size: float = 0.2,
         lgbm_params: dict | None = None,
+        label_type: str = "fwd_ret",
+        pt_sl: tuple[float, float] = (1.0, 1.0),
+        num_days: int = 5,
     ) -> dict[str, float]:
         """
         Build feature matrix, train baseline LightGBM, evaluate on held-out
@@ -152,7 +179,11 @@ class MLSignal:
         period     : yfinance period string for data fetching
         test_size  : fraction of time series reserved for out-of-sample eval
                      (chronological split — latest test_size of dates)
-        lgbm_params : override default LGBMRegressor parameters
+        lgbm_params : override default LGBMRegressor / LGBMClassifier params
+        label_type : "fwd_ret" (regressor on fwd_ret_5d) or "triple_barrier"
+                     (classifier on the tb_bin {-1, 0, +1} label)
+        pt_sl      : (profit-take, stop-loss) multipliers; triple-barrier only
+        num_days   : vertical-barrier horizon in days; triple-barrier only
 
         Returns
         -------
@@ -168,16 +199,25 @@ class MLSignal:
                 "lightgbm is not installed. Run: pip install lightgbm>=4.0.0"
             )
 
-        log.info("ml_signal: building feature matrix", tickers=len(tickers), period=period)
-        fm = build_feature_matrix(tickers, period=period)
+        is_classifier = label_type == "triple_barrier"
+        target_col = _TB_TARGET_COL if is_classifier else _TARGET_COL
+
+        log.info(
+            "ml_signal: building feature matrix",
+            tickers=len(tickers), period=period, label_type=label_type,
+        )
+        fm = build_feature_matrix(
+            tickers, period=period,
+            label_type=label_type, pt_sl=pt_sl, num_days=num_days,
+        )
 
         if fm.empty:
             raise ValueError("Feature matrix is empty — check tickers and period")
 
         # Drop rows with missing target
-        fm = fm.dropna(subset=[_TARGET_COL])
+        fm = fm.dropna(subset=[target_col])
         if fm.empty:
-            raise ValueError(f"No rows with non-NaN target '{_TARGET_COL}'")
+            raise ValueError(f"No rows with non-NaN target '{target_col}'")
 
         # Chronological train/test split on unique dates
         all_dates = sorted(fm.index.get_level_values("date").unique())
@@ -191,25 +231,43 @@ class MLSignal:
         test_df = fm[fm.index.get_level_values("date").isin(test_dates)]
 
         X_train = train_df[feature_cols].values
-        y_train = train_df[_TARGET_COL].values
         X_test = test_df[feature_cols].values
-        y_test = test_df[_TARGET_COL].values
+        if is_classifier:
+            y_train = train_df[target_col].astype(int).values
+            y_test = test_df[target_col].astype(int).values
+            # Evaluate IC against the realised return, not the {-1,0,+1} label
+            ic_eval_train = train_df[_TB_RET_COL].astype(float).values
+            ic_eval_test = test_df[_TB_RET_COL].astype(float).values
+        else:
+            y_train = train_df[target_col].values
+            y_test = test_df[target_col].values
+            ic_eval_train = y_train
+            ic_eval_test = y_test
 
         log.info(
             "ml_signal: training",
             n_train=len(X_train),
             n_test=len(X_test),
             features=len(feature_cols),
+            classifier=is_classifier,
         )
 
         params = {**_DEFAULT_LGBM_PARAMS, **(lgbm_params or {})}
-        model = lgb.LGBMRegressor(**params)
+        if is_classifier:
+            model = lgb.LGBMClassifier(**params)
+        else:
+            model = lgb.LGBMRegressor(**params)
         model.fit(X_train, y_train)
         self._model = model
+        self._is_classifier = is_classifier
 
-        # Evaluate IC on train and test sets
-        train_ic, train_icir = self._eval_ic(model, X_train, y_train)
-        test_ic, test_icir = self._eval_ic(model, X_test, y_test)
+        # Evaluate IC on train and test sets (against realised return)
+        train_ic, train_icir = self._eval_ic(
+            model, X_train, ic_eval_train, classifier=is_classifier,
+        )
+        test_ic, test_icir = self._eval_ic(
+            model, X_test, ic_eval_test, classifier=is_classifier,
+        )
 
         log.info(
             "ml_signal: training complete",
@@ -217,10 +275,10 @@ class MLSignal:
             test_ic=round(test_ic, 4),
         )
 
-        # Persist checkpoint
+        # Persist checkpoint (versioned payload preserves is_classifier flag)
         Path(self._model_path).parent.mkdir(parents=True, exist_ok=True)
         with open(self._model_path, "wb") as f:
-            pickle.dump(model, f)
+            pickle.dump({"model": model, "is_classifier": is_classifier}, f)
         log.info("ml_signal: baseline checkpoint saved", path=self._model_path)
 
         # Write metadata to quant.db
@@ -249,6 +307,9 @@ class MLSignal:
         min_regime_samples: int = _MIN_REGIME_SAMPLES,
         test_size: float = 0.2,
         lgbm_params: dict | None = None,
+        label_type: str = "fwd_ret",
+        pt_sl: tuple[float, float] = (1.0, 1.0),
+        num_days: int = 5,
     ) -> dict[str, dict]:
         """
         Train one LGBMRegressor per market regime.
@@ -280,19 +341,26 @@ class MLSignal:
         if not _LGBM_AVAILABLE:
             raise RuntimeError("lightgbm is not installed.")
 
+        is_classifier = label_type == "triple_barrier"
+        target_col = _TB_TARGET_COL if is_classifier else _TARGET_COL
+
         log.info(
             "ml_signal: building feature matrix for regime models",
             tickers=len(tickers),
             period=period,
+            label_type=label_type,
         )
-        fm = build_feature_matrix(tickers, period=period)
+        fm = build_feature_matrix(
+            tickers, period=period,
+            label_type=label_type, pt_sl=pt_sl, num_days=num_days,
+        )
 
         if fm.empty:
             raise ValueError("Feature matrix is empty — check tickers and period")
 
-        fm = fm.dropna(subset=[_TARGET_COL])
+        fm = fm.dropna(subset=[target_col])
         if fm.empty:
-            raise ValueError(f"No rows with non-NaN target '{_TARGET_COL}'")
+            raise ValueError(f"No rows with non-NaN target '{target_col}'")
 
         # Label each row with its market regime
         regime_series = self._get_historical_regimes(period)
@@ -333,15 +401,28 @@ class MLSignal:
             test_df = regime_fm[regime_fm.index.get_level_values("date").isin(test_dates)]
 
             X_train = train_df[feature_cols].values
-            y_train = train_df[_TARGET_COL].values
             X_test = test_df[feature_cols].values
-            y_test = test_df[_TARGET_COL].values
+            if is_classifier:
+                y_train = train_df[target_col].astype(int).values
+                y_test = test_df[target_col].astype(int).values
+                ic_eval_train = train_df[_TB_RET_COL].astype(float).values
+                ic_eval_test = test_df[_TB_RET_COL].astype(float).values
+                model = lgb.LGBMClassifier(**params)
+            else:
+                y_train = train_df[target_col].values
+                y_test = test_df[target_col].values
+                ic_eval_train = y_train
+                ic_eval_test = y_test
+                model = lgb.LGBMRegressor(**params)
 
-            model = lgb.LGBMRegressor(**params)
             model.fit(X_train, y_train)
 
-            train_ic, train_icir = self._eval_ic(model, X_train, y_train)
-            test_ic, test_icir = self._eval_ic(model, X_test, y_test)
+            train_ic, train_icir = self._eval_ic(
+                model, X_train, ic_eval_train, classifier=is_classifier,
+            )
+            test_ic, test_icir = self._eval_ic(
+                model, X_test, ic_eval_test, classifier=is_classifier,
+            )
 
             regime_models[regime] = model
             results[regime] = {
@@ -360,9 +441,12 @@ class MLSignal:
             )
 
         self._regime_models = regime_models
+        self._is_classifier = is_classifier
         Path(self._regime_model_path).parent.mkdir(parents=True, exist_ok=True)
         with open(self._regime_model_path, "wb") as f:
-            pickle.dump(regime_models, f)
+            pickle.dump(
+                {"models": regime_models, "is_classifier": is_classifier}, f,
+            )
         log.info(
             "ml_signal: regime models saved",
             path=self._regime_model_path,
@@ -409,9 +493,27 @@ class MLSignal:
     # ── Shared eval & metadata helpers ────────────────────────────────────────
 
     @staticmethod
-    def _eval_ic(model, X: np.ndarray, y: np.ndarray) -> tuple[float, float]:
+    def _classifier_scores(model, X: np.ndarray) -> np.ndarray:
+        """Map a {-1, 0, +1} classifier's predict_proba → continuous [-1, 1].
+
+        Score = P(+1) - P(-1), which is monotone in expected directional bet
+        and lives naturally in the same band as the regressor output.
+        """
+        proba = model.predict_proba(X)
+        classes = np.asarray(model.classes_)
+        p_up = proba[:, classes == 1].sum(axis=1) if (classes == 1).any() else np.zeros(len(X))
+        p_dn = proba[:, classes == -1].sum(axis=1) if (classes == -1).any() else np.zeros(len(X))
+        return np.asarray(p_up - p_dn, dtype=float)
+
+    @classmethod
+    def _eval_ic(
+        cls, model, X: np.ndarray, y: np.ndarray, classifier: bool = False,
+    ) -> tuple[float, float]:
         """Return (IC mean, ICIR) from a predictions array vs actuals."""
-        preds = model.predict(X)
+        if classifier:
+            preds = cls._classifier_scores(model, X)
+        else:
+            preds = model.predict(X)
         # Spearman via rank correlation
         from analysis.factor_ic import _spearman_corr
         ic = _spearman_corr(preds, y)
@@ -510,7 +612,10 @@ class MLSignal:
             if latest.empty:
                 return self._momentum_fallback(tickers, period)
 
-            raw_preds = active_model.predict(latest.values)
+            if self._is_classifier and hasattr(active_model, "predict_proba"):
+                raw_preds = self._classifier_scores(active_model, latest.values)
+            else:
+                raw_preds = active_model.predict(latest.values)
 
             # Z-score and clip to [-1, 1]
             std = raw_preds.std()
@@ -545,6 +650,21 @@ class MLSignal:
             except Exception:
                 scores[ticker] = 0.0
         return scores
+
+    # ── Scoring helper (used by backtest path) ────────────────────────────────
+
+    def score_features(self, X: np.ndarray) -> np.ndarray:
+        """
+        Return raw continuous scores for a pre-built feature array.
+
+        Dispatches to predict_proba-derived P(+1)-P(-1) for classifier
+        checkpoints and to regressor.predict for regressor checkpoints.
+        """
+        if self._model is None:
+            raise RuntimeError("ml_signal.score_features: no trained model loaded")
+        if self._is_classifier and hasattr(self._model, "predict_proba"):
+            return self._classifier_scores(self._model, X)
+        return np.asarray(self._model.predict(X), dtype=float)
 
     # ── Feature importance ────────────────────────────────────────────────────
 

--- a/strategies/ml_tuning.py
+++ b/strategies/ml_tuning.py
@@ -18,6 +18,9 @@ Optional deps
 """
 from __future__ import annotations
 
+import json
+import time
+
 import numpy as np
 import pandas as pd
 from scipy.stats import spearmanr
@@ -175,3 +178,57 @@ def tune_lgbm_hyperparams(
     log.info("tune_lgbm_hyperparams: complete", **{k: v for k, v in result.items()
                                                     if k != "best_params"})
     return result
+
+
+# ── Persistence helpers for tuned params ─────────────────────────────────────
+
+def save_best_params(
+    model_name: str,
+    params: dict,
+    best_ic: float,
+) -> None:
+    """Upsert tuned hyperparameters into quant.db model_best_params.
+
+    Logs and swallows any DB error so calling code (typically a UI button
+    handler) does not abort after a successful tune just because persistence
+    failed.
+    """
+    from data.db import get_connection
+
+    try:
+        conn = get_connection()
+        with conn:
+            conn.execute(
+                """
+                INSERT INTO model_best_params (model_name, updated_at, params_json, best_ic)
+                VALUES (?, ?, ?, ?)
+                ON CONFLICT(model_name) DO UPDATE SET
+                    updated_at = excluded.updated_at,
+                    params_json = excluded.params_json,
+                    best_ic = excluded.best_ic
+                """,
+                (model_name, time.time(), json.dumps(params), float(best_ic)),
+            )
+        conn.close()
+        log.info("save_best_params: persisted", model_name=model_name, best_ic=best_ic)
+    except Exception as exc:
+        log.warning("save_best_params: failed", model_name=model_name, error=str(exc))
+
+
+def load_best_params(model_name: str) -> dict | None:
+    """Return persisted tuned hyperparameters for ``model_name`` or None."""
+    from data.db import get_connection
+
+    try:
+        conn = get_connection()
+        row = conn.execute(
+            "SELECT params_json FROM model_best_params WHERE model_name = ?",
+            (model_name,),
+        ).fetchone()
+        conn.close()
+        if row is None:
+            return None
+        return json.loads(row["params_json"])
+    except Exception as exc:
+        log.warning("load_best_params: failed", model_name=model_name, error=str(exc))
+        return None

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -9,7 +9,12 @@ import pytest
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
-from data.features import _FEATURE_COLS, _FWD_COLS, build_feature_matrix
+from data.features import (
+    _FEATURE_COLS,
+    _FWD_COLS,
+    _TB_LABEL_COLS,
+    build_feature_matrix,
+)
 
 
 def _make_ohlcv(n: int = 200, seed: int = 42, start: str = "2022-01-01") -> pd.DataFrame:
@@ -139,6 +144,35 @@ def test_volume_ratio_formula():
     valid = solo["vol_ratio_20d"].dropna()
     assert len(valid) > 0
     assert (valid > 0).all(), "vol_ratio_20d should be positive"
+
+
+def test_build_feature_matrix_triple_barrier_emits_bin_column():
+    """label_type='triple_barrier' adds tb_bin/tb_ret/tb_target columns with
+    values in the expected support."""
+    tickers = ["AAPL", "MSFT"]
+    with patch("data.features.fetch_ohlcv", side_effect=_mock_fetch):
+        fm = build_feature_matrix(
+            tickers, period="2y",
+            label_type="triple_barrier", pt_sl=(1.0, 1.0), num_days=5,
+        )
+
+    for col in _TB_LABEL_COLS:
+        assert col in fm.columns, f"Missing triple-barrier column: {col}"
+
+    bins = fm["tb_bin"].dropna().unique()
+    assert set(bins).issubset({-1, 0, 1}), f"unexpected tb_bin values: {bins}"
+
+    assert fm["tb_target"].dropna().ge(0).all(), "tb_target (vol) must be non-negative"
+
+
+def test_build_feature_matrix_fwd_ret_default_has_no_tb_columns():
+    """Default label_type keeps the feature matrix free of triple-barrier cols."""
+    tickers = ["AAPL"]
+    with patch("data.features.fetch_ohlcv", side_effect=_mock_fetch):
+        fm = build_feature_matrix(tickers, period="2y")
+
+    for col in _TB_LABEL_COLS:
+        assert col not in fm.columns
 
 
 def test_realised_vol_is_finite():

--- a/tests/test_ml_signal.py
+++ b/tests/test_ml_signal.py
@@ -244,6 +244,188 @@ def test_feature_importance_with_mock_model():
     assert (fi["importance"] >= 0).all()
 
 
+# ── Triple-barrier classifier path (pure-mock, no LightGBM needed) ────────────
+
+class _PicklablePlainRegressor:
+    """Plain regressor used by checkpoint-load tests — unlike MagicMock, picklable."""
+    feature_importances_ = np.array([1.0, 2.0, 3.0])
+
+    def predict(self, X):
+        return np.zeros(len(X))
+
+
+class _PicklablePlainClassifier:
+    classes_ = np.array([-1, 0, 1])
+
+    def predict_proba(self, X):
+        return np.tile(np.array([0.2, 0.3, 0.5]), (len(X), 1))
+
+
+def _make_classifier_mock_model(n_rows: int = 4):
+    """Fake LGBMClassifier: predict_proba returns a stable 3-class distribution."""
+    mock = MagicMock()
+    mock.classes_ = np.array([-1, 0, 1])
+    probs = np.tile(np.array([0.2, 0.3, 0.5]), (n_rows, 1))
+    mock.predict_proba.return_value = probs
+    mock.feature_importances_ = np.arange(len(_FEATURE_COLS), 0, -1, dtype=float)
+    return mock
+
+
+def test_classifier_scores_uses_p_up_minus_p_down():
+    mock = _make_classifier_mock_model(n_rows=3)
+    X = np.zeros((3, 5))
+    scores = MLSignal._classifier_scores(mock, X)
+    # p_up(=0.5) − p_down(=0.2) = 0.3 for every row
+    assert scores == pytest.approx(np.array([0.3, 0.3, 0.3]))
+
+
+def test_predict_classifier_path_returns_valid_range():
+    """When _is_classifier=True, predict uses predict_proba instead of predict."""
+    fm = _make_feature_matrix(n_dates=20, n_tickers=4)
+    mock_model = _make_classifier_mock_model(n_rows=4)
+
+    with patch("strategies.ml_signal.build_feature_matrix", return_value=fm):
+        model = MLSignal(model_path="/tmp/nonexistent_clf.pkl")
+        model._model = mock_model
+        model._is_classifier = True
+        tickers = list(fm.index.get_level_values("ticker").unique())
+        scores = model.predict(tickers, period="6mo")
+
+    assert len(scores) == 4
+    # All rows share the same probability; after z-score + clip they collapse to 0
+    for s in scores.values():
+        assert -1.0 <= s <= 1.0
+    # predict_proba should have been called at least once
+    assert mock_model.predict_proba.called
+    # predict() should not have been called (we're on the classifier path)
+    mock_model.predict.assert_not_called()
+
+
+def test_score_features_dispatches_on_classifier_flag():
+    model = MLSignal(model_path="/tmp/nonexistent_sf.pkl")
+    # Regressor path
+    reg_mock = _make_mock_model()
+    model._model = reg_mock
+    model._is_classifier = False
+    out_reg = model.score_features(np.zeros((4, len(_FEATURE_COLS))))
+    assert len(out_reg) == 4
+    reg_mock.predict.assert_called_once()
+    # Classifier path
+    clf_mock = _make_classifier_mock_model(n_rows=4)
+    model._model = clf_mock
+    model._is_classifier = True
+    out_clf = model.score_features(np.zeros((4, len(_FEATURE_COLS))))
+    assert out_clf == pytest.approx(np.array([0.3, 0.3, 0.3, 0.3]))
+
+
+def test_score_features_raises_without_trained_model():
+    model = MLSignal(model_path="/tmp/nonexistent_sf2.pkl")
+    with pytest.raises(RuntimeError, match="no trained model"):
+        model.score_features(np.zeros((2, 3)))
+
+
+def test_train_triple_barrier_routes_to_classifier(monkeypatch, tmp_path):
+    """train(label_type='triple_barrier') should fit LGBMClassifier, set
+    _is_classifier=True, and persist both fields."""
+    from data.features import _FEATURE_COLS as F_COLS
+
+    # Synthetic FM with fwd_ret_5d AND tb_bin + tb_ret columns
+    np.random.seed(0)
+    n_dates, n_tickers = 40, 4
+    dates = pd.date_range("2022-01-01", periods=n_dates, freq="B")
+    tickers = [f"T{i}" for i in range(n_tickers)]
+    rows = []
+    for d in dates:
+        for t in tickers:
+            row = {"date": d, "ticker": t}
+            for c in F_COLS:
+                row[c] = np.random.randn()
+            row["fwd_ret_5d"] = np.random.randn() * 0.01
+            row["tb_bin"] = np.random.choice([-1, 0, 1])
+            row["tb_ret"] = np.random.randn() * 0.01
+            row["tb_target"] = abs(np.random.randn()) * 0.01
+            rows.append(row)
+    fm = pd.DataFrame(rows).set_index(["date", "ticker"])
+
+    fitted_kinds: list[str] = []
+
+    class _FakeRegressor:
+        def __init__(self, **_k): fitted_kinds.append("regressor")
+        def fit(self, X, y): self._y = y
+        def predict(self, X): return np.zeros(len(X))
+
+    class _FakeClassifier:
+        classes_ = np.array([-1, 0, 1])
+        def __init__(self, **_k): fitted_kinds.append("classifier")
+        def fit(self, X, y): self._y = y
+        def predict_proba(self, X):
+            return np.tile(np.array([0.2, 0.3, 0.5]), (len(X), 1))
+
+    fake_lgb = MagicMock()
+    fake_lgb.LGBMRegressor = _FakeRegressor
+    fake_lgb.LGBMClassifier = _FakeClassifier
+
+    # Make triple_barrier FM return non-empty
+    monkeypatch.setattr(
+        "strategies.ml_signal.build_feature_matrix",
+        lambda tickers, **kwargs: fm,
+    )
+    monkeypatch.setattr("strategies.ml_signal._LGBM_AVAILABLE", True)
+    monkeypatch.setattr("strategies.ml_signal.lgb", fake_lgb)
+    monkeypatch.setattr(MLSignal, "_write_metadata", lambda *a, **k: None)
+
+    # The fake classifier is a local class → can't be pickled. Capture the
+    # payload in-memory instead.
+    captured: dict = {}
+    def _capture_pickle(obj, f):
+        captured.update(obj if isinstance(obj, dict) else {"raw": obj})
+    monkeypatch.setattr("strategies.ml_signal.pickle.dump", _capture_pickle)
+
+    ckpt = tmp_path / "clf.pkl"
+    model = MLSignal(model_path=str(ckpt))
+    metrics = model.train(
+        [f"T{i}" for i in range(n_tickers)],
+        period="2y",
+        label_type="triple_barrier",
+    )
+
+    assert model._is_classifier is True
+    assert "classifier" in fitted_kinds
+    assert "regressor" not in fitted_kinds
+    assert "train_ic" in metrics
+
+    # Checkpoint payload preserves the classifier flag
+    assert captured.get("is_classifier") is True
+    assert "model" in captured
+
+
+def test_load_legacy_regressor_checkpoint(tmp_path):
+    """Legacy checkpoints (bare estimator pickle) load as regressor."""
+    import pickle
+    ckpt = tmp_path / "legacy.pkl"
+    with open(ckpt, "wb") as f:
+        pickle.dump(_PicklablePlainRegressor(), f)
+
+    with patch("strategies.ml_signal._LGBM_AVAILABLE", True):
+        model = MLSignal(model_path=str(ckpt))
+    assert model._model is not None
+    assert model._is_classifier is False
+
+
+def test_load_versioned_classifier_checkpoint(tmp_path):
+    """Versioned checkpoints round-trip is_classifier=True."""
+    import pickle
+    ckpt = tmp_path / "versioned.pkl"
+    with open(ckpt, "wb") as f:
+        pickle.dump(
+            {"model": _PicklablePlainClassifier(), "is_classifier": True}, f,
+        )
+
+    with patch("strategies.ml_signal._LGBM_AVAILABLE", True):
+        model = MLSignal(model_path=str(ckpt))
+    assert model._is_classifier is True
+
+
 # ── MLSignal — with LightGBM (skipped if not installed) ───────────────────────
 
 @pytest.mark.skipif(not _LGBM_AVAILABLE, reason="lightgbm not installed")

--- a/tests/test_ml_tuning.py
+++ b/tests/test_ml_tuning.py
@@ -15,6 +15,8 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 from strategies.ml_tuning import (
     _OPTUNA_AVAILABLE,
     _purged_splits,
+    load_best_params,
+    save_best_params,
     tune_lgbm_hyperparams,
 )
 
@@ -65,6 +67,69 @@ def test_tune_lgbm_raises_on_empty_feature_matrix(monkeypatch):
     )
     with pytest.raises(RuntimeError, match="feature matrix is empty"):
         tune_lgbm_hyperparams(["AAPL"], period="1y", n_trials=1)
+
+
+def test_save_and_load_best_params_round_trip(tmp_path, monkeypatch):
+    """save_best_params → load_best_params recovers the original dict."""
+    import sqlite3
+    db_path = tmp_path / "params.db"
+
+    def _fake_conn():
+        conn = sqlite3.connect(str(db_path))
+        conn.row_factory = sqlite3.Row
+        conn.execute("""
+            CREATE TABLE IF NOT EXISTS model_best_params (
+                model_name   TEXT    PRIMARY KEY,
+                updated_at   REAL    NOT NULL,
+                params_json  TEXT    NOT NULL,
+                best_ic      REAL
+            )
+        """)
+        return conn
+
+    monkeypatch.setattr("data.db.get_connection", _fake_conn)
+
+    params = {
+        "n_estimators": 200, "learning_rate": 0.05, "num_leaves": 31,
+    }
+    save_best_params("lgbm_alpha", params, best_ic=0.042)
+    recovered = load_best_params("lgbm_alpha")
+    assert recovered == params
+
+    # Missing row returns None (not an exception)
+    assert load_best_params("does_not_exist") is None
+
+
+def test_save_best_params_upserts_on_conflict(tmp_path, monkeypatch):
+    """Re-saving for the same model_name overwrites the previous row."""
+    import sqlite3
+    db_path = tmp_path / "params.db"
+
+    def _fake_conn():
+        conn = sqlite3.connect(str(db_path))
+        conn.row_factory = sqlite3.Row
+        conn.execute("""
+            CREATE TABLE IF NOT EXISTS model_best_params (
+                model_name   TEXT    PRIMARY KEY,
+                updated_at   REAL    NOT NULL,
+                params_json  TEXT    NOT NULL,
+                best_ic      REAL
+            )
+        """)
+        return conn
+
+    monkeypatch.setattr("data.db.get_connection", _fake_conn)
+
+    save_best_params("lgbm_alpha", {"lr": 0.01}, best_ic=0.01)
+    save_best_params("lgbm_alpha", {"lr": 0.05}, best_ic=0.08)
+    assert load_best_params("lgbm_alpha") == {"lr": 0.05}
+
+
+def test_load_best_params_handles_db_error(monkeypatch):
+    """Transient DB errors return None rather than propagating."""
+    def _broken(): raise RuntimeError("db down")
+    monkeypatch.setattr("data.db.get_connection", _broken)
+    assert load_best_params("lgbm_alpha") is None
 
 
 @pytest.mark.skipif(not _OPTUNA_AVAILABLE, reason="optuna not installed")

--- a/tests/test_monthly_ml_retrain.py
+++ b/tests/test_monthly_ml_retrain.py
@@ -112,6 +112,40 @@ def test_main_exits_on_unexpected_exception(mock_cls):
     assert exc_info.value.code == 1
 
 
+@patch("strategies.ml_tuning.load_best_params")
+@patch("cron.monthly_ml_retrain.MLSignal")
+@patch("cron.monthly_ml_retrain._LGBM_AVAILABLE", True)
+def test_main_passes_tuned_params_when_available(mock_cls, mock_load):
+    """If load_best_params returns a dict, train() must receive it as lgbm_params."""
+    tuned = {"n_estimators": 500, "learning_rate": 0.03}
+    mock_load.return_value = tuned
+    mock_instance = MagicMock()
+    mock_instance.train.return_value = _MOCK_RESULT
+    mock_cls.return_value = mock_instance
+
+    from cron.monthly_ml_retrain import main
+    main()
+
+    call_kwargs = mock_instance.train.call_args[1]
+    assert call_kwargs.get("lgbm_params") == tuned
+
+
+@patch("strategies.ml_tuning.load_best_params", return_value=None)
+@patch("cron.monthly_ml_retrain.MLSignal")
+@patch("cron.monthly_ml_retrain._LGBM_AVAILABLE", True)
+def test_main_passes_none_when_no_tuned_params(mock_cls, mock_load):
+    """No persisted params → train() is called with lgbm_params=None (defaults)."""
+    mock_instance = MagicMock()
+    mock_instance.train.return_value = _MOCK_RESULT
+    mock_cls.return_value = mock_instance
+
+    from cron.monthly_ml_retrain import main
+    main()
+
+    call_kwargs = mock_instance.train.call_args[1]
+    assert call_kwargs.get("lgbm_params") is None
+
+
 @patch("cron.monthly_ml_retrain.MLSignal")
 @patch("cron.monthly_ml_retrain._LGBM_AVAILABLE", True)
 def test_main_strips_whitespace_from_tickers(mock_cls):

--- a/tests/test_pages.py
+++ b/tests/test_pages.py
@@ -736,3 +736,143 @@ class TestPagesMlSignals:
             patch("strategies.linear_signal.LinearSignal", return_value=self._mock_linear_signal()),
         ):
             pg_ml_signals.render()
+
+    def test_render_tune_hyperparameters_button(self):
+        """Click path for the Optimize Hyperparameters button (#64)."""
+        _reset_session()
+
+        def _btn(label, **kw):
+            return kw.get("key") == "ml_tune_btn"
+
+        _ST.button.side_effect = _btn
+        tune_result = {
+            "best_params": {"learning_rate": 0.05, "num_leaves": 48},
+            "best_ic": 0.07,
+            "n_trials": 20,
+            "n_samples": 1500,
+        }
+        with (
+            patch("strategies.ml_signal.MLSignal", return_value=self._mock_ml_signal()),
+            patch("strategies.ml_tuning._OPTUNA_AVAILABLE", True),
+            patch(
+                "strategies.ml_tuning.tune_lgbm_hyperparams",
+                return_value=tune_result,
+            ) as mock_tune,
+            patch("strategies.ml_tuning.save_best_params") as mock_save,
+        ):
+            pg_ml_signals.render()
+
+        mock_tune.assert_called_once()
+        mock_save.assert_called_once()
+        assert _ST.session_state.get("ml_best_params") == tune_result["best_params"]
+        assert _ST.session_state.get("ml_tune_result") == tune_result
+        _ST.button.side_effect = None
+        _ST.button.return_value = False
+
+    def test_render_triple_barrier_label_type_passed(self):
+        """Selecting label_type=triple_barrier passes the kwargs through to train."""
+        _reset_session()
+
+        def _sel(label, options=(), *a, **kw):
+            opts = list(options)
+            if kw.get("key") == "ml_label_type":
+                return "triple_barrier"
+            return opts[kw.get("index", 0)] if opts else ""
+
+        _ST.selectbox.side_effect = _sel
+
+        def _btn(label, **kw):
+            return kw.get("key") == "ml_train_btn"
+
+        _ST.button.side_effect = _btn
+        mock_model = self._mock_ml_signal()
+        with (
+            patch("strategies.ml_signal._LGBM_AVAILABLE", True),
+            patch("strategies.ml_signal.MLSignal", return_value=mock_model),
+        ):
+            pg_ml_signals.render()
+
+        mock_model.train.assert_called_once()
+        kwargs = mock_model.train.call_args[1]
+        assert kwargs.get("label_type") == "triple_barrier"
+        # Mocked number_input returns 5.0 by default (see _reset_session)
+        pt_sl = kwargs.get("pt_sl")
+        assert pt_sl is not None
+        assert all(isinstance(v, float) for v in pt_sl)
+        num_days = kwargs.get("num_days")
+        assert num_days is not None and isinstance(num_days, int)
+        _ST.button.side_effect = None
+        _ST.button.return_value = False
+        _ST.selectbox.side_effect = (
+            lambda label, options=(), *a, **kw:
+            list(options)[kw.get("index", 0)] if list(options) else ""
+        )
+
+    def test_render_backtest_meta_labeling_path(self):
+        """With the meta-labeling checkbox on, two backtest results are stored."""
+        _reset_session()
+        # Reset widget side effects that prior tests may have mutated
+        _ST.selectbox.side_effect = (
+            lambda label, options=(), *a, **kw:
+            list(options)[kw.get("index", 0)] if list(options) else ""
+        )
+        _ST.checkbox.return_value = True
+
+        # Pretend a trained model is in session state already
+        trained = MagicMock()
+        trained._model = MagicMock()
+        trained._is_classifier = False
+        trained.score_features.return_value = np.linspace(-0.3, 0.3, 5)
+        _ST.session_state["ml_model_instance"] = trained
+
+        def _btn(label, **kw):
+            return kw.get("key") == "ml_backtest_btn"
+
+        _ST.button.side_effect = _btn
+
+        # Two tiny indices: 5 feature rows, 60 ohlcv rows
+        idx = pd.date_range("2024-01-01", periods=5, freq="B")
+        feature_cols = [
+            "ret_1d", "ret_5d", "ret_10d", "ret_21d",
+            "skew_21d", "kurt_21d", "autocorr_1", "realised_vol_21d",
+            "vol_ratio_20d", "vol_zscore_20d",
+        ]
+        # Build a MultiIndex FM with focus_ticker="AAPL"
+        fm_rows = []
+        for d in idx:
+            fm_rows.append({"date": d, "ticker": "AAPL",
+                             **{c: 0.0 for c in feature_cols}})
+        fm = pd.DataFrame(fm_rows).set_index(["date", "ticker"])
+
+        bt_result = MagicMock(
+            total_return_pct=1.0, sharpe_ratio=0.5,
+            max_drawdown_pct=-2.0, num_trades=3,
+            equity_curve=pd.DataFrame({"Equity": [1, 1.01], "BuyHold": [1, 1.005]}),
+        )
+
+        with (
+            patch("strategies.ml_signal.MLSignal", return_value=self._mock_ml_signal()),
+            patch("data.features.build_feature_matrix", return_value=fm),
+            patch("data.fetcher.fetch_ohlcv", return_value=_ohlcv(60)),
+            patch("backtester.engine.run_signal_backtest", return_value=bt_result),
+            patch(
+                "analysis.triple_barrier.triple_barrier_labels",
+                return_value=pd.DataFrame(
+                    {"bin": [1, -1, 1, 0, -1], "ret": [0.01]*5, "target": [0.02]*5},
+                    index=idx,
+                ),
+            ),
+            patch("strategies.meta_label._SKLEARN_AVAILABLE", True),
+            patch("strategies.meta_label.MetaLabeler") as mock_labeler_cls,
+        ):
+            labeler = MagicMock()
+            labeler.fit.return_value = {"train_accuracy": 0.6, "n_samples": 5, "positive_rate": 0.5}
+            labeler.predict.return_value = pd.Series([0.7, -0.6, 0.8, 0.0, -0.9], index=idx)
+            mock_labeler_cls.return_value = labeler
+            pg_ml_signals.render()
+
+        assert "ml_backtest_result" in _ST.session_state
+        assert "ml_backtest_result_meta" in _ST.session_state
+        _ST.button.side_effect = None
+        _ST.button.return_value = False
+        _ST.checkbox.return_value = True


### PR DESCRIPTION
Surface three ready-but-unreachable ML pipeline pieces in the Streamlit
ML Signals tab:

- #63 Triple-barrier toggle: data/features.build_feature_matrix gains a
  label_type kwarg; strategies/ml_signal.MLSignal.train (and regime
  variant) route to LGBMClassifier when label_type="triple_barrier", with
  score = P(+1) - P(-1) mapped into [-1, 1].  Versioned checkpoint payload
  preserves the is_classifier flag; legacy bare-estimator pickles still
  load as regressors.
- #64 Optimize Hyperparameters button: new Train-row button calls
  tune_lgbm_hyperparams() and persists best params into a new
  model_best_params table via save_best_params/load_best_params helpers;
  cron/monthly_ml_retrain picks them up on the next scheduled run.
- #65 Meta-labeling in backtest: "Apply meta-labeling" checkbox fits a
  MetaLabeler on triple-barrier bins, applies a confidence threshold, and
  overlays the filtered equity curve on the raw LGBM curve.

Tests cover the new feature-matrix columns, the classifier training
path, checkpoint round-trip, save/load best params, cron using persisted
params, and UI smoke tests for all three toggles/buttons. Coverage
stays above the 76% gate.