### PR TITLE
feat: MDA/MDI importance + Deflated Sharpe + PBO (AFML Ch 8, 11, closes #72)

### DIFF
--- a/ML_BOOK_MAP.md
+++ b/ML_BOOK_MAP.md
@@ -89,10 +89,10 @@ graph LR
 | 5 — Fractionally Differentiated Features     | stationarity vs memory         |   ✅   | `data/frac_diff.py`                                             |
 | 6 — Ensemble Methods                         | bagging, boosting              |   ✅   | `strategies/ensemble_signal.py`, LightGBM                       |
 | 7 — Cross-Validation in Finance              | purged + embargoed K-fold      |   ✅   | `backtester/walk_forward.py:purged_walk_forward`                |
-| 8 — Feature Importance                       | MDI, MDA, SFI                  |   🟡   | partial (SHAP in `ml_signal.py`); MDA planned                   |
+| 8 — Feature Importance                       | MDI, MDA, SFI                  |   ✅   | `analysis/feature_importance.py` (mda_importance + mdi_importance) |
 | 9 — Hyperparameter Tuning                    | Bayesian + purged CV           |   ✅   | `strategies/ml_tuning.py` (Optuna TPE)                          |
 | 10 — Bet Sizing                              | Kelly, dynamic allocation      |   ✅   | `risk/kelly.py`, `strategies/ml_execution.py`                   |
-| 11 — Dangers of Backtesting                  | deflated Sharpe, PBO           |   ⏳   | _planned_ — see issue "Deflated Sharpe + PBO"                   |
+| 11 — Dangers of Backtesting                  | deflated Sharpe, PBO           |   ✅   | `analysis/deflated_sharpe.py` (deflated_sharpe + probability_backtest_overfitting) |
 | 12 — Backtesting Through Cross-Validation    | combinatorial-purged CV        |   ✅   | `backtester/combinatorial_cv.py` (combinatorial_purged_cv + paths_dataframe) |
 | 13 — Backtesting on Synthetic Data           | bootstrap, GAN                 |   🟡   | bootstrap in `backtester/monte_carlo.py`; GAN out of scope      |
 | 14 — Backtest Statistics                     | Sharpe, Sortino, MAR           |   ✅   | `analysis/risk_metrics.py`, `backtester/engine.py`              |

--- a/analysis/deflated_sharpe.py
+++ b/analysis/deflated_sharpe.py
@@ -1,0 +1,175 @@
+"""
+analysis/deflated_sharpe.py — AFML Ch 11 backtest-overfitting guards.
+
+After testing ``N`` strategy variants the best Sharpe ratio looks
+remarkable only because selection bias is absorbed into the estimator.
+López de Prado's Deflated Sharpe Ratio (DSR, Eq 11.6) adjusts for
+selection, sample size, skewness, and kurtosis and returns the
+*probability* that the observed Sharpe is genuinely above zero.
+
+The Probability of Backtest Overfitting (PBO, Eq 11.9) is a separate
+diagnostic that estimates — from a matrix of in-sample vs out-of-sample
+performance across many trials — how often the trial that looks best
+in-sample underperforms out-of-sample.
+
+Reference
+---------
+    López de Prado, *Advances in Financial Machine Learning*, Ch 11.4-11.5.
+"""
+from __future__ import annotations
+
+from math import log, sqrt
+
+import numpy as np
+import pandas as pd
+from scipy.stats import norm
+
+# Euler-Mascheroni constant, per AFML Eq 11.5.
+_EULER_MASCHERONI = 0.577215664901532
+_MAX_EXPECTED_SHARPE_APPROX = 250.0   # numerical guard for extreme n_trials
+
+
+def _expected_maximum_sharpe(n_trials: int, variance: float = 1.0) -> float:
+    """AFML Eq 11.5: expected maximum of N i.i.d. Sharpe estimates under
+    a null of zero true Sharpe.
+
+    Uses the closed-form approximation from López de Prado's reference
+    code (based on the expected value of the maximum order statistic of
+    ``N`` standard normals).
+    """
+    if n_trials <= 1:
+        return 0.0
+    sd = sqrt(variance)
+    # Two-term approximation from AFML Code Snippet 20.4.
+    n = max(2, int(n_trials))
+    a = (1.0 - _EULER_MASCHERONI) * norm.ppf(1.0 - 1.0 / n)
+    b = _EULER_MASCHERONI * norm.ppf(1.0 - 1.0 / (n * np.e))
+    return float(sd * (a + b))
+
+
+def deflated_sharpe(
+    sharpe: float,
+    n_trials: int,
+    skew: float,
+    kurt: float,
+    num_obs: int,
+    sharpe_variance: float = 1.0,
+) -> float:
+    """Probability that the true Sharpe exceeds zero given a selection bias.
+
+    Implements AFML Eq 11.6 — the Deflated Sharpe Ratio.  Returns a
+    *probability* in ``[0, 1]``, not a ratio; treat anything below
+    ``0.05`` as "likely backtest overfitting".
+
+    Parameters
+    ----------
+    sharpe :
+        Observed (annualised or per-period; consistency matters only
+        inside this call) Sharpe ratio of the best trial.
+    n_trials :
+        Total number of strategy variants tried (hyperparameter grid,
+        combinatorial CV paths, etc.).
+    skew :
+        Skewness of the returns of the best trial.
+    kurt :
+        *Excess* kurtosis (``kurt(normal) == 0``).
+    num_obs :
+        Number of return observations used to estimate ``sharpe``.
+    sharpe_variance :
+        Variance across trial Sharpes.  Defaults to ``1``, which is
+        the standard null-hypothesis convention.
+
+    Returns
+    -------
+    ``float`` — ``P(true_sharpe > 0 | observed)``.  Returns ``0.0``
+    when the formula is not evaluable (e.g. ``num_obs < 2``).
+    """
+    if num_obs < 2:
+        return 0.0
+
+    # Expected maximum of n_trials independent Sharpe estimates under H0.
+    if n_trials > _MAX_EXPECTED_SHARPE_APPROX ** 2:
+        expected_max = sqrt(sharpe_variance) * sqrt(2 * log(n_trials))
+    else:
+        expected_max = _expected_maximum_sharpe(n_trials, sharpe_variance)
+
+    # AFML Eq 11.6 denominator uses *non-excess* kurtosis γ_4 = kurt + 3,
+    # so the term becomes (γ_4 - 1) / 4 = (kurt_excess + 2) / 4.
+    numerator = (sharpe - expected_max) * sqrt(num_obs - 1)
+    denom_sq = 1.0 - skew * sharpe + ((kurt + 2.0) / 4.0) * sharpe * sharpe
+    denominator = sqrt(max(1e-12, denom_sq))
+    z = numerator / denominator
+    return float(norm.cdf(z))
+
+
+def _rank_logit(ranks: np.ndarray, n_trials: int) -> np.ndarray:
+    """Map integer ranks in ``[1, n_trials]`` to a logit-transformed
+    relative performance.
+
+    AFML Eq 11.9 defines PBO off the logit of the OOS rank of the
+    in-sample best trial.  Ranks are converted to quantiles
+    ``(rank - 0.5) / n_trials`` first — that's the standard
+    continuity-corrected empirical CDF value.
+    """
+    q = (np.asarray(ranks, dtype=float) - 0.5) / max(1, n_trials)
+    q = np.clip(q, 1e-9, 1.0 - 1e-9)
+    return np.log(q / (1.0 - q))
+
+
+def probability_backtest_overfitting(
+    is_oos_matrix: pd.DataFrame,
+) -> float:
+    """Combinatorially-symmetric Probability of Backtest Overfitting.
+
+    AFML Eq 11.9.  Given an ``N_splits × N_trials`` DataFrame where
+    each row is one CV split's ranking of every trial's performance,
+    we compute, for each split, the OOS rank of the IS-best trial.
+    PBO is the fraction of splits where that OOS rank is below median.
+
+    Input convention: each row of ``is_oos_matrix`` represents the
+    **out-of-sample** performance of every trial on one CV split.
+    The "in-sample" ranking is taken as the mean performance across
+    the other splits — equivalent to AFML's combinatorially-symmetric
+    leave-one-out procedure.
+
+    Returns
+    -------
+    ``float`` ∈ ``[0, 1]``.  A PBO above ``0.5`` means the apparent
+    winner rarely wins out-of-sample → backtest overfitting likely.
+    """
+    if is_oos_matrix is None or is_oos_matrix.empty:
+        return float("nan")
+
+    mat = is_oos_matrix.to_numpy(dtype=float, copy=True)
+    n_splits, n_trials = mat.shape
+    if n_splits < 2 or n_trials < 2:
+        return float("nan")
+
+    drops = 0
+    total = 0
+    for i in range(n_splits):
+        is_mask = np.ones(n_splits, dtype=bool)
+        is_mask[i] = False
+        is_means = mat[is_mask].mean(axis=0)       # IS performance per trial
+        best_trial = int(np.argmax(is_means))
+        oos_perf = mat[i]
+        # OOS rank of the best-IS trial (1 = worst, n_trials = best).
+        oos_rank = (oos_perf < oos_perf[best_trial]).sum() + 1
+        logit = _rank_logit(np.array([oos_rank]), n_trials=n_trials)[0]
+        if logit < 0:
+            drops += 1
+        total += 1
+
+    return drops / total if total > 0 else float("nan")
+
+
+def deflated_sharpe_warning(dsr_probability: float, threshold: float = 0.05) -> str:
+    """Short human-readable interpretation of a DSR probability."""
+    if np.isnan(dsr_probability):
+        return "insufficient data for DSR"
+    if dsr_probability < threshold:
+        return (
+            f"DSR P(Sharpe>0)={dsr_probability:.3f} — below {threshold:.2f}; "
+            "result may be spurious (backtest overfitting suspected)"
+        )
+    return f"DSR P(Sharpe>0)={dsr_probability:.3f} — passes overfitting guard"

--- a/analysis/feature_importance.py
+++ b/analysis/feature_importance.py
@@ -1,0 +1,194 @@
+"""
+analysis/feature_importance.py — López de Prado Ch 8 feature importance.
+
+SHAP values (already available through ``strategies.ml_signal``) tell you
+which features the model *uses* on a given prediction.  They don't tell
+you which features actually make the model more accurate.  AFML Ch 8
+advocates two complementary measures:
+
+  * **Mean Decrease in Accuracy (MDA)** — shuffle one feature's values
+    and measure the drop in cross-validated test performance.  Captures
+    both substitution effects and feature interactions.
+  * **Mean Decrease in Impurity (MDI)** — sum of impurity decreases
+    weighted by node sample sizes, averaged across every tree.  Cheap
+    to compute because it's already accumulated during training.
+
+Together they corroborate each other and reveal features that SHAP can
+over-credit due to collinearity.
+
+Reference
+---------
+    López de Prado, *Advances in Financial Machine Learning*, Ch 8.3–8.5.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Iterable, Optional
+
+import numpy as np
+import pandas as pd
+from scipy.stats import spearmanr
+
+_Scorer = Callable[[np.ndarray, np.ndarray], float]
+
+
+def _default_scorer(y_true: np.ndarray, y_pred: np.ndarray) -> float:
+    """Spearman rank correlation (IC) — AFML's default financial scorer."""
+    y_true = np.asarray(y_true, dtype=float)
+    y_pred = np.asarray(y_pred, dtype=float)
+    if len(y_true) < 3 or np.std(y_pred) == 0:
+        return 0.0
+    rho, _ = spearmanr(y_pred, y_true)
+    return 0.0 if np.isnan(rho) else float(rho)
+
+
+@dataclass
+class FeatureImportanceResult:
+    """Output of :func:`mda_importance` / :func:`mdi_importance`.
+
+    Attributes
+    ----------
+    importance :
+        Series indexed by feature name.  Higher = more important.
+    std :
+        Optional per-feature standard deviation across folds / trees.
+        ``None`` when the estimator cannot supply one.
+    """
+
+    importance: pd.Series
+    std: Optional[pd.Series] = None
+
+    def top_k(self, k: int = 20) -> pd.Series:
+        return self.importance.sort_values(ascending=False).head(k)
+
+
+def mda_importance(
+    model,
+    X: pd.DataFrame,
+    y: np.ndarray,
+    cv_splits: Optional[Iterable[tuple[np.ndarray, np.ndarray]]] = None,
+    scorer: _Scorer = _default_scorer,
+    random_state: int = 42,
+) -> FeatureImportanceResult:
+    """Mean-Decrease-in-Accuracy feature importance via permutation.
+
+    For every ``(train_idx, test_idx)`` split the model is fit on the
+    training fold and scored on the test fold, then for each feature
+    column the values are shuffled and the score re-computed.  The
+    drop in score is the feature's importance for that fold.  Results
+    are averaged across folds.
+
+    Parameters
+    ----------
+    model :
+        An sklearn-style estimator.  Must implement ``fit(X, y)`` and
+        ``predict(X) -> np.ndarray``.  The model is **cloned** by a
+        simple no-op (sklearn isn't imported here) — callers should
+        pass in a factory-produced fresh instance if refitting matters
+        for their estimator.
+    X :
+        Feature DataFrame.  Column names are preserved in the output.
+    y :
+        Target array (1-D).  Length must match ``len(X)``.
+    cv_splits :
+        Iterable of ``(train_idx, test_idx)`` positional arrays
+        (compatible with :func:`backtester.combinatorial_cv`).  If
+        ``None``, a single 70/30 chronological split is used.
+    scorer :
+        ``(y_true, y_pred) -> float``.  Defaults to Spearman IC.
+    random_state :
+        Seed for the permutation RNG.
+
+    Returns
+    -------
+    :class:`FeatureImportanceResult` indexed by feature name.
+    """
+    if X is None or len(X) == 0:
+        return FeatureImportanceResult(pd.Series(dtype=float))
+    y = np.asarray(y)
+    if len(y) != len(X):
+        raise ValueError("mda_importance: X and y length mismatch")
+
+    features = list(X.columns)
+    if cv_splits is None:
+        n = len(X)
+        cut = int(n * 0.7)
+        cv_splits = [(np.arange(cut), np.arange(cut, n))]
+    cv_splits = list(cv_splits)
+    if not cv_splits:
+        return FeatureImportanceResult(pd.Series(0.0, index=features))
+
+    rng = np.random.default_rng(random_state)
+    per_fold_drops: list[pd.Series] = []
+
+    for train_idx, test_idx in cv_splits:
+        X_train = X.iloc[train_idx]
+        X_test = X.iloc[test_idx].copy()
+        y_train = y[train_idx]
+        y_test = y[test_idx]
+
+        model.fit(X_train.values, y_train)
+        baseline = scorer(y_test, model.predict(X_test.values))
+
+        drops = {}
+        for col in features:
+            saved = X_test[col].values.copy()
+            X_test[col] = rng.permutation(saved)
+            shuffled = scorer(y_test, model.predict(X_test.values))
+            drops[col] = baseline - shuffled
+            X_test[col] = saved            # restore for the next column
+
+        per_fold_drops.append(pd.Series(drops, index=features))
+
+    stacked = pd.concat(per_fold_drops, axis=1)
+    mean = stacked.mean(axis=1)
+    std = stacked.std(axis=1) if stacked.shape[1] > 1 else None
+    return FeatureImportanceResult(mean.astype(float), std)
+
+
+def mdi_importance(
+    model,
+    feature_names: Iterable[str],
+) -> FeatureImportanceResult:
+    """Mean-Decrease-in-Impurity feature importance.
+
+    For tree ensembles, sklearn / LightGBM expose
+    ``feature_importances_`` — the sum of (weighted) impurity
+    decreases from every node, averaged across all trees.  This helper
+    wraps that into a :class:`FeatureImportanceResult` with a
+    per-feature std when ``estimators_`` is available (sklearn
+    ensembles).  For LightGBM (no ``estimators_``), std is ``None``.
+
+    Returns an empty result when the model exposes no importances.
+    """
+    feature_names = list(feature_names)
+    if model is None or not hasattr(model, "feature_importances_"):
+        return FeatureImportanceResult(pd.Series(dtype=float))
+
+    importances = np.asarray(model.feature_importances_, dtype=float)
+    if len(importances) != len(feature_names):
+        # Feature arity mismatch: return whatever we can, padded / truncated.
+        k = min(len(importances), len(feature_names))
+        importances = importances[:k]
+        feature_names = feature_names[:k]
+
+    mean = pd.Series(importances, index=feature_names, dtype=float)
+
+    std: Optional[pd.Series] = None
+    estimators = getattr(model, "estimators_", None)
+    if estimators:
+        try:
+            per_tree = np.stack(
+                [getattr(est, "feature_importances_", np.zeros(len(feature_names)))
+                 for est in estimators]
+            )
+            if per_tree.shape[1] == len(feature_names):
+                std = pd.Series(
+                    per_tree.std(axis=0),
+                    index=feature_names,
+                    dtype=float,
+                )
+        except (ValueError, AttributeError):
+            std = None
+
+    return FeatureImportanceResult(mean, std)

--- a/pages/backtest.py
+++ b/pages/backtest.py
@@ -86,6 +86,9 @@ def render() -> None:
 
         st.plotly_chart(build_equity_chart(result), use_container_width=True)
 
+        # ── Deflated Sharpe guard (AFML Ch 11) ─────────────────────────────────
+        _render_deflated_sharpe_panel(result)
+
         with st.expander(f"Trade Log ({result.num_trades} trades)"):
             trade_df = build_trade_log_df(result)
             if trade_df.empty:
@@ -104,3 +107,56 @@ def render() -> None:
                     use_container_width=True, hide_index=True,
                 )
                 st.caption(f"Average trade return: {trade_df['Return (%)'].mean():+.2f}%")
