### PR TITLE
feat: Hierarchical Risk Parity allocator (AFML Ch 16, closes #67)

### DIFF
--- a/ML_BOOK_MAP.md
+++ b/ML_BOOK_MAP.md
@@ -44,6 +44,7 @@ graph LR
         B5[risk/markowitz.py]
         B6[risk/var.py]
         B7[analysis/regime.py]
+        B8[risk/hrp.py<br/>Hierarchical Risk Parity]
     end
 
     subgraph Execution[Execution & Ops]
@@ -53,7 +54,7 @@ graph LR
         E4[cron/monthly_ml_retrain.py]
     end
 
-    AFML --> F3 & F4 & M4 & M5 & B1 & B4
+    AFML --> F3 & F4 & M4 & M5 & B1 & B4 & B8
     ML4T --> F1 & F2 & F5 & M1 & M2 & M3 & M5 & B2 & B3 & B5 & B6 & B7
 
     F1 --> M1 & M2
@@ -71,7 +72,7 @@ graph LR
 
     classDef done fill:#d5f5e3,stroke:#229954,color:#154360
     classDef planned fill:#fdebd0,stroke:#b9770e,color:#7e5109
-    class F1,F2,F3,F4,F5,M1,M2,M3,M4,M5,B1,B2,B3,B4,B5,B6,B7,E1,E2,E3,E4 done
+    class F1,F2,F3,F4,F5,M1,M2,M3,M4,M5,B1,B2,B3,B4,B5,B6,B7,B8,E1,E2,E3,E4 done
 ```
 
 ---
@@ -96,7 +97,7 @@ graph LR
 | 13 — Backtesting on Synthetic Data           | bootstrap, GAN                 |   🟡   | bootstrap in `backtester/monte_carlo.py`; GAN out of scope      |
 | 14 — Backtest Statistics                     | Sharpe, Sortino, MAR           |   ✅   | `analysis/risk_metrics.py`, `backtester/engine.py`              |
 | 15 — Understanding Strategy Risk             | efficient frontier, VaR        |   ✅   | `risk/markowitz.py`, `risk/var.py`                              |
-| 16 — ML Asset Allocation                     | Hierarchical Risk Parity       |   ⏳   | _planned_ — see issue "HRP allocator"                           |
+| 16 — ML Asset Allocation                     | Hierarchical Risk Parity       |   ✅   | `risk/hrp.py` (quasi-diag + recursive bisection)                 |
 | 17 — Structural Breaks                       | CUSUM, Chow tests              |   ⏳   | _planned_ — see issue "Structural break detection"              |
 | 18 — Entropy Features                        | Shannon / plug-in / K-L        |   ⏳   | _planned_ — see issue "Entropy features"                        |
 | 19 — Microstructural Features                | VPIN, Kyle λ                   |   ⏳   | _planned_ — see issue "Microstructural features"                |

--- a/pages/efficient_frontier.py
+++ b/pages/efficient_frontier.py
@@ -5,6 +5,7 @@ import pandas as pd
 import streamlit as st
 
 from data.fetcher import fetch_latest_price, fetch_ohlcv
+from risk.hrp import get_hrp_portfolio
 from risk.markowitz import (
     build_efficient_frontier_chart,
     get_max_sharpe_portfolio,
@@ -121,8 +122,11 @@ def render() -> None:
         st.error("Optimisation failed — not enough data.")
         return
 
+    with st.spinner("Computing Hierarchical Risk Parity weights…"):
+        hrp = get_hrp_portfolio(price_data, risk_free_rate=risk_free)
+
     st.subheader("Optimal Portfolios")
-    oc1, oc2 = st.columns(2)
+    oc1, oc2, oc3 = st.columns(3)
 
     with oc1:
         st.markdown("**Max Sharpe Ratio**")
@@ -154,13 +158,42 @@ def render() -> None:
             )
             st.dataframe(minvol_df, use_container_width=True, hide_index=True)
 
+    with oc3:
+        st.markdown("**Hierarchical Risk Parity**")
+        st.caption("AFML Ch 16 · no matrix inversion")
+        if hrp is None:
+            st.info("HRP unavailable for this universe.")
+        else:
+            hp1, hp2, hp3 = st.columns(3)
+            hp1.metric("Expected Return", f"{hrp.expected_return * 100:.1f}%")
+            hp2.metric("Volatility",      f"{hrp.expected_volatility * 100:.1f}%")
+            hp3.metric("Sharpe Ratio",    f"{hrp.sharpe_ratio:.2f}")
+            hrp_df = pd.DataFrame(
+                [{"Ticker": k, "Allocation %": v * 100}
+                 for k, v in sorted(hrp.weights.items(), key=lambda x: -x[1])]
+            )
+            st.dataframe(
+                hrp_df.style.bar(
+                    subset=["Allocation %"], color="#6c5ce7"
+                ).format({"Allocation %": "{:.1f}%"}),
+                use_container_width=True, hide_index=True,
+            )
+
     # ── Rebalancer ────────────────────────────────────────────────────────────
     st.divider()
     st.subheader("⚖️ Portfolio Rebalancer")
     st.caption(
         "Enter your current holdings to see what trades would move you to the "
-        "max-Sharpe-ratio allocation."
+        "selected target allocation."
     )
+
+    target_options: dict[str, dict] = {
+        "Max Sharpe": max_sharpe.weights,
+    }
+    if min_vol is not None:
+        target_options["Min Volatility"] = min_vol.weights
+    if hrp is not None:
+        target_options["Hierarchical Risk Parity"] = hrp.weights
 
     rc1, rc2 = st.columns([2, 1])
     with rc1:
@@ -171,6 +204,12 @@ def render() -> None:
             help="Enter market value in dollars for each position you currently hold.",
         )
     with rc2:
+        target_choice = st.selectbox(
+            "Target allocation",
+            options=list(target_options.keys()),
+            index=0,
+            help="Pick which optimal portfolio to rebalance towards.",
+        )
         total_equity = st.number_input(
             "Total equity ($)",
             min_value=1_000.0,
@@ -192,9 +231,10 @@ def render() -> None:
 
     if run_rebalance:
         current_positions = _parse_holdings(holdings_text)
+        target_weights = target_options[target_choice]
 
         # Fetch current prices for all tickers in the optimal portfolio
-        price_tickers = set(max_sharpe.weights) | set(current_positions)
+        price_tickers = set(target_weights) | set(current_positions)
         prices_key = ",".join(sorted(price_tickers))
         with st.spinner("Fetching current prices…"):
             current_prices = _fetch_current_prices(prices_key)
@@ -208,7 +248,7 @@ def render() -> None:
 
         trades = compute_rebalance_trades(
             current_positions=current_positions,
-            target_weights=max_sharpe.weights,
+            target_weights=target_weights,
             total_equity=total_equity,
             current_prices=current_prices,
             min_trade_value=min_trade,

--- a/risk/hrp.py
+++ b/risk/hrp.py
@@ -1,0 +1,217 @@
+"""
+risk/hrp.py — Hierarchical Risk Parity portfolio allocation.
+
+Implements López de Prado (AFML Ch 16)'s HRP algorithm: allocates capital
+by recursively bisecting a quasi-diagonalised correlation matrix instead
+of inverting the covariance matrix.  Avoids Markowitz's sensitivity to
+ill-conditioned covariance matrices and typically produces more stable
+out-of-sample weights.
+
+Algorithm
+---------
+1. Distance matrix:        d_ij = sqrt(0.5 * (1 - corr_ij))
+2. Hierarchical clustering: scipy.cluster.hierarchy.linkage
+3. Quasi-diagonalisation:   re-order assets so correlated ones are adjacent
+4. Recursive bisection:     split each cluster in half, allocate via
+                            inverse-variance weighting
+
+Reference
+---------
+    López de Prado, *Advances in Financial Machine Learning*, Ch 16.4.
+"""
+from __future__ import annotations
+
+from typing import Optional
+
+import numpy as np
+import pandas as pd
+from scipy.cluster.hierarchy import linkage
+from scipy.spatial.distance import squareform
+
+from risk.markowitz import OptimalPortfolio
+
+
+def _correlation_distance(corr: pd.DataFrame) -> pd.DataFrame:
+    """AFML Ch 16 distance metric: d_ij = sqrt(0.5 * (1 - corr_ij))."""
+    # Clip to [-1, 1] to avoid sqrt(negative) from tiny float noise.
+    dist = np.sqrt(np.clip(0.5 * (1.0 - corr), 0.0, 1.0))
+    return dist
+
+
+def _quasi_diag(link: np.ndarray) -> list[int]:
+    """Re-order the linkage matrix so correlated items sit adjacent.
+
+    Follows AFML Code Snippet 16.2 verbatim (apart from int casts).
+    """
+    link = link.astype(int)
+    sort_ix = pd.Series([link[-1, 0], link[-1, 1]])
+    num_items = link[-1, 3]
+
+    while sort_ix.max() >= num_items:
+        sort_ix.index = range(0, sort_ix.shape[0] * 2, 2)
+        df0 = sort_ix[sort_ix >= num_items]          # clusters that must expand
+        i = df0.index
+        j = df0.values - num_items
+        sort_ix[i] = link[j, 0]
+        df_right = pd.Series(link[j, 1], index=i + 1)
+        sort_ix = pd.concat([sort_ix, df_right])
+        sort_ix = sort_ix.sort_index()
+        sort_ix.index = range(sort_ix.shape[0])
+
+    return sort_ix.tolist()
+
+
+def _inverse_variance_weights(cov_slice: pd.DataFrame) -> pd.Series:
+    """Inverse-variance sub-weights inside a cluster (AFML Eq 16.3)."""
+    ivp = 1.0 / np.diag(cov_slice.values)
+    ivp /= ivp.sum()
+    return pd.Series(ivp, index=cov_slice.index)
+
+
+def _cluster_variance(cov: pd.DataFrame, items: list) -> float:
+    """Variance of a sub-portfolio using inverse-variance sub-weights."""
+    cov_slice = cov.loc[items, items]
+    w = _inverse_variance_weights(cov_slice).values.reshape(-1, 1)
+    return float((w.T @ cov_slice.values @ w).item())
+
+
+def _recursive_bisection(cov: pd.DataFrame, sorted_tickers: list) -> pd.Series:
+    """Top-down recursive bisection weighting (AFML Code Snippet 16.4)."""
+    weights = pd.Series(1.0, index=sorted_tickers)
+    clusters: list[list] = [sorted_tickers]
+
+    while clusters:
+        next_clusters: list[list] = []
+        for cluster in clusters:
+            if len(cluster) <= 1:
+                continue
+            half = len(cluster) // 2
+            left, right = cluster[:half], cluster[half:]
+            var_left = _cluster_variance(cov, left)
+            var_right = _cluster_variance(cov, right)
+            total = var_left + var_right
+            # alpha is the fraction allocated to the LEFT cluster.  Higher
+            # variance on the right → more to the left (and vice-versa).
+            alpha = 1.0 - var_left / total if total > 0 else 0.5
+            weights[left] *= alpha
+            weights[right] *= 1.0 - alpha
+            next_clusters.extend([left, right])
+        clusters = next_clusters
+
+    return weights
+
+
+def hrp_weights(
+    returns: pd.DataFrame,
+    method: str = "single",
+) -> pd.Series:
+    """Compute Hierarchical Risk Parity weights from a returns DataFrame.
+
+    Parameters
+    ----------
+    returns : pd.DataFrame
+        Columns are tickers, rows are time-ordered returns.  At least two
+        assets and two observations are required.
+    method : str
+        Linkage method forwarded to ``scipy.cluster.hierarchy.linkage``.
+        Defaults to ``"single"``, matching the AFML reference
+        implementation.
+
+    Returns
+    -------
+    pd.Series indexed by ticker, weights summing to 1.0.  Single-asset
+    input returns a one-element series with weight 1.0.  Empty or
+    degenerate input returns an empty series.
+    """
+    if returns is None or returns.empty:
+        return pd.Series(dtype=float)
+
+    n = returns.shape[1]
+    if n == 0:
+        return pd.Series(dtype=float)
+    if n == 1:
+        return pd.Series([1.0], index=returns.columns)
+
+    corr = returns.corr().fillna(0.0)
+    cov = returns.cov().fillna(0.0)
+
+    # Guard against singular correlation: clamp diagonal to exactly 1.
+    # pandas >=3.0 returns read-only .values views, so work on a copy.
+    corr_arr = corr.to_numpy(copy=True)
+    np.fill_diagonal(corr_arr, 1.0)
+    corr = pd.DataFrame(corr_arr, index=corr.index, columns=corr.columns)
+
+    dist = _correlation_distance(corr)
+    # squareform requires a strictly-symmetric zero-diagonal matrix; tiny
+    # float noise can break this, so we explicitly zero the diagonal.
+    dist_values = dist.to_numpy(copy=True)
+    np.fill_diagonal(dist_values, 0.0)
+    condensed = squareform(dist_values, checks=False)
+
+    try:
+        link = linkage(condensed, method=method)
+    except ValueError:
+        # Degenerate case: fall back to equal weights so callers don't crash.
+        return pd.Series(1.0 / n, index=returns.columns)
+
+    sort_indices = _quasi_diag(link)
+    sorted_tickers = [returns.columns[i] for i in sort_indices]
+
+    weights = _recursive_bisection(cov, sorted_tickers)
+    # Re-align to the input column order so callers can reason about order.
+    return weights.reindex(returns.columns).astype(float)
+
+
+def get_hrp_portfolio(
+    price_data: dict,
+    risk_free_rate: float = 0.05,
+    method: str = "single",
+) -> Optional[OptimalPortfolio]:
+    """Return an HRP-allocated ``OptimalPortfolio`` for the given price data.
+
+    Mirrors ``risk.markowitz.get_max_sharpe_portfolio`` so the UI can
+    swap the two without special-casing.  Expected return and volatility
+    are computed on the resulting weights using annualised mean / cov of
+    daily returns.
+    """
+    if price_data is None or len(price_data) == 0:
+        return None
+    if len(price_data) < 2:
+        # Single-asset portfolio trivially has weight 1 — keep the shape.
+        ticker = next(iter(price_data.keys()))
+        series = price_data[ticker]
+        if series is None or len(series) < 2:
+            return None
+        daily_ret = series.pct_change().dropna()
+        exp_ret = float(daily_ret.mean() * 252)
+        exp_vol = float(daily_ret.std() * np.sqrt(252))
+        sharpe = (exp_ret - risk_free_rate) / exp_vol if exp_vol > 0 else 0.0
+        return OptimalPortfolio(
+            weights={ticker: 1.0},
+            expected_return=exp_ret,
+            expected_volatility=exp_vol,
+            sharpe_ratio=float(sharpe),
+        )
+
+    df = pd.DataFrame(price_data).pct_change().dropna()
+    if df.empty or df.shape[1] < 2:
+        return None
+
+    weights = hrp_weights(df, method=method)
+    if weights.empty:
+        return None
+
+    mean_returns = df.mean() * 252
+    cov_matrix = df.cov() * 252
+
+    w_vec = weights.reindex(df.columns).fillna(0.0).values
+    exp_ret = float(w_vec @ mean_returns.values)
+    exp_vol = float(np.sqrt(w_vec @ cov_matrix.values @ w_vec))
+    sharpe = (exp_ret - risk_free_rate) / exp_vol if exp_vol > 0 else 0.0
+
+    return OptimalPortfolio(
+        weights={t: float(weights[t]) for t in df.columns},
+        expected_return=exp_ret,
+        expected_volatility=exp_vol,
+        sharpe_ratio=float(sharpe),
+    )

--- a/tests/test_hrp.py
+++ b/tests/test_hrp.py
@@ -1,0 +1,199 @@
+"""Unit tests for risk/hrp.py — Hierarchical Risk Parity allocator.
+
+Fixtures mirror tests/test_markowitz.py so that HRP and Markowitz are
+covered by the same style of deterministic synthetic data.
+"""
+import os
+import sys
+
+import numpy as np
+import pandas as pd
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from risk.hrp import (
+    _correlation_distance,
+    _inverse_variance_weights,
+    _quasi_diag,
+    _recursive_bisection,
+    get_hrp_portfolio,
+    hrp_weights,
+)
+from risk.markowitz import OptimalPortfolio
+
+
+def _make_price_data(n: int = 250, seed: int = 5) -> dict:
+    """Three synthetic assets — mirrors tests/test_markowitz.py."""
+    np.random.seed(seed)
+    tickers = ["AAPL", "MSFT", "GOOG"]
+    return {
+        t: pd.Series(100 + np.cumsum(np.random.randn(n) * 0.5))
+        for t in tickers
+    }
+
+
+def _make_correlated_returns(n: int = 300, seed: int = 7) -> pd.DataFrame:
+    """Five-asset returns where pairs (0,1) and (2,3) are tightly coupled.
+
+    HRP should group the coupled pairs and push weight onto asset 4 which
+    has uncorrelated noise.
+    """
+    rng = np.random.default_rng(seed)
+    base_ab = rng.normal(0, 0.01, n)
+    base_cd = rng.normal(0, 0.01, n)
+    cols = {
+        "A": base_ab + rng.normal(0, 0.001, n),
+        "B": base_ab + rng.normal(0, 0.001, n),
+        "C": base_cd + rng.normal(0, 0.001, n),
+        "D": base_cd + rng.normal(0, 0.001, n),
+        "E": rng.normal(0, 0.01, n),
+    }
+    return pd.DataFrame(cols)
+
+
+# ── Internal helpers ───────────────────────────────────────────────────────────
+
+def test_correlation_distance_diagonal_is_zero():
+    corr = pd.DataFrame(
+        [[1.0, 0.5], [0.5, 1.0]], index=["A", "B"], columns=["A", "B"],
+    )
+    dist = _correlation_distance(corr)
+    assert dist.loc["A", "A"] == pytest.approx(0.0)
+    assert dist.loc["B", "B"] == pytest.approx(0.0)
+    assert dist.loc["A", "B"] == pytest.approx(np.sqrt(0.25))
+
+
+def test_correlation_distance_clips_tiny_negative_noise():
+    """Floating-point noise can push the argument slightly below 0 — clip."""
+    corr = pd.DataFrame(
+        [[1.0 + 1e-12, 1.0], [1.0, 1.0]], index=["A", "B"], columns=["A", "B"],
+    )
+    dist = _correlation_distance(corr)
+    # Must be real (no NaN from sqrt of negative).
+    assert not dist.isna().any().any()
+
+
+def test_inverse_variance_weights_sum_to_one():
+    cov = pd.DataFrame(
+        np.diag([1.0, 2.0, 4.0]), index=["A", "B", "C"], columns=["A", "B", "C"],
+    )
+    w = _inverse_variance_weights(cov)
+    assert w.sum() == pytest.approx(1.0)
+    # Lowest variance should get the largest weight.
+    assert w["A"] > w["B"] > w["C"]
+
+
+def test_recursive_bisection_single_cluster_is_one():
+    cov = pd.DataFrame([[1.0]], index=["A"], columns=["A"])
+    w = _recursive_bisection(cov, ["A"])
+    assert w["A"] == pytest.approx(1.0)
+
+
+# ── hrp_weights ───────────────────────────────────────────────────────────────
+
+def test_hrp_weights_sum_to_one():
+    returns = _make_correlated_returns()
+    w = hrp_weights(returns)
+    assert w.sum() == pytest.approx(1.0)
+
+
+def test_hrp_weights_all_positive():
+    returns = _make_correlated_returns()
+    w = hrp_weights(returns)
+    assert (w >= 0).all()
+
+
+def test_hrp_weights_empty_frame_returns_empty():
+    w = hrp_weights(pd.DataFrame())
+    assert w.empty
+
+
+def test_hrp_weights_single_asset_returns_one():
+    returns = pd.DataFrame({"AAPL": np.random.randn(50) * 0.01})
+    w = hrp_weights(returns)
+    assert len(w) == 1
+    assert w["AAPL"] == pytest.approx(1.0)
+
+
+def test_hrp_weights_retain_input_order():
+    returns = _make_correlated_returns()
+    w = hrp_weights(returns)
+    # Columns come back in the original order, not the quasi-diag order.
+    assert list(w.index) == list(returns.columns)
+
+
+def test_hrp_weights_penalise_redundant_assets():
+    """Two near-identical pairs (A,B) + (C,D) vs an independent E.
+
+    Each correlated pair should share roughly one slice of the bisection,
+    so E (alone) should receive more weight than any individual pair
+    member."""
+    returns = _make_correlated_returns(n=500, seed=11)
+    w = hrp_weights(returns)
+    assert w["E"] > w["A"]
+    assert w["E"] > w["C"]
+
+
+def test_hrp_weights_reproducible():
+    returns = _make_correlated_returns()
+    w1 = hrp_weights(returns)
+    w2 = hrp_weights(returns)
+    pd.testing.assert_series_equal(w1, w2)
+
+
+# ── get_hrp_portfolio ─────────────────────────────────────────────────────────
+
+def test_get_hrp_portfolio_returns_optimal_portfolio():
+    data = _make_price_data()
+    p = get_hrp_portfolio(data)
+    assert isinstance(p, OptimalPortfolio)
+    assert set(p.weights.keys()) == set(data.keys())
+    assert sum(p.weights.values()) == pytest.approx(1.0, abs=1e-6)
+    assert p.expected_volatility > 0
+
+
+def test_get_hrp_portfolio_empty_data_returns_none():
+    assert get_hrp_portfolio({}) is None
+
+
+def test_get_hrp_portfolio_none_returns_none():
+    assert get_hrp_portfolio(None) is None
+
+
+def test_get_hrp_portfolio_single_ticker_trivial_weight():
+    series = pd.Series(100 + np.cumsum(np.random.randn(60) * 0.5))
+    p = get_hrp_portfolio({"AAPL": series})
+    assert p is not None
+    assert p.weights == {"AAPL": 1.0}
+
+
+def test_get_hrp_portfolio_single_ticker_too_short_returns_none():
+    # Need at least 2 points to have a non-trivial return series.
+    p = get_hrp_portfolio({"AAPL": pd.Series([100.0])})
+    assert p is None
+
+
+def test_get_hrp_portfolio_sharpe_matches_formula():
+    data = _make_price_data()
+    rf = 0.02
+    p = get_hrp_portfolio(data, risk_free_rate=rf)
+    assert p is not None
+    expected_sharpe = (p.expected_return - rf) / p.expected_volatility
+    assert p.sharpe_ratio == pytest.approx(expected_sharpe, rel=1e-6)
+
+
+# ── quasi-diagonalisation (small hand-crafted linkage) ────────────────────────
+
+def test_quasi_diag_simple_linkage():
+    """A 3-item single-link tree: items 0+1 merge first, then cluster 3 ∪ 2."""
+    # Columns: [left, right, distance, size]
+    link = np.array([
+        [0, 1, 0.5, 2],   # cluster 3 = {0, 1}
+        [3, 2, 0.9, 3],   # cluster 4 = {3, 2}
+    ])
+    order = _quasi_diag(link)
+    assert sorted(order) == [0, 1, 2]
+    # The last merge pulled cluster 3 to the left of leaf 2 → 2 should be
+    # the last element after quasi-diagonalisation.
+    assert order[-1] == 2


### PR DESCRIPTION
## Summary

Adds an HRP allocator alongside Max Sharpe and Min Volatility on the Efficient Frontier page. HRP (López de Prado AFML Ch 16) avoids Markowitz's covariance-inversion step by quasi-diagonalising the correlation matrix and recursively bisecting the resulting cluster hierarchy with inverse-variance sub-weights — typically more stable out-of-sample on ill-conditioned covariance matrices.

- `risk/hrp.py` — core algorithm. Distance = `sqrt(0.5 * (1 - corr))`, scipy single-linkage clustering, AFML Code-Snippet-16.2 quasi-diag, Snippet-16.4 recursive bisection. Public surface mirrors `risk/markowitz.py`:
  - `hrp_weights(returns) -> pd.Series`
  - `get_hrp_portfolio(price_data) -> OptimalPortfolio` so the UI and rebalancer consume it unchanged
- `pages/efficient_frontier.py` — 3-column "Optimal Portfolios" grid (Max Sharpe / Min Vol / HRP); rebalancer now has a selectbox to target any of the three allocations.
- `tests/test_hrp.py` — 18 tests covering distance metric, inverse-variance weights, recursive bisection, full pipeline, edge cases (empty, single asset, redundant correlated assets), quasi-diag ordering, determinism.
- `ML_BOOK_MAP.md` — AFML Ch 16 flips from ⏳ to ✅.

## Test plan

- [x] `pytest tests/test_hrp.py -v` — 18/18 passing
- [x] `pytest tests/ -m "not integration" --cov=. --cov-fail-under=76 -q` — 926 passed, 1 skipped, coverage **78.85%**
- [x] `ruff check .` — clean
- [x] `tests/test_pages.py::TestPagesEfficientFrontier` (41 page smoke tests) — still green after 2→3 column refactor
- [ ] Manual browser smoke: `streamlit run app.py` → Efficient Frontier tab → verify HRP panel renders and rebalancer accepts the new target — recommend reviewer sanity-check this locally since the existing page suite exercises the code but not the visuals

Closes #67.