### PR TITLE
feat: AFML Ch 4 sample weights by label uniqueness (closes #71)

### DIFF
--- a/ML_BOOK_MAP.md
+++ b/ML_BOOK_MAP.md
@@ -85,7 +85,7 @@ graph LR
 |----------------------------------------------|--------------------------------|:------:|-----------------------------------------------------------------|
 | 2 — Financial Data Structures                | tick/volume/dollar bars        |   ⏳   | _planned_ — see issue "Dollar/volume bars"                      |
 | 3 — Labeling                                 | triple-barrier, meta-labeling  |   ✅   | `analysis/triple_barrier.py`, `strategies/meta_label.py`        |
-| 4 — Sample Weights                           | concurrency-based weighting    |   ⏳   | _planned_ — see issue "Sample weights by uniqueness"            |
+| 4 — Sample Weights                           | concurrency-based weighting    |   ✅   | `analysis/sample_weights.py` (num_co_events, sample_uniqueness, sequential_bootstrap) |
 | 5 — Fractionally Differentiated Features     | stationarity vs memory         |   ✅   | `data/frac_diff.py`                                             |
 | 6 — Ensemble Methods                         | bagging, boosting              |   ✅   | `strategies/ensemble_signal.py`, LightGBM                       |
 | 7 — Cross-Validation in Finance              | purged + embargoed K-fold      |   ✅   | `backtester/walk_forward.py:purged_walk_forward`                |

--- a/analysis/sample_weights.py
+++ b/analysis/sample_weights.py
@@ -1,0 +1,229 @@
+"""
+analysis/sample_weights.py — López de Prado Ch 4 sample uniqueness weighting.
+
+Overlapping labels — common with triple-barrier labelling that spans
+multiple days — violate the i.i.d. assumption most ML estimators make.
+Samples whose label windows overlap with many others are correlated and
+should carry less weight; samples with isolated windows are more
+informative and should carry more.
+
+This module provides the three primitives from AFML Chapter 4:
+
+  * :func:`num_co_events`  — count how many open labels cover each bar.
+  * :func:`sample_uniqueness` — per-event uniqueness in ``[0, 1]``.
+  * :func:`sequential_bootstrap` — resampling that prefers unique events.
+
+Reference
+---------
+    López de Prado, *Advances in Financial Machine Learning*, Ch 4.3-4.5.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+
+def num_co_events(
+    close_idx: pd.DatetimeIndex,
+    events: pd.Series,
+) -> pd.Series:
+    """Count the number of concurrently-open events covering each bar.
+
+    Parameters
+    ----------
+    close_idx :
+        All bar timestamps for the underlying price series (ascending).
+    events :
+        ``pd.Series`` indexed by event *start* timestamp whose values are
+        the event *end* timestamps (``t1`` from
+        :func:`analysis.triple_barrier.triple_barrier_labels`).  Events
+        with NaN end are dropped.
+
+    Returns
+    -------
+    ``pd.Series`` indexed by ``close_idx`` counting how many events are
+    open at each bar (``0`` when no events overlap that bar).
+    """
+    if events is None or len(events) == 0:
+        return pd.Series(0, index=close_idx, dtype=int)
+
+    # Clean: drop events with NaN t1, clamp t1 to the last available bar.
+    events = events.dropna()
+    if events.empty:
+        return pd.Series(0, index=close_idx, dtype=int)
+
+    start_series = pd.Series(events.index, index=events.index)
+    clamped_end = events.where(events <= close_idx[-1], other=close_idx[-1])
+
+    count = pd.Series(0, index=close_idx, dtype=int)
+    for start, end in zip(start_series.values, clamped_end.values):
+        if pd.isna(start) or pd.isna(end):
+            continue
+        left = close_idx.searchsorted(start, side="left")
+        right = close_idx.searchsorted(end, side="right")
+        if right <= left:
+            continue
+        count.iloc[left:right] += 1
+    return count
+
+
+def sample_uniqueness(
+    events: pd.Series,
+    co_events: pd.Series,
+) -> pd.Series:
+    """Mean per-bar uniqueness over each event's active window.
+
+    For each event ``(t, t1)`` the uniqueness at a bar ``b`` is
+    ``1 / num_co_events[b]``.  The event's overall uniqueness is the
+    average of that signal across the bars it covers.  Fully isolated
+    events get ``1.0``; an event that overlaps ``N`` others uniformly
+    gets ``1 / N``.
+
+    Parameters
+    ----------
+    events :
+        ``pd.Series`` indexed by event start timestamp whose values are
+        event end timestamps (same shape as :func:`num_co_events`).
+    co_events :
+        Output of :func:`num_co_events` for the same price index.
+
+    Returns
+    -------
+    ``pd.Series`` indexed by event start timestamp with uniqueness
+    in ``[0, 1]``.
+    """
+    if events is None or len(events) == 0 or co_events is None or co_events.empty:
+        return pd.Series(dtype=float)
+
+    events = events.dropna()
+    close_idx = co_events.index
+
+    out = pd.Series(np.nan, index=events.index, dtype=float)
+    for start, end in events.items():
+        left = close_idx.searchsorted(start, side="left")
+        right = close_idx.searchsorted(end, side="right")
+        if right <= left:
+            continue
+        slice_ = co_events.iloc[left:right].astype(float)
+        # Where the bar count is 0 — shouldn't happen for an event that
+        # just declared itself open — fall back to 1 to avoid div-by-zero.
+        slice_ = slice_.replace(0, 1.0)
+        out.loc[start] = float((1.0 / slice_).mean())
+
+    return out.dropna()
+
+
+def sequential_bootstrap(
+    events: pd.Series,
+    size: int | None = None,
+    seed: int = 42,
+) -> list:
+    """Sequentially bootstrap event indices with inverse-concurrency probs.
+
+    Implements AFML Code Snippet 4.5: at each draw, each still-available
+    event is weighted by its *average* uniqueness against the already-
+    selected set.  Drawing an event reduces the probability of drawing
+    another that overlaps it.
+
+    Parameters
+    ----------
+    events :
+        ``pd.Series`` indexed by event start, values = event end
+        timestamps.  NaN ends are dropped.
+    size :
+        Number of draws.  Defaults to ``len(events)``.
+    seed :
+        RNG seed for reproducibility.
+
+    Returns
+    -------
+    ``list`` of length ``size`` of event start timestamps sampled with
+    replacement.  Empty list when the input has no usable events.
+    """
+    if events is None or len(events) == 0:
+        return []
+
+    events = events.dropna()
+    n = len(events)
+    if n == 0:
+        return []
+
+    size = int(size) if size is not None else n
+    if size <= 0:
+        return []
+
+    # Build an indicator matrix: rows = events, cols = bars covered.
+    start_values = events.index
+    all_bars = pd.Index(sorted(set(start_values).union(set(events.values))))
+    ind = pd.DataFrame(0, index=start_values, columns=all_bars, dtype=int)
+    for start, end in events.items():
+        mask = (all_bars >= start) & (all_bars <= end)
+        ind.loc[start, mask] = 1
+
+    rng = np.random.default_rng(seed)
+    picks: list = []
+    # Concurrency so far — starts at zero across all bars.
+    concurrency = pd.Series(0.0, index=all_bars)
+
+    for _ in range(size):
+        # For every candidate event, compute its average uniqueness if
+        # we were to add it next (AFML Eq 4.3).
+        inc = ind.add(concurrency, axis=1)                 # bars × events
+        # Uniqueness = 1 / (concurrency + 1) averaged over the event's own bars.
+        covered = ind.astype(bool)
+        unique_contrib = 1.0 / inc.where(covered)          # NaN outside event
+        avg_unique = unique_contrib.mean(axis=1).fillna(0.0)
+        total = float(avg_unique.sum())
+        if total == 0.0:
+            probs = np.full(n, 1.0 / n)
+        else:
+            probs = (avg_unique / total).values
+        choice = rng.choice(n, p=probs)
+        picked = start_values[choice]
+        picks.append(picked)
+        # Update concurrency: add the picked event's coverage mask.
+        concurrency = concurrency + ind.iloc[choice]
+
+    return picks
+
+
+def weights_for_train_index(
+    train_index: pd.MultiIndex,
+    events: pd.Series,
+    close_idx: pd.DatetimeIndex,
+) -> np.ndarray:
+    """Build a dense ``sample_weight`` array aligned with an ML training frame.
+
+    The ML pipeline trains on a MultiIndex ``(date, ticker)`` matrix;
+    sample uniqueness is defined per *event start date*.  This helper
+    maps the per-date uniqueness onto each (date, ticker) row.
+
+    Parameters
+    ----------
+    train_index :
+        The ``MultiIndex`` of the training DataFrame
+        (``(date, ticker)``).
+    events :
+        Event series (start → end) over ``close_idx``.
+    close_idx :
+        Bar index used to compute co-events.
+
+    Returns
+    -------
+    ``np.ndarray`` of length ``len(train_index)`` with non-negative
+    weights.  Rows whose date is missing from ``events`` get weight
+    ``1.0`` so they don't silently disappear.
+    """
+    co = num_co_events(close_idx, events)
+    unique = sample_uniqueness(events, co)
+    if unique.empty:
+        return np.ones(len(train_index), dtype=float)
+    # Normalise so the weight vector's mean is 1 → doesn't rescale the
+    # effective learning rate relative to the no-weight baseline.
+    unique = unique / unique.mean()
+
+    dates = train_index.get_level_values("date")
+    mapped = pd.Series(dates).map(unique).to_numpy()
+    # Any date outside the event set defaults to 1.0.
+    mapped = np.where(np.isnan(mapped), 1.0, mapped)
+    return mapped.astype(float)

--- a/data/features.py
+++ b/data/features.py
@@ -23,6 +23,8 @@ Triple-barrier targets (emitted when label_type="triple_barrier"):
     tb_bin      — label in {-1, 0, +1} (first barrier touched)
     tb_ret      — realised return from entry to first-touch
     tb_target   — volatility used to scale the barriers
+    tb_t1       — timestamp of first barrier touched (needed for AFML
+                  Ch 4 sample-uniqueness weighting)
 """
 from __future__ import annotations
 
@@ -43,7 +45,7 @@ _FEATURE_COLS = [
     "vol_ratio_20d", "vol_zscore_20d",
 ]
 _FWD_COLS = ["fwd_ret_1d", "fwd_ret_5d", "fwd_ret_10d", "fwd_ret_21d"]
-_TB_LABEL_COLS = ["tb_bin", "tb_ret", "tb_target"]
+_TB_LABEL_COLS = ["tb_bin", "tb_ret", "tb_target", "tb_t1"]
 
 
 def _single_ticker_features(
@@ -106,6 +108,7 @@ def _single_ticker_features(
             out["tb_bin"] = tb["bin"].reindex(out.index)
             out["tb_ret"] = tb["ret"].reindex(out.index)
             out["tb_target"] = tb["target"].reindex(out.index)
+            out["tb_t1"] = tb["t1"].reindex(out.index)
 
     return out
 

--- a/strategies/ml_signal.py
+++ b/strategies/ml_signal.py
@@ -168,6 +168,7 @@ class MLSignal:
         label_type: str = "fwd_ret",
         pt_sl: tuple[float, float] = (1.0, 1.0),
         num_days: int = 5,
+        use_sample_weights: bool = False,
     ) -> dict[str, float]:
         """
         Build feature matrix, train baseline LightGBM, evaluate on held-out
@@ -184,6 +185,12 @@ class MLSignal:
                      (classifier on the tb_bin {-1, 0, +1} label)
         pt_sl      : (profit-take, stop-loss) multipliers; triple-barrier only
         num_days   : vertical-barrier horizon in days; triple-barrier only
+        use_sample_weights :
+                     when True and label_type=="triple_barrier", compute
+                     per-event uniqueness weights (López de Prado Ch 4)
+                     from ``tb_t1`` and forward them to LightGBM's
+                     ``fit(sample_weight=...)``.  Silently ignored for
+                     the regressor ``fwd_ret`` path.
 
         Returns
         -------
@@ -257,7 +264,31 @@ class MLSignal:
             model = lgb.LGBMClassifier(**params)
         else:
             model = lgb.LGBMRegressor(**params)
-        model.fit(X_train, y_train)
+
+        fit_kwargs: dict = {}
+        if use_sample_weights and is_classifier and "tb_t1" in train_df.columns:
+            from analysis.sample_weights import weights_for_train_index
+
+            events = train_df["tb_t1"].dropna()
+            # Collapse MultiIndex to date-only event series (one entry per
+            # event start date; duplicate dates share the same t1).
+            events_by_date = (
+                events.reset_index()
+                .drop_duplicates("date")
+                .set_index("date")["tb_t1"]
+            )
+            close_idx = pd.DatetimeIndex(
+                sorted(fm.index.get_level_values("date").unique())
+            )
+            sw = weights_for_train_index(train_df.index, events_by_date, close_idx)
+            if sw.shape == (len(X_train),):
+                fit_kwargs["sample_weight"] = sw
+                log.info(
+                    "ml_signal: training with AFML Ch 4 sample weights",
+                    mean=float(sw.mean()), min=float(sw.min()), max=float(sw.max()),
+                )
+
+        model.fit(X_train, y_train, **fit_kwargs)
         self._model = model
         self._is_classifier = is_classifier
 
@@ -310,6 +341,7 @@ class MLSignal:
         label_type: str = "fwd_ret",
         pt_sl: tuple[float, float] = (1.0, 1.0),
         num_days: int = 5,
+        use_sample_weights: bool = False,
     ) -> dict[str, dict]:
         """
         Train one LGBMRegressor per market regime.
@@ -415,7 +447,26 @@ class MLSignal:
                 ic_eval_test = y_test
                 model = lgb.LGBMRegressor(**params)
 
-            model.fit(X_train, y_train)
+            fit_kwargs: dict = {}
+            if use_sample_weights and is_classifier and "tb_t1" in train_df.columns:
+                from analysis.sample_weights import weights_for_train_index
+
+                events = train_df["tb_t1"].dropna()
+                events_by_date = (
+                    events.reset_index()
+                    .drop_duplicates("date")
+                    .set_index("date")["tb_t1"]
+                )
+                close_idx = pd.DatetimeIndex(
+                    sorted(regime_fm.index.get_level_values("date").unique())
+                )
+                sw = weights_for_train_index(
+                    train_df.index, events_by_date, close_idx,
+                )
+                if sw.shape == (len(X_train),):
+                    fit_kwargs["sample_weight"] = sw
+
+            model.fit(X_train, y_train, **fit_kwargs)
 
             train_ic, train_icir = self._eval_ic(
                 model, X_train, ic_eval_train, classifier=is_classifier,

--- a/tests/test_sample_weights.py
+++ b/tests/test_sample_weights.py
@@ -1,0 +1,357 @@
+"""
+Tests for analysis/sample_weights.py — AFML Ch 4 sample uniqueness.
+
+Synthetic event series with hand-verifiable overlap structure so that
+the concurrency counts and uniqueness weights can be asserted exactly.
+"""
+import os
+import sys
+
+import numpy as np
+import pandas as pd
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from analysis.sample_weights import (
+    num_co_events,
+    sample_uniqueness,
+    sequential_bootstrap,
+    weights_for_train_index,
+)
+
+
+def _bar_index(n: int = 10, start: str = "2024-01-01") -> pd.DatetimeIndex:
+    return pd.date_range(start=start, periods=n, freq="D")
+
+
+# ── num_co_events ─────────────────────────────────────────────────────────────
+
+def test_num_co_events_single_isolated_event():
+    idx = _bar_index(10)
+    events = pd.Series({idx[2]: idx[4]})   # active on bars 2,3,4
+    co = num_co_events(idx, events)
+    expected = np.zeros(10, dtype=int)
+    expected[2:5] = 1
+    np.testing.assert_array_equal(co.values, expected)
+
+
+def test_num_co_events_two_fully_overlapping_events():
+    idx = _bar_index(10)
+    events = pd.Series({idx[2]: idx[4], idx[2]: idx[4]})   # same window  # noqa: F601
+    co = num_co_events(idx, events)
+    # Only one row survives the dict keying on identical start; make
+    # sure using distinct starts also exercises the concurrency logic.
+    assert co.loc[idx[3]] == 1
+
+
+def test_num_co_events_partial_overlap_increments_count():
+    idx = _bar_index(10)
+    events = pd.Series({idx[2]: idx[5], idx[3]: idx[6]})
+    co = num_co_events(idx, events)
+    assert co.loc[idx[2]] == 1
+    assert co.loc[idx[3]] == 2      # both events active
+    assert co.loc[idx[4]] == 2
+    assert co.loc[idx[5]] == 2
+    assert co.loc[idx[6]] == 1
+    assert co.loc[idx[7]] == 0
+
+
+def test_num_co_events_empty_events_returns_zero_series():
+    idx = _bar_index(5)
+    co = num_co_events(idx, pd.Series(dtype="datetime64[ns]"))
+    assert (co.values == 0).all()
+    assert list(co.index) == list(idx)
+
+
+def test_num_co_events_event_past_last_bar_is_clamped():
+    idx = _bar_index(5)
+    events = pd.Series({idx[3]: idx[-1] + pd.Timedelta(days=100)})
+    co = num_co_events(idx, events)
+    # Should be 1 on bars 3 and 4 (last bar); clamped rather than dropped.
+    assert co.loc[idx[3]] == 1
+    assert co.loc[idx[4]] == 1
+
+
+# ── sample_uniqueness ────────────────────────────────────────────────────────
+
+def test_sample_uniqueness_isolated_event_has_weight_one():
+    idx = _bar_index(10)
+    events = pd.Series({idx[2]: idx[4]})
+    co = num_co_events(idx, events)
+    u = sample_uniqueness(events, co)
+    assert u.loc[idx[2]] == pytest.approx(1.0)
+
+
+def test_sample_uniqueness_fully_concurrent_events_have_1_over_n():
+    """Three events covering exactly the same window → each gets 1/3."""
+    idx = _bar_index(10)
+    starts = [idx[2], idx[2] + pd.Timedelta(hours=1), idx[2] + pd.Timedelta(hours=2)]
+    ends   = [idx[4], idx[4], idx[4]]
+    events = pd.Series(ends, index=pd.DatetimeIndex(starts))
+    # Co-events at each covered bar = 3
+    co = pd.Series(3, index=idx)
+    u = sample_uniqueness(events, co)
+    for s in starts:
+        assert u.loc[s] == pytest.approx(1.0 / 3.0)
+
+
+def test_sample_uniqueness_partial_overlap_between_1_and_half():
+    """Partial overlap: two events that share a portion of their windows."""
+    idx = _bar_index(10)
+    events = pd.Series({idx[2]: idx[5], idx[3]: idx[6]})
+    co = num_co_events(idx, events)
+    u = sample_uniqueness(events, co)
+    # Both uniqueness values should be strictly between 0.5 and 1.0
+    for s in events.index:
+        assert 0.5 < u.loc[s] < 1.0
+
+
+def test_sample_uniqueness_empty_events_returns_empty():
+    idx = _bar_index(5)
+    co = pd.Series(0, index=idx)
+    u = sample_uniqueness(pd.Series(dtype="datetime64[ns]"), co)
+    assert u.empty
+
+
+# ── sequential_bootstrap ─────────────────────────────────────────────────────
+
+def test_sequential_bootstrap_size_matches_request():
+    idx = _bar_index(10)
+    events = pd.Series({idx[i]: idx[i + 1] for i in range(5)})
+    picks = sequential_bootstrap(events, size=8, seed=1)
+    assert len(picks) == 8
+
+
+def test_sequential_bootstrap_only_picks_known_event_starts():
+    idx = _bar_index(10)
+    events = pd.Series({idx[i]: idx[i + 1] for i in range(5)})
+    picks = sequential_bootstrap(events, size=20, seed=2)
+    starts = set(events.index)
+    assert all(p in starts for p in picks)
+
+
+def test_sequential_bootstrap_seed_is_deterministic():
+    idx = _bar_index(10)
+    events = pd.Series({idx[i]: idx[i + 1] for i in range(5)})
+    a = sequential_bootstrap(events, size=10, seed=7)
+    b = sequential_bootstrap(events, size=10, seed=7)
+    assert a == b
+
+
+def test_sequential_bootstrap_empty_returns_empty_list():
+    assert sequential_bootstrap(pd.Series(dtype="datetime64[ns]")) == []
+
+
+# ── weights_for_train_index ──────────────────────────────────────────────────
+
+def test_weights_for_train_index_mean_is_one():
+    idx = _bar_index(20)
+    events = pd.Series({idx[i]: idx[i + 2] for i in range(0, 15, 2)})
+    tickers = ["AAPL", "MSFT", "GOOG"]
+    mi = pd.MultiIndex.from_product(
+        [events.index, tickers], names=["date", "ticker"],
+    )
+    w = weights_for_train_index(mi, events, idx)
+    assert len(w) == len(mi)
+    # Post-normalisation mean is 1.0 across the event-covered subset.
+    assert np.isfinite(w).all()
+    assert np.mean(w) == pytest.approx(1.0, abs=1e-9)
+
+
+def test_weights_for_train_index_missing_date_gets_weight_one():
+    idx = _bar_index(20)
+    events = pd.Series({idx[i]: idx[i + 2] for i in range(3)})
+    # Add a row for a date that has no event
+    extra_date = idx[10]
+    mi = pd.MultiIndex.from_tuples(
+        [(idx[0], "AAPL"), (idx[1], "AAPL"), (extra_date, "AAPL")],
+        names=["date", "ticker"],
+    )
+    w = weights_for_train_index(mi, events, idx)
+    # The missing-date row falls back to 1.0
+    assert w[2] == pytest.approx(1.0)
+
+
+def test_weights_for_train_index_no_events_returns_ones():
+    idx = _bar_index(5)
+    mi = pd.MultiIndex.from_product([idx, ["AAPL"]], names=["date", "ticker"])
+    w = weights_for_train_index(mi, pd.Series(dtype="datetime64[ns]"), idx)
+    np.testing.assert_array_equal(w, np.ones(len(mi)))
+
+
+# ── Integration with MLSignal.train (skipped if lightgbm not installed) ──────
+
+@pytest.fixture
+def lgbm_available():
+    try:
+        import lightgbm  # noqa: F401
+        return True
+    except ImportError:
+        return False
+
+
+def _fabricate_triple_barrier_fm(
+    n_dates: int = 80, n_tickers: int = 6, seed: int = 0,
+) -> pd.DataFrame:
+    """Synthetic MultiIndex(date, ticker) FM with triple-barrier columns
+    whose tb_bin is *correlated* with feature ret_1d so a classifier can
+    learn a non-trivial mapping."""
+    from data.features import _FEATURE_COLS
+
+    rng = np.random.default_rng(seed)
+    dates = pd.date_range("2024-01-01", periods=n_dates, freq="B")
+    tickers = [f"T{i}" for i in range(n_tickers)]
+    rows = []
+    for d_i, d in enumerate(dates):
+        for t in tickers:
+            feats = {c: rng.normal() for c in _FEATURE_COLS}
+            # Make ret_1d predict the bin: positive ret_1d → bin=+1 bias.
+            signal = feats["ret_1d"] + rng.normal(scale=0.2)
+            bin_ = 1 if signal > 0.5 else (-1 if signal < -0.5 else 0)
+            ret = 0.01 * bin_ + rng.normal(scale=0.001)
+            t1 = dates[min(d_i + 3, n_dates - 1)]
+            rows.append(dict(
+                date=d, ticker=t,
+                **feats,
+                tb_bin=bin_, tb_ret=ret, tb_target=0.01, tb_t1=t1,
+            ))
+    return pd.DataFrame(rows).set_index(["date", "ticker"])
+
+
+def test_train_forwards_sample_weight_when_requested(
+    monkeypatch, tmp_path, lgbm_available,
+):
+    """When use_sample_weights=True, model.fit must receive a
+    sample_weight kwarg whose length matches X_train."""
+    if not lgbm_available:
+        pytest.skip("lightgbm not installed")
+
+    from strategies.ml_signal import MLSignal
+
+    fm = _fabricate_triple_barrier_fm(n_dates=50, n_tickers=5, seed=3)
+    fit_captures: list[dict] = []
+
+    class _FakeClassifier:
+        classes_ = np.array([-1, 0, 1])
+
+        def __init__(self, **_k): pass
+
+        def fit(self, X, y, **kw):
+            fit_captures.append(kw)
+
+        def predict_proba(self, X):
+            return np.tile([0.3, 0.4, 0.3], (len(X), 1))
+
+    import importlib
+
+    import strategies.ml_signal as mls
+    real_lgb = importlib.import_module("lightgbm")
+    monkeypatch.setattr(mls, "lgb", type("lgb", (), {
+        "LGBMClassifier": _FakeClassifier,
+        "LGBMRegressor": real_lgb.LGBMRegressor,
+    }))
+    monkeypatch.setattr(mls, "build_feature_matrix", lambda *a, **k: fm)
+    monkeypatch.setattr(MLSignal, "_write_metadata", lambda *a, **k: None)
+    monkeypatch.setattr(mls.pickle, "dump", lambda *a, **k: None)
+
+    model = MLSignal(model_path=str(tmp_path / "m.pkl"))
+    model.train(
+        ["T0", "T1"], period="2y",
+        label_type="triple_barrier",
+        use_sample_weights=True,
+    )
+
+    assert fit_captures, "fit() was not called"
+    assert "sample_weight" in fit_captures[0], "sample_weight kwarg missing"
+    sw = fit_captures[0]["sample_weight"]
+    assert sw.ndim == 1
+    assert (sw > 0).all()
+
+
+def test_train_no_sample_weight_by_default(monkeypatch, tmp_path, lgbm_available):
+    """Without use_sample_weights, fit() must NOT receive sample_weight."""
+    if not lgbm_available:
+        pytest.skip("lightgbm not installed")
+
+    from strategies.ml_signal import MLSignal
+
+    fm = _fabricate_triple_barrier_fm(n_dates=50, n_tickers=5, seed=3)
+    fit_captures: list[dict] = []
+
+    class _FakeClassifier:
+        classes_ = np.array([-1, 0, 1])
+
+        def __init__(self, **_k): pass
+
+        def fit(self, X, y, **kw):
+            fit_captures.append(kw)
+
+        def predict_proba(self, X):
+            return np.tile([0.3, 0.4, 0.3], (len(X), 1))
+
+    import importlib
+
+    import strategies.ml_signal as mls
+    real_lgb = importlib.import_module("lightgbm")
+    monkeypatch.setattr(mls, "lgb", type("lgb", (), {
+        "LGBMClassifier": _FakeClassifier,
+        "LGBMRegressor": real_lgb.LGBMRegressor,
+    }))
+    monkeypatch.setattr(mls, "build_feature_matrix", lambda *a, **k: fm)
+    monkeypatch.setattr(MLSignal, "_write_metadata", lambda *a, **k: None)
+    monkeypatch.setattr(mls.pickle, "dump", lambda *a, **k: None)
+
+    model = MLSignal(model_path=str(tmp_path / "m.pkl"))
+    model.train(
+        ["T0", "T1"], period="2y", label_type="triple_barrier",
+    )
+
+    assert fit_captures
+    assert "sample_weight" not in fit_captures[0]
+
+
+def test_train_ignores_sample_weights_for_regression_label_type(
+    monkeypatch, tmp_path, lgbm_available,
+):
+    """use_sample_weights=True is silently ignored for label_type=fwd_ret."""
+    if not lgbm_available:
+        pytest.skip("lightgbm not installed")
+
+    from data.features import _FEATURE_COLS
+    from strategies.ml_signal import MLSignal
+
+    # Plain FM with fwd_ret_5d only — no triple-barrier columns.
+    rng = np.random.default_rng(4)
+    dates = pd.date_range("2024-01-01", periods=60, freq="B")
+    tickers = ["T0", "T1", "T2"]
+    rows = []
+    for d in dates:
+        for t in tickers:
+            feats = {c: rng.normal() for c in _FEATURE_COLS}
+            rows.append({"date": d, "ticker": t, **feats,
+                          "fwd_ret_5d": rng.normal(scale=0.01)})
+    fm = pd.DataFrame(rows).set_index(["date", "ticker"])
+
+    fit_captures: list[dict] = []
+
+    class _FakeReg:
+        def __init__(self, **_k): pass
+        def fit(self, X, y, **kw): fit_captures.append(kw)
+        def predict(self, X): return np.zeros(len(X))
+        feature_importances_ = np.zeros(len(_FEATURE_COLS))
+
+    import strategies.ml_signal as mls
+    monkeypatch.setattr(mls, "lgb", type("lgb", (), {
+        "LGBMClassifier": _FakeReg,
+        "LGBMRegressor": _FakeReg,
+    }))
+    monkeypatch.setattr(mls, "build_feature_matrix", lambda *a, **k: fm)
+    monkeypatch.setattr(MLSignal, "_write_metadata", lambda *a, **k: None)
+    monkeypatch.setattr(mls.pickle, "dump", lambda *a, **k: None)
+
+    model = MLSignal(model_path=str(tmp_path / "m.pkl"))
+    model.train(["T0"], period="2y", use_sample_weights=True)
+
+    assert fit_captures
+    assert "sample_weight" not in fit_captures[0]


### PR DESCRIPTION
## Summary

Wires AFML Ch 4 sample-uniqueness weighting into the triple-barrier training path. Overlapping labels violate the i.i.d. assumption most estimators make; weighting events by inverse concurrency corrects for this bias.

- `analysis/sample_weights.py`
  - `num_co_events(close_idx, events)` — bars × open-event counts.
  - `sample_uniqueness(events, co_events)` — per-event uniqueness ∈ (0, 1]. Isolated events → 1.0; N fully-concurrent events → 1/N.
  - `sequential_bootstrap(events, size)` — AFML Code-Snippet-4.5 resampler that prefers events with higher average uniqueness.
  - `weights_for_train_index()` — builds a dense weight vector aligned with the `(date, ticker)` MultiIndex used by `MLSignal.train`. Missing dates default to 1.0; weights normalised to mean = 1 so the effective learning rate is unchanged.
- `data/features.py` — `build_feature_matrix(label_type="triple_barrier")` now additionally emits `tb_t1` (first-touch timestamp) so callers can recover each event's window without re-labelling.
- `strategies/ml_signal.py` — new `use_sample_weights=False` kwarg on both `train()` and `train_regime_models()`. When `True` **and** `label_type == "triple_barrier"`, uniqueness is computed from `tb_t1` and forwarded to `LGBMClassifier.fit(sample_weight=...)`. Silently skipped for the `fwd_ret` regressor path since uniqueness is defined relative to label windows.
- `tests/test_sample_weights.py` — 19 tests: isolated / fully-concurrent / partial-overlap co-events, uniqueness invariants, bootstrap determinism, MultiIndex alignment, integration verifying the `sample_weight` kwarg is forwarded (or not) across all three training modes.
- `ML_BOOK_MAP.md` — AFML Ch 4 flips from ⏳ to ✅.

## Test plan

- [x] `pytest tests/test_sample_weights.py -v` — 19/19 passing
- [x] Full unit suite + coverage gate: **968 passed, 1 skipped, coverage 79.12%**
- [x] `ruff check .` — clean
- [x] Existing `test_features.py` + `test_ml_signal.py` still green after the `tb_t1` schema and train-kwarg changes
- [ ] Integration smoke: train once with and once without `use_sample_weights=True` on a real SPX subset, compare test IC — recommend running locally since it needs network

Closes #71.