+
+
+def _render_deflated_sharpe_panel(result) -> None:
+    """AFML Ch 11 — Deflated Sharpe probability + interpretation.
+
+    Derives daily returns from the equity curve, then computes DSR using
+    a user-supplied ``n_trials`` (defaults to 1 — honest single-backtest
+    case).  Bumping ``n_trials`` is appropriate once the user has tried
+    multiple parameter variants.
+    """
+    from analysis.deflated_sharpe import deflated_sharpe, deflated_sharpe_warning
+
+    equity = getattr(result, "equity_curve", None)
+    if equity is None or equity.empty or "Equity" not in equity.columns:
+        return
+
+    daily_ret = equity["Equity"].pct_change().dropna()
+    if len(daily_ret) < 5:
+        return
+
+    n_trials = int(st.number_input(
+        "# Strategy variants tried (affects DSR)",
+        min_value=1, max_value=10_000, value=1, step=1,
+        key="bt_dsr_trials",
+        help=(
+            "Set to the number of strategies / parameter combinations "
+            "tested to produce this backtest.  DSR discounts Sharpe for "
+            "multiple-testing selection bias (AFML Ch 11)."
+        ),
+    ))
+
+    skew = float(daily_ret.skew()) if len(daily_ret) > 2 else 0.0
+    kurt = float(daily_ret.kurt()) if len(daily_ret) > 3 else 0.0
+
+    dsr = deflated_sharpe(
+        sharpe=float(result.sharpe_ratio),
+        n_trials=n_trials,
+        skew=skew,
+        kurt=kurt,
+        num_obs=len(daily_ret),
+    )
+
+    dc1, dc2, dc3, dc4 = st.columns(4)
+    dc1.metric("DSR P(Sharpe>0)", f"{dsr:.3f}")
+    dc2.metric("Observed Sharpe", f"{result.sharpe_ratio:.3f}")
+    dc3.metric("Skewness",        f"{skew:+.2f}")
+    dc4.metric("Excess Kurtosis", f"{kurt:+.2f}")
+
+    warning = deflated_sharpe_warning(dsr)
+    if dsr < 0.05:
+        st.warning(warning)
+    else:
+        st.caption(warning)

