### PR TITLE
feat: PCA + k-means risk-factor decomposition (Jansen Ch 13, closes #68)

### DIFF
--- a/ML_BOOK_MAP.md
+++ b/ML_BOOK_MAP.md
@@ -118,7 +118,7 @@ graph LR
 | 10 — Bayesian ML                             | Bayesian linear regression     |   ⏳   | _planned_ — see issue "Bayesian regression"                     |
 | 11 — Random Forests                          | long-short strategies          |   🟡   | used internally by `meta_label.py`; no dedicated strategy       |
 | 12 — Boosting                                | LightGBM / XGBoost             |   ✅   | `strategies/ml_signal.py`                                       |
-| 13 — Unsupervised Learning                   | PCA, k-means, risk factors     |   ⏳   | _planned_ — see issue "PCA / k-means risk factors"              |
+| 13 — Unsupervised Learning                   | PCA, k-means, risk factors     |   ✅   | `analysis/unsupervised.py` (PCA loadings + scree; k-means on corr-distance) |
 | 14 — Text Data / Sentiment Analysis          | Vader, VADER                   |   ✅   | `adapters/sentiment/vader_adapter.py`                           |
 | 15 — Topic Modeling                          | LDA on news                    |   ⏳   | _planned_ — see issue "Topic modeling on news"                  |
 | 16 — Word Embeddings                         | word2vec on filings            |   ⏳   | _planned_ — see issue "Word embeddings on filings"              |

--- a/analysis/unsupervised.py
+++ b/analysis/unsupervised.py
@@ -1,0 +1,166 @@
+"""
+analysis/unsupervised.py — PCA + k-means risk-factor decomposition.
+
+Surfaces latent risk factors and asset clusters via unsupervised learning:
+  * PCA on asset returns yields principal "statistical factors" — the top
+    few components typically explain the bulk of variance and look like
+    market / sector / style factors.
+  * k-means on a correlation-distance matrix groups assets that move
+    together.  Useful for pairs discovery and cluster-aware risk budgets.
+
+Reference
+---------
+    Jansen, *Machine Learning for Algorithmic Trading* (2nd ed.), Ch 13.
+
+Dependencies
+------------
+    scikit-learn >= 1.3.0, numpy, pandas.  Both are hard deps already
+    pulled in by the rest of the platform.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+import pandas as pd
+from sklearn.cluster import KMeans
+from sklearn.decomposition import PCA
+
+# Minimum observations per asset before PCA / k-means will run.
+_MIN_OBS = 20
+
+
+@dataclass
+class PCAFactors:
+    """Output of :func:`pca_risk_factors`.
+
+    Attributes
+    ----------
+    loadings :
+        ``n_assets × n_components`` DataFrame — each column is an
+        eigenvector of the returns covariance, indexed by ticker.
+    explained_variance :
+        Series indexed ``PC1, PC2, …`` giving the fraction of total
+        variance explained by each component.
+    components :
+        ``n_observations × n_components`` DataFrame — the returns
+        projected onto the PCA axes (handy for plotting factor
+        timeseries).
+    """
+
+    loadings: pd.DataFrame
+    explained_variance: pd.Series
+    components: pd.DataFrame
+
+
+def pca_risk_factors(
+    returns: pd.DataFrame,
+    n_components: int = 5,
+) -> PCAFactors:
+    """Run PCA on a returns matrix and return loadings + explained-variance.
+
+    Parameters
+    ----------
+    returns :
+        DataFrame with tickers as columns and a DatetimeIndex of
+        observations (typically daily returns).  Missing values are
+        filled with ``0.0`` so the estimator sees a dense matrix.
+    n_components :
+        Number of principal components to keep.  Automatically clipped
+        to ``min(n_assets, n_observations)`` when the requested value
+        would exceed the matrix rank.
+
+    Returns
+    -------
+    :class:`PCAFactors` with `loadings`, `explained_variance` and
+    `components`.  An empty :class:`PCAFactors` is returned when the
+    input does not have enough rows / columns to fit.
+    """
+    if returns is None or returns.empty:
+        return PCAFactors(pd.DataFrame(), pd.Series(dtype=float), pd.DataFrame())
+
+    cleaned = returns.fillna(0.0)
+    n_obs, n_assets = cleaned.shape
+    if n_obs < _MIN_OBS or n_assets < 2:
+        return PCAFactors(pd.DataFrame(), pd.Series(dtype=float), pd.DataFrame())
+
+    k = max(1, min(int(n_components), n_assets, n_obs))
+    pca = PCA(n_components=k)
+    projected = pca.fit_transform(cleaned.values)
+
+    component_names = [f"PC{i + 1}" for i in range(k)]
+
+    loadings = pd.DataFrame(
+        pca.components_.T,
+        index=cleaned.columns,
+        columns=component_names,
+    )
+    explained = pd.Series(
+        np.asarray(pca.explained_variance_ratio_, dtype=float),
+        index=component_names,
+        name="explained_variance_ratio",
+    )
+    components = pd.DataFrame(
+        projected,
+        index=cleaned.index,
+        columns=component_names,
+    )
+    return PCAFactors(loadings=loadings, explained_variance=explained, components=components)
+
+
+def _correlation_distance(corr: pd.DataFrame) -> np.ndarray:
+    """AFML-style distance in correlation space: d = sqrt(0.5 * (1 − ρ)).
+
+    Same metric as :mod:`risk.hrp`; reproduced here instead of importing
+    to keep this module free of intra-analysis cross-dependencies.
+    """
+    arr = corr.to_numpy(copy=True)
+    np.fill_diagonal(arr, 1.0)
+    return np.sqrt(np.clip(0.5 * (1.0 - arr), 0.0, 1.0))
+
+
+def cluster_assets(
+    returns: pd.DataFrame,
+    n_clusters: int = 8,
+    random_state: int = 42,
+) -> pd.Series:
+    """Group assets by k-means on a correlation-distance matrix.
+
+    Parameters
+    ----------
+    returns :
+        DataFrame of asset returns (tickers as columns).
+    n_clusters :
+        Target cluster count.  Automatically clipped to ``n_assets``.
+    random_state :
+        Seed forwarded to :class:`~sklearn.cluster.KMeans` for
+        deterministic tests.
+
+    Returns
+    -------
+    pd.Series indexed by ticker, values are integer cluster labels
+    ``0 … n_clusters − 1``.  Returns an empty series when the input is
+    unusable (fewer than 2 tickers or insufficient observations).
+    """
+    if returns is None or returns.empty or returns.shape[1] < 2:
+        return pd.Series(dtype=int)
+    if returns.shape[0] < _MIN_OBS:
+        return pd.Series(dtype=int)
+
+    corr = returns.corr().fillna(0.0)
+    dist = _correlation_distance(corr)
+
+    k = max(1, min(int(n_clusters), corr.shape[0]))
+    model = KMeans(n_clusters=k, random_state=random_state, n_init=10)
+    labels = model.fit_predict(dist)
+    return pd.Series(labels, index=corr.index, name="cluster").astype(int)
+
+
+def cluster_members(cluster_labels: pd.Series) -> dict[int, list[str]]:
+    """Invert a ticker → cluster series into ``{cluster_id: [tickers]}``."""
+    if cluster_labels is None or cluster_labels.empty:
+        return {}
+    out: dict[int, list[str]] = {}
+    for ticker, cid in cluster_labels.items():
+        out.setdefault(int(cid), []).append(str(ticker))
+    return {k: sorted(v) for k, v in sorted(out.items())}

--- a/pages/portfolio.py
+++ b/pages/portfolio.py
@@ -2,6 +2,8 @@
 pages/portfolio.py — Paper trading portfolio tab.
 """
 import numpy as np
+import pandas as pd
+import plotly.graph_objects as go
 import streamlit as st
 
 from broker.paper_trader import (
@@ -17,7 +19,7 @@ from broker.paper_trader import (
 from broker.paper_trader import (
     sell as pt_sell,
 )
-from data.fetcher import fetch_latest_price
+from data.fetcher import fetch_latest_price, fetch_ohlcv
 
 
 def render() -> None:
@@ -231,6 +233,16 @@ def render() -> None:
                     rc7.metric("Worst Day",  f"{rm.worst_day_pct:.2f}%")
                     rc8.metric("Best Day",   f"{rm.best_day_pct:.2f}%")
 
+    # ── Risk Factors (PCA / k-means) ──────────────────────────────────────────
+    st.divider()
+    with st.expander("🧬 Risk Factors (PCA / k-means)", expanded=False):
+        st.caption(
+            "Decompose a ticker universe into latent statistical factors (PCA) "
+            "and group assets by correlation distance (k-means). "
+            "Jansen, *ML for Algorithmic Trading* Ch 13."
+        )
+        _render_risk_factors()
+
     # ── Danger zone: reset ────────────────────────────────────────────────────
     st.divider()
     with st.expander("⚠️ Danger Zone"):
@@ -242,3 +254,141 @@ def render() -> None:
             reset_account()
             st.success("Account reset. Starting fresh.")
             st.rerun()
+
+
+# ── Risk Factor helpers ──────────────────────────────────────────────────────
+
+@st.cache_data(ttl=600, show_spinner=False)
+def _fetch_return_matrix(tickers_key: str, period: str) -> pd.DataFrame:
+    """Fetch daily-return frame for the comma-separated ticker string."""
+    cols: dict[str, pd.Series] = {}
+    for ticker in tickers_key.split(","):
+        t = ticker.strip().upper()
+        if not t:
+            continue
+        try:
+            df = fetch_ohlcv(t, period)
+            if df is not None and not df.empty:
+                cols[t] = df["Close"].astype(float)
+        except Exception:
+            pass
+    if not cols:
+        return pd.DataFrame()
+    prices = pd.DataFrame(cols).dropna(how="all")
+    return prices.pct_change().dropna(how="all")
+
+
+def _render_risk_factors() -> None:
+    """PCA scree + cluster heatmap + downloadable assignments."""
+    from analysis.unsupervised import (
+        cluster_assets,
+        cluster_members,
+        pca_risk_factors,
+    )
+
+    rf_col1, rf_col2, rf_col3 = st.columns([3, 1, 1])
+    with rf_col1:
+        raw_tickers = st.text_input(
+            "Tickers (comma-separated)",
+            value="AAPL, MSFT, GOOG, AMZN, META, NVDA, JPM, XOM",
+            key="rf_tickers",
+            help="Enter 3+ tickers to run PCA + k-means on their daily returns.",
+        )
+    with rf_col2:
+        rf_period = st.selectbox(
+            "History",
+            options=["6mo", "1y", "2y", "5y"],
+            index=2,
+            key="rf_period",
+        )
+    with rf_col3:
+        rf_k = int(st.number_input(
+            "Clusters (k)",
+            min_value=2, max_value=12, value=4, step=1,
+            key="rf_k",
+            help="k-means cluster count. Capped at the number of tickers.",
+        ))
+
+    tickers = [t.strip().upper() for t in raw_tickers.split(",") if t.strip()]
+    if len(tickers) < 3:
+        st.info("Enter at least 3 tickers to run the decomposition.")
+        return
+
+    tickers_key = ",".join(sorted(set(tickers)))
+    with st.spinner("Fetching daily returns…"):
+        returns = _fetch_return_matrix(tickers_key, rf_period)
+
+    if returns.empty or returns.shape[1] < 2:
+        st.error("Could not build a return matrix from the selected tickers.")
+        return
+
+    missing = [t for t in tickers if t not in returns.columns]
+    if missing:
+        st.warning(f"No data for: {', '.join(missing)}. Excluded.")
+
+    # ── PCA scree ─────────────────────────────────────────────────────────────
+    n_components = min(len(returns.columns), 6)
+    factors = pca_risk_factors(returns, n_components=n_components)
+    if factors.explained_variance.empty:
+        st.info("Not enough observations for PCA (need ≥ 20 rows).")
+        return
+
+    scree_fig = go.Figure(go.Bar(
+        x=list(factors.explained_variance.index),
+        y=(factors.explained_variance.values * 100).tolist(),
+        marker_color="#3498db",
+        text=[f"{v * 100:.1f}%" for v in factors.explained_variance.values],
+        textposition="outside",
+    ))
+    scree_fig.update_layout(
+        title="PCA Scree — Variance Explained per Component",
+        xaxis_title="Component",
+        yaxis_title="Variance Explained (%)",
+        height=320,
+        margin=dict(l=60, r=40, t=50, b=40),
+    )
+    st.plotly_chart(scree_fig, use_container_width=True)
+
+    # ── Loadings heatmap (tickers × components) ───────────────────────────────
+    loadings = factors.loadings
+    load_fig = go.Figure(data=go.Heatmap(
+        z=loadings.values,
+        x=list(loadings.columns),
+        y=list(loadings.index),
+        colorscale="RdBu",
+        zmid=0,
+        text=[[f"{v:+.2f}" for v in row] for row in loadings.values],
+        texttemplate="%{text}",
+        showscale=True,
+    ))
+    load_fig.update_layout(
+        title="PCA Factor Loadings (ticker × component)",
+        height=max(320, len(loadings.index) * 28),
+        margin=dict(l=80, r=40, t=50, b=40),
+    )
+    st.plotly_chart(load_fig, use_container_width=True)
+
+    # ── k-means cluster assignments ───────────────────────────────────────────
+    labels = cluster_assets(returns, n_clusters=rf_k)
+    if labels.empty:
+        st.info("Clustering skipped — not enough data.")
+        return
+
+    members = cluster_members(labels)
+    cluster_rows = [
+        {"Cluster": cid, "N": len(tickers_in_cluster),
+         "Tickers": ", ".join(tickers_in_cluster)}
+        for cid, tickers_in_cluster in members.items()
+    ]
+    cluster_df = pd.DataFrame(cluster_rows)
+    st.markdown("**k-means clusters (correlation distance)**")
+    st.dataframe(cluster_df, use_container_width=True, hide_index=True)
+
+    csv_df = pd.DataFrame({"ticker": labels.index, "cluster": labels.values})
+    st.download_button(
+        label="Download cluster assignments (CSV)",
+        data=csv_df.to_csv(index=False).encode("utf-8"),
+        file_name="risk_factor_clusters.csv",
+        mime="text/csv",
+        key="rf_download",
+    )

--- a/tests/test_unsupervised.py
+++ b/tests/test_unsupervised.py
@@ -1,0 +1,206 @@
+"""Tests for analysis/unsupervised.py — PCA + k-means risk factors.
+
+Uses deterministic synthetic data so the results are reproducible on
+every run (matches the style of tests/test_markowitz.py and
+tests/test_hrp.py).
+"""
+import os
+import sys
+
+import numpy as np
+import pandas as pd
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from analysis.unsupervised import (
+    PCAFactors,
+    _correlation_distance,
+    cluster_assets,
+    cluster_members,
+    pca_risk_factors,
+)
+
+
+def _two_factor_returns(n: int = 250, seed: int = 7) -> pd.DataFrame:
+    """Two latent factors (A=B, C=D correlated; E pure noise)."""
+    rng = np.random.default_rng(seed)
+    f_ab = rng.normal(0, 0.01, n)
+    f_cd = rng.normal(0, 0.01, n)
+    cols = {
+        "A": f_ab + rng.normal(0, 0.001, n),
+        "B": f_ab + rng.normal(0, 0.001, n),
+        "C": f_cd + rng.normal(0, 0.001, n),
+        "D": f_cd + rng.normal(0, 0.001, n),
+        "E": rng.normal(0, 0.01, n),
+    }
+    return pd.DataFrame(cols)
+
+
+def _random_returns(n: int = 250, n_assets: int = 6, seed: int = 42) -> pd.DataFrame:
+    rng = np.random.default_rng(seed)
+    data = rng.normal(0, 0.01, (n, n_assets))
+    return pd.DataFrame(data, columns=[f"T{i}" for i in range(n_assets)])
+
+
+# ── pca_risk_factors ──────────────────────────────────────────────────────────
+
+def test_pca_returns_pcafactors_instance():
+    returns = _random_returns()
+    factors = pca_risk_factors(returns, n_components=3)
+    assert isinstance(factors, PCAFactors)
+
+
+def test_pca_loadings_shape():
+    returns = _random_returns(n_assets=6)
+    factors = pca_risk_factors(returns, n_components=3)
+    assert factors.loadings.shape == (6, 3)
+    assert list(factors.loadings.columns) == ["PC1", "PC2", "PC3"]
+    assert list(factors.loadings.index) == list(returns.columns)
+
+
+def test_pca_explained_variance_monotone_decreasing():
+    returns = _random_returns(n_assets=8, n=300)
+    factors = pca_risk_factors(returns, n_components=5)
+    vals = factors.explained_variance.values
+    for i in range(1, len(vals)):
+        assert vals[i - 1] >= vals[i] - 1e-9
+
+
+def test_pca_explained_variance_sums_leq_one():
+    returns = _random_returns(n_assets=6)
+    factors = pca_risk_factors(returns, n_components=3)
+    assert factors.explained_variance.sum() <= 1.0 + 1e-9
+
+
+def test_pca_two_factor_structure_dominates_first_two_components():
+    """A/B/C/D driven by two latent factors; PC1+PC2 should capture most var."""
+    returns = _two_factor_returns(n=500, seed=11)
+    factors = pca_risk_factors(returns, n_components=5)
+    top_two = factors.explained_variance.iloc[:2].sum()
+    assert top_two > 0.4
+
+
+def test_pca_components_have_observation_index():
+    returns = _random_returns(n_assets=4)
+    factors = pca_risk_factors(returns, n_components=2)
+    assert list(factors.components.index) == list(returns.index)
+    assert factors.components.shape == (len(returns), 2)
+
+
+def test_pca_n_components_clipped_to_rank():
+    """Requesting more components than min(n_rows, n_assets) is capped."""
+    returns = _random_returns(n_assets=3, n=100)
+    factors = pca_risk_factors(returns, n_components=10)
+    assert factors.loadings.shape[1] == 3
+
+
+def test_pca_empty_returns_empty_factors():
+    factors = pca_risk_factors(pd.DataFrame())
+    assert factors.loadings.empty
+    assert factors.explained_variance.empty
+    assert factors.components.empty
+
+
+def test_pca_none_returns_empty_factors():
+    factors = pca_risk_factors(None)  # type: ignore[arg-type]
+    assert factors.loadings.empty
+
+
+def test_pca_single_asset_returns_empty():
+    one_col = pd.DataFrame({"AAPL": np.random.randn(100)})
+    factors = pca_risk_factors(one_col)
+    assert factors.loadings.empty
+
+
+def test_pca_too_few_observations_returns_empty():
+    returns = _random_returns(n=10, n_assets=4)   # below _MIN_OBS=20
+    factors = pca_risk_factors(returns)
+    assert factors.loadings.empty
+
+
+# ── cluster_assets ───────────────────────────────────────────────────────────
+
+def test_cluster_assets_returns_series_indexed_by_ticker():
+    returns = _random_returns(n_assets=6)
+    labels = cluster_assets(returns, n_clusters=3, random_state=0)
+    assert isinstance(labels, pd.Series)
+    assert list(labels.index) == list(returns.columns)
+
+
+def test_cluster_assets_label_count_matches_request():
+    returns = _random_returns(n_assets=10, n=300)
+    labels = cluster_assets(returns, n_clusters=4, random_state=0)
+    assert labels.nunique() <= 4
+
+
+def test_cluster_assets_reproducible_with_seed():
+    returns = _random_returns(n_assets=8, n=250)
+    a = cluster_assets(returns, n_clusters=3, random_state=7)
+    b = cluster_assets(returns, n_clusters=3, random_state=7)
+    pd.testing.assert_series_equal(a, b)
+
+
+def test_cluster_assets_groups_correlated_pairs():
+    """A,B correlated; C,D correlated; E independent — A should cluster with
+    B and C with D."""
+    returns = _two_factor_returns(n=500, seed=2)
+    labels = cluster_assets(returns, n_clusters=3, random_state=0)
+    assert labels["A"] == labels["B"]
+    assert labels["C"] == labels["D"]
+
+
+def test_cluster_assets_n_clusters_clipped_to_n_assets():
+    returns = _random_returns(n_assets=3, n=250)
+    labels = cluster_assets(returns, n_clusters=10, random_state=0)
+    assert labels.nunique() <= 3
+
+
+def test_cluster_assets_empty_returns_empty():
+    assert cluster_assets(pd.DataFrame()).empty
+
+
+def test_cluster_assets_single_asset_returns_empty():
+    assert cluster_assets(pd.DataFrame({"A": [0.01] * 50})).empty
+
+
+def test_cluster_assets_too_few_observations_returns_empty():
+    returns = _random_returns(n=10, n_assets=4)  # below _MIN_OBS
+    assert cluster_assets(returns).empty
+
+
+# ── cluster_members helper ───────────────────────────────────────────────────
+
+def test_cluster_members_inverts_labels():
+    labels = pd.Series(
+        {"A": 0, "B": 0, "C": 1, "D": 1, "E": 2}, name="cluster",
+    )
+    members = cluster_members(labels)
+    assert members == {0: ["A", "B"], 1: ["C", "D"], 2: ["E"]}
+
+
+def test_cluster_members_empty_input():
+    assert cluster_members(pd.Series(dtype=int)) == {}
+    assert cluster_members(None) == {}  # type: ignore[arg-type]
+
+
+# ── _correlation_distance ────────────────────────────────────────────────────
+
+def test_correlation_distance_zero_on_diagonal():
+    corr = pd.DataFrame(
+        [[1.0, 0.5], [0.5, 1.0]], index=["A", "B"], columns=["A", "B"],
+    )
+    dist = _correlation_distance(corr)
+    assert dist[0, 0] == pytest.approx(0.0)
+    assert dist[1, 1] == pytest.approx(0.0)
+
+
+def test_correlation_distance_symmetric():
+    corr = pd.DataFrame(
+        [[1.0, 0.3, -0.2],
+         [0.3, 1.0, 0.7],
+         [-0.2, 0.7, 1.0]],
+        index=["A", "B", "C"], columns=["A", "B", "C"],
+    )
+    dist = _correlation_distance(corr)
+    assert np.allclose(dist, dist.T)


### PR DESCRIPTION
## Summary

Adds unsupervised risk-factor discovery to the platform: PCA on the return matrix for latent statistical factors, k-means on a correlation-distance matrix for asset clusters (Jansen *ML for Algorithmic Trading* Ch 13).

- `analysis/unsupervised.py`
  - `pca_risk_factors(returns, n_components) → PCAFactors` dataclass (loadings, explained_variance, components).  `n_components` auto-clipped to `min(n_assets, n_observations)`.
  - `cluster_assets(returns, n_clusters, random_state) → pd.Series` cluster labels.  Uses AFML-style correlation distance `sqrt(0.5 · (1 − ρ))` as the feature matrix fed to `sklearn.cluster.KMeans`.
  - `cluster_members()` helper inverts the series into `{cluster_id: [tickers]}` for UI display and pairs-discovery downstream.
- `pages/portfolio.py` — new **"🧬 Risk Factors (PCA / k-means)"** expander below the existing Portfolio Risk Metrics section.  Inputs: ticker list + history window + k. Renders a scree plot, a ticker × PC loadings heatmap, a cluster members table, and a CSV download of the assignments. Returns are fetched via a cached `fetch_ohlcv` helper.
- `tests/test_unsupervised.py` — 23 tests covering loadings shape, explained-variance monotonicity, the correlated-pair clustering invariant, n_components rank-clipping, empty / single-asset / short-history edges, and seed determinism.
- `ML_BOOK_MAP.md` — ML4T Ch 13 flips from ⏳ to ✅.

## Test plan

- [x] `pytest tests/test_unsupervised.py -v` — 23/23 passing
- [x] Full unit suite + coverage gate: **949 passed, 1 skipped, coverage 79.02%**
- [x] `ruff check .` — clean
- [x] `tests/test_pages.py::TestPagesPortfolio` — existing portfolio-page smoke tests still pass
- [ ] Manual browser check: `streamlit run app.py` → Portfolio tab → expand "Risk Factors" — recommend reviewer sanity-check the heatmap / scree visuals locally

Closes #68.