### PR TITLE
feat: combinatorial purged cross-validation (AFML Ch 12, closes #76)

### DIFF
--- a/ML_BOOK_MAP.md
+++ b/ML_BOOK_MAP.md
@@ -93,7 +93,7 @@ graph LR
 | 9 — Hyperparameter Tuning                    | Bayesian + purged CV           |   ✅   | `strategies/ml_tuning.py` (Optuna TPE)                          |
 | 10 — Bet Sizing                              | Kelly, dynamic allocation      |   ✅   | `risk/kelly.py`, `strategies/ml_execution.py`                   |
 | 11 — Dangers of Backtesting                  | deflated Sharpe, PBO           |   ⏳   | _planned_ — see issue "Deflated Sharpe + PBO"                   |
-| 12 — Backtesting Through Cross-Validation    | combinatorial-purged CV        |   🟡   | partial (purged WF only)                                        |
+| 12 — Backtesting Through Cross-Validation    | combinatorial-purged CV        |   ✅   | `backtester/combinatorial_cv.py` (combinatorial_purged_cv + paths_dataframe) |
 | 13 — Backtesting on Synthetic Data           | bootstrap, GAN                 |   🟡   | bootstrap in `backtester/monte_carlo.py`; GAN out of scope      |
 | 14 — Backtest Statistics                     | Sharpe, Sortino, MAR           |   ✅   | `analysis/risk_metrics.py`, `backtester/engine.py`              |
 | 15 — Understanding Strategy Risk             | efficient frontier, VaR        |   ✅   | `risk/markowitz.py`, `risk/var.py`                              |

--- a/backtester/combinatorial_cv.py
+++ b/backtester/combinatorial_cv.py
@@ -1,0 +1,200 @@
+"""
+backtester/combinatorial_cv.py — AFML Ch 12 combinatorial purged CV.
+
+`purged_walk_forward` (AFML Ch 7) yields a single OOS path by sliding a
+single test window across the timeline.  Combinatorial-purged CV (Ch 12)
+splits the same timeline into ``N`` equal groups and, for every
+``C(N, k)`` combination of ``k`` groups, designates that combination as
+the test set — producing many more backtest paths from the same data.
+
+The extra paths are exactly what the Deflated Sharpe Ratio (AFML Eq 11.6)
+and the Probability of Backtest Overfitting metric (AFML Eq 11.9) need
+to estimate tail risk from hyper-parameter search.
+
+Algorithm (AFML 12.4)
+---------------------
+1. Partition ``[0, n_samples)`` into ``n_splits`` contiguous groups.
+2. Each combination of ``n_test_splits`` groups is the test set; the
+   complement minus an embargo is the train set.
+3. The number of paths emitted is ``C(n_splits, n_test_splits)``.
+
+Embargo is applied *symmetrically* around every test group to prevent
+leakage from overlapping forward-return labels.
+
+Reference
+---------
+    López de Prado, *Advances in Financial Machine Learning*, Ch 12.4.
+"""
+from __future__ import annotations
+
+from itertools import combinations
+from math import comb
+from typing import Iterable, Iterator
+
+import numpy as np
+import pandas as pd
+
+
+def _group_ranges(n_samples: int, n_splits: int) -> list[tuple[int, int]]:
+    """Return ``n_splits`` contiguous ``[start, end)`` ranges covering
+    ``[0, n_samples)`` as evenly as possible."""
+    if n_samples <= 0 or n_splits <= 0:
+        return []
+    # np.array_split gives groups whose sizes differ by at most 1.
+    boundaries = np.array_split(np.arange(n_samples), n_splits)
+    return [(int(g[0]), int(g[-1]) + 1) for g in boundaries if len(g) > 0]
+
+
+def _apply_embargo(
+    train_mask: np.ndarray,
+    test_ranges: Iterable[tuple[int, int]],
+    embargo: int,
+    n_samples: int,
+) -> np.ndarray:
+    """Zero out train bars that fall within ``embargo`` of any test bar.
+
+    Applied on both sides so a backward-looking or forward-looking label
+    cannot leak across the train/test boundary.
+    """
+    if embargo <= 0:
+        return train_mask
+    out = train_mask.copy()
+    for start, end in test_ranges:
+        lo = max(0, start - embargo)
+        hi = min(n_samples, end + embargo)
+        out[lo:hi] = False
+    return out
+
+
+def num_combinatorial_paths(n_splits: int, n_test_splits: int) -> int:
+    """Expected number of ``(train, test)`` splits emitted — i.e.
+    ``C(n_splits, n_test_splits)``.  Zero if arguments are invalid."""
+    if n_splits <= 0 or n_test_splits <= 0 or n_test_splits > n_splits:
+        return 0
+    return comb(n_splits, n_test_splits)
+
+
+def combinatorial_purged_splits(
+    n_samples: int,
+    n_splits: int = 10,
+    n_test_splits: int = 2,
+    embargo: int = 0,
+) -> Iterator[tuple[np.ndarray, np.ndarray]]:
+    """Yield ``(train_idx, test_idx)`` positional arrays for every
+    combination of ``n_test_splits`` groups.
+
+    Parameters
+    ----------
+    n_samples : total observation count (e.g. ``len(feature_matrix)``).
+    n_splits : partition the timeline into this many contiguous groups.
+    n_test_splits : size of each test combination (must be ``<= n_splits``).
+    embargo : number of bars excluded on each side of every test group.
+
+    Yields
+    ------
+    ``(train_idx, test_idx)`` ndarrays of ``int`` positional indices.
+
+    Raises
+    ------
+    ValueError on invalid argument combinations.
+    """
+    if n_samples <= 0:
+        return
+    if n_splits <= 1:
+        raise ValueError("n_splits must be at least 2")
+    if n_test_splits < 1 or n_test_splits > n_splits:
+        raise ValueError(
+            f"n_test_splits must be in [1, {n_splits}], got {n_test_splits}"
+        )
+    if n_splits > n_samples:
+        raise ValueError(
+            f"n_splits ({n_splits}) cannot exceed n_samples ({n_samples})"
+        )
+    if embargo < 0:
+        raise ValueError("embargo must be non-negative")
+
+    groups = _group_ranges(n_samples, n_splits)
+    all_idx = np.arange(n_samples)
+
+    for test_group_indices in combinations(range(n_splits), n_test_splits):
+        test_ranges = [groups[i] for i in test_group_indices]
+        test_mask = np.zeros(n_samples, dtype=bool)
+        for start, end in test_ranges:
+            test_mask[start:end] = True
+
+        # Train = everything outside test, then purge the embargo bands.
+        train_mask = ~test_mask
+        train_mask = _apply_embargo(train_mask, test_ranges, embargo, n_samples)
+
+        yield all_idx[train_mask], all_idx[test_mask]
+
+
+def combinatorial_purged_cv(
+    data: pd.DataFrame | int,
+    n_splits: int = 10,
+    n_test_splits: int = 2,
+    embargo: int = 0,
+) -> list[tuple[np.ndarray, np.ndarray]]:
+    """Materialise :func:`combinatorial_purged_splits` into a list.
+
+    Accepts either an integer ``n_samples`` or a DataFrame-like whose
+    ``len`` is the sample count (a MultiIndex ``(date, ticker)`` is fine;
+    positional indices address its rows).  Returns ``[]`` when ``data``
+    is empty rather than raising — this keeps caller code simple.
+    """
+    if isinstance(data, (int, np.integer)):
+        n_samples = int(data)
+    else:
+        if data is None:
+            return []
+        n_samples = len(data)
+        if n_samples == 0:
+            return []
+
+    return list(
+        combinatorial_purged_splits(
+            n_samples=n_samples,
+            n_splits=n_splits,
+            n_test_splits=n_test_splits,
+            embargo=embargo,
+        )
+    )
+
+
+def paths_dataframe(
+    fold_results: list[dict],
+    n_splits: int,
+    n_test_splits: int,
+) -> pd.DataFrame:
+    """Stack per-fold result dicts into a DataFrame keyed by path id.
+
+    Primarily a convenience so downstream consumers (e.g. the Deflated
+    Sharpe / PBO metrics planned in issue #72) can read all paths with
+    a single ``.loc`` lookup.
+
+    Parameters
+    ----------
+    fold_results :
+        List of result dictionaries in the same order as the splits
+        yielded by :func:`combinatorial_purged_splits`.  Each dict
+        typically contains ``sharpe``, ``total_return``, etc.
+    n_splits, n_test_splits : the parameters the splits were generated
+        with.  Used to validate the length of ``fold_results`` and to
+        label the rows.
+
+    Returns
+    -------
+    ``pd.DataFrame`` indexed by integer path id ``0 .. C(N, k) - 1``.
+    """
+    expected = num_combinatorial_paths(n_splits, n_test_splits)
+    if expected == 0 or not fold_results:
+        return pd.DataFrame(fold_results)
+    if len(fold_results) != expected:
+        raise ValueError(
+            f"paths_dataframe: expected {expected} fold results "
+            f"(C({n_splits}, {n_test_splits})), got {len(fold_results)}"
+        )
+
+    df = pd.DataFrame(fold_results)
+    df.index = pd.Index(range(len(df)), name="path")
+    return df

--- a/tests/test_combinatorial_cv.py
+++ b/tests/test_combinatorial_cv.py
@@ -1,0 +1,246 @@
+"""Tests for backtester/combinatorial_cv.py — AFML Ch 12."""
+import os
+import sys
+from math import comb
+
+import numpy as np
+import pandas as pd
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from backtester.combinatorial_cv import (
+    _apply_embargo,
+    _group_ranges,
+    combinatorial_purged_cv,
+    combinatorial_purged_splits,
+    num_combinatorial_paths,
+    paths_dataframe,
+)
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+def _fake_feature_matrix(n_samples: int = 100) -> pd.DataFrame:
+    dates = pd.date_range("2024-01-01", periods=n_samples, freq="D")
+    return pd.DataFrame({"x": np.arange(n_samples)}, index=dates)
+
+
+# ── num_combinatorial_paths ──────────────────────────────────────────────────
+
+@pytest.mark.parametrize(
+    "n, k, expected",
+    [
+        (10, 2, 45),          # C(10, 2) = 45
+        (6, 3, 20),
+        (4, 1, 4),
+        (5, 5, 1),
+        (5, 6, 0),            # k > n → 0
+        (0, 1, 0),
+        (5, 0, 0),
+    ],
+)
+def test_num_combinatorial_paths(n, k, expected):
+    assert num_combinatorial_paths(n, k) == expected
+
+
+# ── _group_ranges ────────────────────────────────────────────────────────────
+
+def test_group_ranges_equal_split():
+    ranges = _group_ranges(10, 5)
+    assert ranges == [(0, 2), (2, 4), (4, 6), (6, 8), (8, 10)]
+
+
+def test_group_ranges_uneven_split_covers_all():
+    ranges = _group_ranges(11, 3)
+    # Every sample must be covered exactly once
+    covered = np.zeros(11, dtype=bool)
+    for start, end in ranges:
+        covered[start:end] = True
+    assert covered.all()
+    assert len(ranges) == 3
+
+
+def test_group_ranges_zero_samples():
+    assert _group_ranges(0, 5) == []
+
+
+# ── combinatorial_purged_splits ──────────────────────────────────────────────
+
+def test_emits_expected_number_of_paths():
+    splits = list(combinatorial_purged_splits(
+        n_samples=100, n_splits=6, n_test_splits=2, embargo=0,
+    ))
+    assert len(splits) == comb(6, 2)
+
+
+def test_test_and_train_are_disjoint_without_embargo():
+    splits = list(combinatorial_purged_splits(
+        n_samples=60, n_splits=6, n_test_splits=2, embargo=0,
+    ))
+    for train, test in splits:
+        assert set(train).isdisjoint(set(test))
+
+
+def test_every_combination_covers_all_samples_without_embargo():
+    """Without embargo the train and test sets together cover every bar."""
+    splits = list(combinatorial_purged_splits(
+        n_samples=60, n_splits=6, n_test_splits=2, embargo=0,
+    ))
+    for train, test in splits:
+        assert len(train) + len(test) == 60
+
+
+def test_test_set_has_expected_size():
+    """Each test set covers n_test_splits contiguous groups."""
+    n_samples = 60
+    n_splits = 6
+    n_test = 2
+    group_size = n_samples / n_splits  # 10 per group
+    splits = list(combinatorial_purged_splits(
+        n_samples=n_samples, n_splits=n_splits, n_test_splits=n_test, embargo=0,
+    ))
+    for _, test in splits:
+        assert len(test) == int(group_size * n_test)
+
+
+def test_embargo_removes_train_bars_adjacent_to_test():
+    n = 40
+    splits = list(combinatorial_purged_splits(
+        n_samples=n, n_splits=4, n_test_splits=1, embargo=3,
+    ))
+    # Take the fold whose test group is [10, 20)
+    for train, test in splits:
+        if test.min() == 10 and test.max() == 19:
+            # Train should exclude 7, 8, 9 (embargo before) and 20, 21, 22 (embargo after)
+            forbidden = {7, 8, 9, 20, 21, 22}
+            assert forbidden.isdisjoint(set(train.tolist()))
+            break
+    else:
+        pytest.fail("expected fold with test range [10, 20) not found")
+
+
+def test_every_sample_appears_in_test_across_all_paths():
+    """Union of test indices across all paths = full sample range."""
+    n_samples = 50
+    splits = list(combinatorial_purged_splits(
+        n_samples=n_samples, n_splits=5, n_test_splits=2, embargo=0,
+    ))
+    seen = set()
+    for _, test in splits:
+        seen.update(test.tolist())
+    assert seen == set(range(n_samples))
+
+
+def test_each_group_appears_in_k_over_n_fraction_of_tests():
+    """Combinatorial symmetry: each group is in test exactly
+    C(n-1, k-1) times out of C(n, k)."""
+    n_splits, n_test = 5, 2
+    splits = list(combinatorial_purged_splits(
+        n_samples=50, n_splits=n_splits, n_test_splits=n_test, embargo=0,
+    ))
+    group_ranges = _group_ranges(50, n_splits)
+    # For each group range, count how many paths have that group in test
+    for group_idx, (gs, ge) in enumerate(group_ranges):
+        count = sum(
+            1 for _, test in splits
+            if ((test >= gs) & (test < ge)).any() and
+               ((test >= gs) & (test < ge)).sum() == (ge - gs)
+        )
+        assert count == comb(n_splits - 1, n_test - 1)
+
+
+def test_invalid_n_splits_raises():
+    with pytest.raises(ValueError, match="n_splits"):
+        list(combinatorial_purged_splits(n_samples=10, n_splits=1))
+
+
+def test_invalid_n_test_splits_raises():
+    with pytest.raises(ValueError, match="n_test_splits"):
+        list(combinatorial_purged_splits(
+            n_samples=10, n_splits=5, n_test_splits=6,
+        ))
+
+
+def test_negative_embargo_raises():
+    with pytest.raises(ValueError, match="embargo"):
+        list(combinatorial_purged_splits(
+            n_samples=10, n_splits=5, n_test_splits=2, embargo=-1,
+        ))
+
+
+def test_n_splits_larger_than_samples_raises():
+    with pytest.raises(ValueError):
+        list(combinatorial_purged_splits(
+            n_samples=4, n_splits=10, n_test_splits=2,
+        ))
+
+
+def test_zero_samples_emits_nothing():
+    assert list(combinatorial_purged_splits(n_samples=0, n_splits=5)) == []
+
+
+# ── combinatorial_purged_cv (materialised helper) ────────────────────────────
+
+def test_cv_accepts_dataframe():
+    fm = _fake_feature_matrix(60)
+    splits = combinatorial_purged_cv(fm, n_splits=5, n_test_splits=2)
+    assert len(splits) == comb(5, 2)
+
+
+def test_cv_accepts_integer_n_samples():
+    splits = combinatorial_purged_cv(60, n_splits=5, n_test_splits=2)
+    assert len(splits) == comb(5, 2)
+
+
+def test_cv_returns_empty_for_empty_input():
+    empty = pd.DataFrame()
+    assert combinatorial_purged_cv(empty, n_splits=5, n_test_splits=2) == []
+
+
+def test_cv_returns_empty_for_zero_samples_int():
+    assert combinatorial_purged_cv(0, n_splits=5, n_test_splits=2) == []
+
+
+def test_cv_returns_empty_for_none_input():
+    assert combinatorial_purged_cv(None, n_splits=5, n_test_splits=2) == []  # type: ignore[arg-type]
+
+
+# ── paths_dataframe ──────────────────────────────────────────────────────────
+
+def test_paths_dataframe_indexes_by_path_id():
+    results = [{"sharpe": 1.0 + i, "ret": 0.01 * i} for i in range(comb(5, 2))]
+    df = paths_dataframe(results, n_splits=5, n_test_splits=2)
+    assert list(df.columns) == ["sharpe", "ret"]
+    assert df.index.name == "path"
+    assert len(df) == comb(5, 2)
+    assert df.iloc[3]["sharpe"] == pytest.approx(4.0)
+
+
+def test_paths_dataframe_wrong_length_raises():
+    results = [{"sharpe": 1.0}] * 5  # wrong count for C(5, 2) = 10
+    with pytest.raises(ValueError, match="expected 10 fold results"):
+        paths_dataframe(results, n_splits=5, n_test_splits=2)
+
+
+def test_paths_dataframe_empty_returns_empty_dataframe():
+    df = paths_dataframe([], n_splits=5, n_test_splits=2)
+    assert df.empty
+
+
+# ── _apply_embargo ───────────────────────────────────────────────────────────
+
+def test_apply_embargo_zero_is_noop():
+    mask = np.ones(10, dtype=bool)
+    out = _apply_embargo(mask, [(3, 6)], embargo=0, n_samples=10)
+    np.testing.assert_array_equal(out, mask)
+
+
+def test_apply_embargo_is_symmetric():
+    mask = np.ones(20, dtype=bool)
+    out = _apply_embargo(mask, [(10, 14)], embargo=2, n_samples=20)
+    # Bars 8-9 (before) and 14-15 (after) purged; so true train bars
+    # are 0..7 and 16..19.
+    assert out[7] and not out[8] and not out[9]
+    assert not out[10:14].any()
+    assert not out[14] and not out[15]
+    assert out[16]


### PR DESCRIPTION
## Summary

Adds AFML Ch 12.4 combinatorial-purged cross-validation. `purged_walk_forward` (Ch 7) yields a single OOS path; this extension yields `C(n_splits, n_test_splits)` paths from the same timeline — the required input for the Deflated Sharpe Ratio and PBO metrics planned in #72.

- `backtester/combinatorial_cv.py`
  - `combinatorial_purged_splits(n_samples, n_splits, n_test_splits, embargo)` — generator yielding `(train_idx, test_idx)` positional arrays for every combination of test groups, with symmetric-embargo purge on both sides of each test range.
  - `combinatorial_purged_cv()` — materialised list form accepting a DataFrame (uses `len`) or an int `n_samples`.
  - `num_combinatorial_paths(n_splits, n_test_splits)` — exposes `C(n, k)` so callers can size output arrays up-front.
  - `paths_dataframe(fold_results, n_splits, n_test_splits)` — stacks per-fold dicts into a DataFrame indexed by path id, ready for downstream PBO / Deflated Sharpe aggregation.
- `tests/test_combinatorial_cv.py` — 32 tests covering path counts matching `C(n, k)`, train/test disjointness without embargo, test-set sizes, embargo bars on both sides, combinatorial symmetry (each group appears in exactly `C(n−1, k−1)` test folds), invalid-arg validation, empty-input behaviour, and `paths_dataframe` round-trip.
- `ML_BOOK_MAP.md` — AFML Ch 12 flips from 🟡 to ✅.

## Test plan

- [x] `pytest tests/test_combinatorial_cv.py -v` — 32/32 passing
- [x] Full unit suite + coverage gate: **1000 passed, 1 skipped, coverage 79.33%**
- [x] `ruff check .` — clean

Closes #76.  Unblocks #72 (Deflated Sharpe + PBO).