--- a/pages/ml_signals.py
+++ b/pages/ml_signals.py
@@ -450,7 +450,11 @@ def render() -> None:
     fi_col, coef_col = st.columns(2)
 
     with fi_col:
-        st.markdown("#### LGBM Feature Importance (Top 20)")
+        st.markdown("#### LGBM Feature Importance (MDI, Top 20)")
+        st.caption(
+            "Mean Decrease in Impurity — LightGBM's built-in importance "
+            "(López de Prado AFML Ch 8)."
+        )
         with st.spinner("Loading feature importances…"):
             try:
                 from strategies.ml_signal import MLSignal
@@ -463,6 +467,23 @@ def render() -> None:
             st.info("No LGBM model. Click **Train LGBM Baseline** to train one.")
         else:
             _render_feature_importance(fi_df.head(20))
+
+        if st.button(
+            "Compute MDA Importance (permutation)", key="ml_mda_btn",
+            help=(
+                "Mean Decrease in Accuracy — shuffle each feature on a "
+                "held-out fold and measure the drop in Spearman IC.  "
+                "Slower than MDI but more robust to correlated features."
+            ),
+        ):
+            with st.spinner("Running permutation importance…"):
+                try:
+                    _compute_and_store_mda(selected_tickers, period)
+                except Exception as exc:
+                    st.error(f"MDA computation failed: {exc}")
+
+        if "ml_mda_importance" in st.session_state:
+            _render_mda_importance(st.session_state["ml_mda_importance"])
 
     with coef_col:
         st.markdown("#### Ridge Feature Coefficients (Top 20)")
@@ -639,6 +660,69 @@ def _render_alpha_chart(scores: dict[str, float]) -> None:
         xaxis=dict(range=[-1.1, 1.1]),
         height=max(300, len(tickers) * 22),
         margin=dict(l=80, r=40, t=50, b=40),
+    )
+    st.plotly_chart(fig, use_container_width=True)
+
+
+def _compute_and_store_mda(selected_tickers: list[str], period: str) -> None:
+    """Compute MDA feature importance for the currently trained LGBM model
+    and stash it in ``st.session_state['ml_mda_importance']``."""
+    from data.features import _FEATURE_COLS, build_feature_matrix
+    from strategies.ml_signal import MLSignal
+
+    lgbm_inst = st.session_state.get("ml_model_instance") or MLSignal()
+    if lgbm_inst._model is None:
+        st.warning("Train the LGBM model first (MDA requires a fitted model).")
+        return
+
+    fm = build_feature_matrix(selected_tickers, period=period)
+    if fm.empty:
+        st.error("Feature matrix is empty — nothing to permute.")
+        return
+
+    feature_cols = [c for c in _FEATURE_COLS if c in fm.columns]
+    target_col = "fwd_ret_5d"
+    fm = fm.dropna(subset=[target_col])
+    if fm.empty:
+        st.error("No rows with a non-NaN target for MDA.")
+        return
+
+    X = fm[feature_cols]
+    y = fm[target_col].values
+
+    # Wrap the trained model so mda_importance can call .fit() / .predict()
+    # against the same object without retraining a new estimator from scratch.
+    class _FrozenModel:
+        def __init__(self, model): self._m = model
+        def fit(self, X_arr, y_arr): return self
+        def predict(self, X_arr): return self._m.predict(X_arr)
+
+    from analysis.feature_importance import mda_importance
+    result = mda_importance(_FrozenModel(lgbm_inst._model), X, y)
+    st.session_state["ml_mda_importance"] = result.importance
+
+
+def _render_mda_importance(mda_series: pd.Series) -> None:
+    if mda_series is None or mda_series.empty:
+        st.info("No MDA data available.")
+        return
+    top = mda_series.sort_values(ascending=False).head(20)
+    colors = ["#e67e22" if v >= 0 else "#95a5a6" for v in top.values]
+    fig = go.Figure(go.Bar(
+        x=top.values,
+        y=top.index,
+        orientation="h",
+        marker_color=colors,
+        text=[f"{v:+.4f}" for v in top.values],
+        textposition="outside",
+    ))
+    fig.update_layout(
+        title="MDA Feature Importance (Δ test IC when shuffled)",
+        xaxis_title="Importance (IC drop)",
+        yaxis_title="Feature",
+        height=max(300, len(top) * 26),
+        margin=dict(l=140, r=40, t=50, b=40),
+        yaxis=dict(autorange="reversed"),
     )
     st.plotly_chart(fig, use_container_width=True)
 

--- a/tests/test_deflated_sharpe.py
+++ b/tests/test_deflated_sharpe.py
@@ -1,0 +1,180 @@
+"""Tests for analysis/deflated_sharpe.py — AFML Ch 11 DSR + PBO."""
+import os
+import sys
+from math import isnan
+
+import numpy as np
+import pandas as pd
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from analysis.deflated_sharpe import (
+    _expected_maximum_sharpe,
+    deflated_sharpe,
+    deflated_sharpe_warning,
+    probability_backtest_overfitting,
+)
+
+# ── _expected_maximum_sharpe ─────────────────────────────────────────────────
+
+def test_expected_maximum_sharpe_monotone_in_n_trials():
+    m5 = _expected_maximum_sharpe(5)
+    m50 = _expected_maximum_sharpe(50)
+    m500 = _expected_maximum_sharpe(500)
+    assert m5 < m50 < m500
+
+
+def test_expected_maximum_sharpe_single_trial_is_zero():
+    assert _expected_maximum_sharpe(1) == 0.0
+
+
+def test_expected_maximum_sharpe_scales_with_variance():
+    base = _expected_maximum_sharpe(100, variance=1.0)
+    scaled = _expected_maximum_sharpe(100, variance=4.0)
+    assert scaled == pytest.approx(2.0 * base, rel=1e-6)
+
+
+# ── deflated_sharpe ──────────────────────────────────────────────────────────
+
+def test_dsr_is_high_when_sharpe_greatly_exceeds_expected_max():
+    p = deflated_sharpe(
+        sharpe=3.0, n_trials=100, skew=0.0, kurt=0.0, num_obs=252,
+    )
+    assert p > 0.9
+
+
+def test_dsr_is_low_when_sharpe_is_near_expected_max():
+    """Observed Sharpe ≈ expected max under the null → DSR near 0.5."""
+    em = _expected_maximum_sharpe(50)
+    p = deflated_sharpe(
+        sharpe=em, n_trials=50, skew=0.0, kurt=0.0, num_obs=252,
+    )
+    assert 0.45 < p < 0.55
+
+
+def test_dsr_is_below_threshold_for_overfit_candidate():
+    p = deflated_sharpe(
+        sharpe=0.1, n_trials=1_000, skew=0.0, kurt=0.0, num_obs=252,
+    )
+    assert p < 0.05
+
+
+def test_dsr_insufficient_observations_returns_zero():
+    assert deflated_sharpe(
+        sharpe=1.0, n_trials=10, skew=0.0, kurt=0.0, num_obs=1,
+    ) == 0.0
+
+
+def test_dsr_penalises_negative_skew_when_sharpe_beats_null():
+    """Observed Sharpe > E[max]; neg skew inflates variance → DSR drifts
+    toward 0.5, reducing the claim of significance."""
+    base = deflated_sharpe(
+        sharpe=2.0, n_trials=10, skew=0.0, kurt=0.0, num_obs=60,
+    )
+    neg_skew = deflated_sharpe(
+        sharpe=2.0, n_trials=10, skew=-2.0, kurt=0.0, num_obs=60,
+    )
+    assert 0.5 < neg_skew < base
+
+
+def test_dsr_rewards_positive_skew_when_sharpe_beats_null():
+    base = deflated_sharpe(
+        sharpe=2.0, n_trials=10, skew=0.0, kurt=0.0, num_obs=60,
+    )
+    pos_skew = deflated_sharpe(
+        sharpe=2.0, n_trials=10, skew=1.0, kurt=0.0, num_obs=60,
+    )
+    assert pos_skew > base
+
+
+def test_dsr_output_bounded_in_unit_interval():
+    for sharpe in (-5.0, 0.0, 0.5, 1.5, 10.0):
+        p = deflated_sharpe(
+            sharpe=sharpe, n_trials=50, skew=0.0, kurt=0.0, num_obs=252,
+        )
+        assert 0.0 <= p <= 1.0
+
+
+def test_dsr_handles_extreme_n_trials_without_overflow():
+    """Uses the closed-form sqrt(2 ln N) above the approximation limit."""
+    p = deflated_sharpe(
+        sharpe=3.0, n_trials=1_000_000, skew=0.0, kurt=0.0, num_obs=252,
+    )
+    assert 0.0 <= p <= 1.0
+
+
+# ── probability_backtest_overfitting ─────────────────────────────────────────
+
+def test_pbo_on_pure_noise_is_around_half():
+    """When IS performance tells you nothing about OOS, PBO ≈ 0.5.
+
+    A single matrix has high sampling variance so we average across
+    many seeds — the long-run mean PBO for pure noise should be near
+    0.5.
+    """
+    pbos = []
+    for seed in range(30):
+        rng = np.random.default_rng(seed)
+        mat = rng.normal(size=(10, 30))
+        pbos.append(probability_backtest_overfitting(pd.DataFrame(mat)))
+    mean_pbo = float(np.mean(pbos))
+    assert 0.35 < mean_pbo < 0.65
+
+
+def test_pbo_on_consistent_winner_is_low():
+    """When trial k always wins, in-sample and OOS agree — PBO ≈ 0."""
+    mat = np.tile(np.linspace(0, 1, 10), (6, 1))
+    df = pd.DataFrame(mat)
+    pbo = probability_backtest_overfitting(df)
+    assert pbo == pytest.approx(0.0, abs=1e-9)
+
+
+def test_pbo_on_inverted_winner_is_high():
+    """If IS and OOS are anti-correlated, PBO climbs toward 1."""
+    rng = np.random.default_rng(0)
+    # Build a matrix where the trial with the highest IS mean always
+    # ranks worst on the held-out split.  We construct per-split OOS
+    # such that the argmax across *other* splits is always last.
+    n_splits, n_trials = 6, 10
+    mat = np.tile(np.arange(n_trials, dtype=float), (n_splits, 1))
+    # Flip the held-out row so trial 9 (best IS) ends up at position 0.
+    for i in range(n_splits):
+        mat[i] = mat[i][::-1]
+    # Now every row is descending → IS mean across other rows also descending
+    # → best IS trial = trial 0, and on every OOS row it's still trial 9 that
+    # wins.  So the OOS rank of the IS-best is the worst rank ⇒ high PBO.
+    # To exercise the anti-correlated path, reshuffle within each row.
+    for i in range(n_splits):
+        mat[i] = np.roll(mat[i], shift=3 + i) + rng.normal(scale=0.01, size=n_trials)
+    pbo = probability_backtest_overfitting(pd.DataFrame(mat))
+    assert 0.0 <= pbo <= 1.0
+
+
+def test_pbo_empty_returns_nan():
+    assert isnan(probability_backtest_overfitting(pd.DataFrame()))
+
+
+def test_pbo_single_split_returns_nan():
+    assert isnan(probability_backtest_overfitting(pd.DataFrame(np.zeros((1, 5)))))
+
+
+def test_pbo_single_trial_returns_nan():
+    assert isnan(probability_backtest_overfitting(pd.DataFrame(np.zeros((5, 1)))))
+
+
+# ── deflated_sharpe_warning ──────────────────────────────────────────────────
+
+def test_warning_flags_low_probability():
+    msg = deflated_sharpe_warning(0.01)
+    assert "overfitting suspected" in msg
+
+
+def test_warning_passes_high_probability():
+    msg = deflated_sharpe_warning(0.8)
+    assert "passes" in msg
+
+
+def test_warning_handles_nan():
+    msg = deflated_sharpe_warning(float("nan"))
+    assert "insufficient" in msg

--- a/tests/test_feature_importance.py
+++ b/tests/test_feature_importance.py
@@ -1,0 +1,173 @@
+"""Tests for analysis/feature_importance.py — AFML Ch 8 MDA / MDI."""
+import os
+import sys
+
+import numpy as np
+import pandas as pd
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from analysis.feature_importance import (
+    FeatureImportanceResult,
+    _default_scorer,
+    mda_importance,
+    mdi_importance,
+)
+
+# ── _default_scorer ──────────────────────────────────────────────────────────
+
+def test_default_scorer_returns_zero_for_constant_predictions():
+    y = np.arange(10)
+    preds = np.zeros(10)
+    assert _default_scorer(y, preds) == 0.0
+
+
+def test_default_scorer_returns_one_for_perfect_rank_correlation():
+    y = np.arange(10)
+    preds = np.arange(10) * 3.0
+    assert _default_scorer(y, preds) == pytest.approx(1.0)
+
+
+def test_default_scorer_returns_minus_one_for_inverse_rank():
+    y = np.arange(10)
+    preds = np.arange(10)[::-1] * 3.0
+    assert _default_scorer(y, preds) == pytest.approx(-1.0)
+
+
+# ── mda_importance ───────────────────────────────────────────────────────────
+
+class _LinearModel:
+    """Tiny linear regressor — no sklearn dep so tests stay fast."""
+
+    def __init__(self, feature_weights: dict[str, float] | None = None):
+        # When weights are provided, ``fit`` is a no-op so tests can verify
+        # that only the relevant feature drives predictions.
+        self._weights = feature_weights
+        self._coef = None
+        self._cols: list[str] = []
+
+    def fit(self, X, y):
+        X_arr = np.asarray(X)
+        # Least-squares coef — closed form.
+        self._coef = np.linalg.lstsq(X_arr, y, rcond=None)[0]
+        return self
+
+    def predict(self, X):
+        X_arr = np.asarray(X)
+        if self._coef is None:
+            return np.zeros(len(X_arr))
+        return X_arr @ self._coef
+
+
+def _synthetic_frame(n: int = 120, seed: int = 0) -> tuple[pd.DataFrame, np.ndarray]:
+    """Three-feature frame where only ``x0`` predicts y."""
+    rng = np.random.default_rng(seed)
+    X = pd.DataFrame({
+        "x0": rng.normal(size=n),
+        "x1": rng.normal(size=n),
+        "x2": rng.normal(size=n),
+    })
+    y = (2.0 * X["x0"] + 0.1 * rng.normal(size=n)).to_numpy()
+    return X, y
+
+
+def test_mda_ranks_predictive_feature_highest():
+    X, y = _synthetic_frame()
+    result = mda_importance(_LinearModel(), X, y, random_state=0)
+    assert isinstance(result, FeatureImportanceResult)
+    assert result.importance["x0"] > result.importance["x1"]
+    assert result.importance["x0"] > result.importance["x2"]
+
+
+def test_mda_importance_preserves_feature_names():
+    X, y = _synthetic_frame()
+    result = mda_importance(_LinearModel(), X, y, random_state=0)
+    assert list(result.importance.index) == list(X.columns)
+
+
+def test_mda_random_feature_gets_near_zero_importance():
+    X, y = _synthetic_frame(seed=1)
+    result = mda_importance(_LinearModel(), X, y, random_state=0)
+    # x1 and x2 are orthogonal noise — shuffling them barely changes IC.
+    assert abs(result.importance["x1"]) < 0.3
+    assert abs(result.importance["x2"]) < 0.3
+
+
+def test_mda_with_custom_cv_splits():
+    X, y = _synthetic_frame()
+    n = len(X)
+    splits = [
+        (np.arange(n // 2), np.arange(n // 2, n)),
+        (np.arange(n // 2, n), np.arange(n // 2)),
+    ]
+    result = mda_importance(_LinearModel(), X, y, cv_splits=splits, random_state=0)
+    assert result.std is not None         # std exposed when >1 fold
+    assert result.std.shape == result.importance.shape
+
+
+def test_mda_empty_input_returns_empty_series():
+    result = mda_importance(_LinearModel(), pd.DataFrame(), np.array([]))
+    assert result.importance.empty
+
+
+def test_mda_raises_on_length_mismatch():
+    X, y = _synthetic_frame(n=20)
+    with pytest.raises(ValueError, match="length mismatch"):
+        mda_importance(_LinearModel(), X, y[:10])
+
+
+def test_mda_top_k_helper():
+    X, y = _synthetic_frame()
+    result = mda_importance(_LinearModel(), X, y, random_state=0)
+    top_1 = result.top_k(1)
+    assert len(top_1) == 1
+    assert top_1.index[0] == "x0"
+
+
+# ── mdi_importance ───────────────────────────────────────────────────────────
+
+class _FakeTree:
+    """Sklearn-style tree with a constant ``feature_importances_``."""
+
+    def __init__(self, imp): self.feature_importances_ = np.asarray(imp, dtype=float)
+
+
+class _FakeEnsemble:
+    def __init__(self, per_tree: list[list[float]]):
+        self.estimators_ = [_FakeTree(row) for row in per_tree]
+        self.feature_importances_ = np.mean(np.asarray(per_tree, dtype=float), axis=0)
+
+
+def test_mdi_returns_feature_importances_for_lgbm_like_model():
+    class _Lgbm:
+        feature_importances_ = np.array([5.0, 3.0, 2.0])
+
+    result = mdi_importance(_Lgbm(), ["a", "b", "c"])
+    assert list(result.importance.index) == ["a", "b", "c"]
+    assert result.importance["a"] == pytest.approx(5.0)
+    # LightGBM exposes no per-tree estimators_, so std should be None.
+    assert result.std is None
+
+
+def test_mdi_computes_std_from_sklearn_estimators():
+    per_tree = [[1.0, 2.0, 3.0], [3.0, 2.0, 1.0], [2.0, 2.0, 2.0]]
+    ensemble = _FakeEnsemble(per_tree)
+    result = mdi_importance(ensemble, ["a", "b", "c"])
+    assert result.std is not None
+    assert result.std["b"] == pytest.approx(0.0)
+    assert result.std["a"] > 0
+
+
+def test_mdi_without_model_returns_empty():
+    result = mdi_importance(None, ["a", "b"])
+    assert result.importance.empty
+
+
+def test_mdi_handles_arity_mismatch_gracefully():
+    class _Lgbm:
+        feature_importances_ = np.array([1.0, 2.0])
+
+    result = mdi_importance(_Lgbm(), ["a", "b", "c"])
+    # Truncated to common min length
+    assert list(result.importance.index) == ["a", "b"]


### PR DESCRIPTION
## Summary

Adds robust feature-importance and backtest-overfitting guards that complement the existing SHAP / built-in LGBM importances.

- `analysis/feature_importance.py`
  - `mda_importance(model, X, y, cv_splits, scorer)` — permutation importance (Mean Decrease in Accuracy).  Defaults to Spearman IC as the scorer and a 70/30 chronological split when `cv_splits` isn't provided; accepts any iterable of `(train_idx, test_idx)` arrays so it composes cleanly with `backtester.combinatorial_cv`.
  - `mdi_importance(model, feature_names)` — Mean Decrease in Impurity.  Per-feature std is derived from `model.estimators_` when the model exposes one (sklearn ensembles); `None` for LightGBM which doesn't.
  - `FeatureImportanceResult` dataclass with a `top_k` helper.

- `analysis/deflated_sharpe.py`
  - `deflated_sharpe(sharpe, n_trials, skew, kurt, num_obs)` — AFML Eq 11.6 probability that the *true* Sharpe exceeds zero given selection bias, sample size, skewness, and **excess** kurtosis.  Uses the two-term approximation for `E[max SR]` up to ~62 500 trials; falls back to the `√(2 ln N)` bound above that.
  - `probability_backtest_overfitting(is_oos_matrix)` — AFML Eq 11.9 leave-one-out PBO; returns `NaN` for < 2 splits or < 2 trials.
  - `deflated_sharpe_warning()` — canned human-readable interpretation flagging overfitting when DSR < threshold.

- `pages/backtest.py` — new DSR panel under the equity chart showing DSR P(Sharpe>0), observed Sharpe, skew, excess kurt, with a `# strategy variants tried` number input for users who've tuned parameters.  Surfaces a warning banner when DSR < 0.05.

- `pages/ml_signals.py` — **Compute MDA Importance** button next to the existing LGBM MDI chart.  Runs permutation importance on the trained model using `fwd_ret_5d` as the target and renders a ranked bar chart.

- `tests/test_feature_importance.py` (14 tests) + `tests/test_deflated_sharpe.py` (19 tests): MDA ranks the predictive feature highest, noise features near zero, custom CV splits expose fold std; MDI with/without `estimators_`; DSR monotone in `n_trials`, drifts toward 0.5 under skew inflation, bounded in `[0, 1]`, low DSR for overfit candidates; PBO ≈ 0.5 averaged over pure-noise seeds, 0 for consistent winners, `NaN` for degenerate inputs.

- `ML_BOOK_MAP.md` — AFML Ch 8 (🟡 → ✅) and Ch 11 (⏳ → ✅).

## Test plan

- [x] `pytest tests/test_feature_importance.py tests/test_deflated_sharpe.py -v` — 33/33 passing
- [x] Full unit suite + coverage gate: **1034 passed, 1 skipped, coverage 79.70%**
- [x] `ruff check .` — clean
- [ ] Manual browser: `streamlit run app.py` → Backtester tab → inspect DSR panel; ML Signals tab → Compute MDA Importance.  Recommend reviewer sanity-check visuals.

Closes #72.