### PR TITLE
feat: information-driven bars (AFML Ch 2, closes #70)

### DIFF
--- a/ML_BOOK_MAP.md
+++ b/ML_BOOK_MAP.md
@@ -83,7 +83,7 @@ graph LR
 
 | Chapter                                      | Topic                          | Status | Module(s)                                                       |
 |----------------------------------------------|--------------------------------|:------:|-----------------------------------------------------------------|
-| 2 — Financial Data Structures                | tick/volume/dollar bars        |   ⏳   | _planned_ — see issue "Dollar/volume bars"                      |
+| 2 — Financial Data Structures                | tick/volume/dollar bars        |   ✅   | `data/bars.py` (dollar_bars, volume_bars, tick_bars)            |
 | 3 — Labeling                                 | triple-barrier, meta-labeling  |   ✅   | `analysis/triple_barrier.py`, `strategies/meta_label.py`        |
 | 4 — Sample Weights                           | concurrency-based weighting    |   ✅   | `analysis/sample_weights.py` (num_co_events, sample_uniqueness, sequential_bootstrap) |
 | 5 — Fractionally Differentiated Features     | stationarity vs memory         |   ✅   | `data/frac_diff.py`                                             |

--- a/data/bars.py
+++ b/data/bars.py
@@ -1,0 +1,180 @@
+"""
+data/bars.py — AFML Ch 2 information-driven bars.
+
+Time-bar OHLCV (daily, hourly) samples information unevenly: a low-
+activity day carries the same weight as a high-activity day even
+though it contains far less price discovery.  López de Prado advocates
+*information-driven* bars — dollar, volume, and tick bars — that
+aggregate tick data until a fixed amount of traded notional, traded
+volume, or tick count accumulates.  Resulting bars have more uniform
+information content, which usually improves the i.i.d.-ness of features
+downstream.
+
+This module ships three aggregators that all accept a raw tick
+DataFrame:
+
+  * :func:`dollar_bars` — aggregate until `threshold` dollars trade.
+  * :func:`volume_bars` — aggregate until `threshold` shares trade.
+  * :func:`tick_bars`   — aggregate every ``n`` ticks.
+
+All three preserve the standard OHLCV schema so they plug directly into
+the existing feature pipeline.
+
+Reference
+---------
+    López de Prado, *Advances in Financial Machine Learning*, Ch 2.3-2.4.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+_PRICE_COL = "price"
+_VOLUME_COL = "volume"
+
+
+def _validate(tick_df: pd.DataFrame) -> pd.DataFrame:
+    if tick_df is None or tick_df.empty:
+        return pd.DataFrame(
+            columns=["Open", "High", "Low", "Close", "Volume", "DollarValue"]
+        )
+    if _PRICE_COL not in tick_df.columns or _VOLUME_COL not in tick_df.columns:
+        raise ValueError(
+            f"tick_df must contain '{_PRICE_COL}' and '{_VOLUME_COL}' columns"
+        )
+    if not tick_df.index.is_monotonic_increasing:
+        tick_df = tick_df.sort_index()
+    return tick_df
+
+
+def _aggregate_bar(bar_ticks: pd.DataFrame) -> dict:
+    price = bar_ticks[_PRICE_COL].to_numpy(dtype=float)
+    volume = bar_ticks[_VOLUME_COL].to_numpy(dtype=float)
+    return {
+        "Open":        float(price[0]),
+        "High":        float(price.max()),
+        "Low":         float(price.min()),
+        "Close":       float(price[-1]),
+        "Volume":      float(volume.sum()),
+        "DollarValue": float((price * volume).sum()),
+    }
+
+
+def _bars_from_cuts(tick_df: pd.DataFrame, cuts: list[int]) -> pd.DataFrame:
+    """Turn a list of integer cut points into an OHLCV DataFrame.
+
+    ``cuts`` lists the last tick index (inclusive) in each bar.  The
+    resulting bar is timestamped with the last tick's index.
+    """
+    if not cuts:
+        return pd.DataFrame(
+            columns=["Open", "High", "Low", "Close", "Volume", "DollarValue"]
+        )
+
+    rows: list[dict] = []
+    timestamps: list = []
+    start = 0
+    for end in cuts:
+        bar_slice = tick_df.iloc[start : end + 1]
+        rows.append(_aggregate_bar(bar_slice))
+        timestamps.append(bar_slice.index[-1])
+        start = end + 1
+
+    out = pd.DataFrame(rows, index=pd.Index(timestamps, name="timestamp"))
+    return out[["Open", "High", "Low", "Close", "Volume", "DollarValue"]]
+
+
+def dollar_bars(tick_df: pd.DataFrame, threshold: float) -> pd.DataFrame:
+    """Aggregate ticks into bars of (approximately) equal traded dollar value.
+
+    Parameters
+    ----------
+    tick_df :
+        DataFrame indexed by timestamp with ``price`` and ``volume``
+        columns.  Rows represent individual ticks (or trade summaries).
+    threshold :
+        Dollar value at which a new bar is emitted.  Must be positive.
+
+    Returns
+    -------
+    ``pd.DataFrame`` with columns ``Open, High, Low, Close, Volume,
+    DollarValue`` indexed by the timestamp of the last tick in each
+    bar.  Any residual ticks whose cumulative dollar value never
+    crosses the threshold are silently dropped so the round-trip
+    invariant (``sum(dollar) == sum(tick_dollar)`` for complete bars)
+    holds.
+    """
+    if threshold <= 0:
+        raise ValueError("threshold must be positive")
+
+    tick_df = _validate(tick_df)
+    if tick_df.empty:
+        return tick_df
+
+    dollar = (
+        tick_df[_PRICE_COL].to_numpy(dtype=float)
+        * tick_df[_VOLUME_COL].to_numpy(dtype=float)
+    )
+    cum = np.cumsum(dollar)
+    # Find positions where cumulative dollar crosses each multiple of threshold.
+    milestones = np.arange(threshold, cum[-1] + 1e-12, threshold)
+    if milestones.size == 0:
+        return pd.DataFrame(
+            columns=["Open", "High", "Low", "Close", "Volume", "DollarValue"]
+        )
+    cuts = np.searchsorted(cum, milestones, side="left").tolist()
+    # Dedup consecutive identical cuts (can happen when a single huge
+    # trade blows past multiple thresholds in one tick).
+    unique_cuts: list[int] = []
+    for c in cuts:
+        if not unique_cuts or c != unique_cuts[-1]:
+            unique_cuts.append(int(c))
+    return _bars_from_cuts(tick_df, unique_cuts)
+
+
+def volume_bars(tick_df: pd.DataFrame, threshold: float) -> pd.DataFrame:
+    """Aggregate ticks into bars of (approximately) equal traded volume."""
+    if threshold <= 0:
+        raise ValueError("threshold must be positive")
+
+    tick_df = _validate(tick_df)
+    if tick_df.empty:
+        return tick_df
+
+    volume = tick_df[_VOLUME_COL].to_numpy(dtype=float)
+    cum = np.cumsum(volume)
+    milestones = np.arange(threshold, cum[-1] + 1e-12, threshold)
+    if milestones.size == 0:
+        return pd.DataFrame(
+            columns=["Open", "High", "Low", "Close", "Volume", "DollarValue"]
+        )
+    cuts = np.searchsorted(cum, milestones, side="left").tolist()
+    unique_cuts: list[int] = []
+    for c in cuts:
+        if not unique_cuts or c != unique_cuts[-1]:
+            unique_cuts.append(int(c))
+    return _bars_from_cuts(tick_df, unique_cuts)
+
+
+def tick_bars(tick_df: pd.DataFrame, n: int) -> pd.DataFrame:
+    """Aggregate every ``n`` ticks into a bar.
+
+    Unlike dollar / volume bars, tick bars have deterministic lengths
+    (except the final partial bar, which is dropped to match the other
+    aggregators' round-trip invariant).
+    """
+    if n <= 0:
+        raise ValueError("n must be positive")
+
+    tick_df = _validate(tick_df)
+    if tick_df.empty:
+        return tick_df
+
+    total = len(tick_df)
+    num_bars = total // n
+    if num_bars == 0:
+        return pd.DataFrame(
+            columns=["Open", "High", "Low", "Close", "Volume", "DollarValue"]
+        )
+    cuts = [(i + 1) * n - 1 for i in range(num_bars)]
+    return _bars_from_cuts(tick_df, cuts)

--- a/tests/test_bars.py
+++ b/tests/test_bars.py
@@ -1,0 +1,169 @@
+"""Tests for data/bars.py — AFML Ch 2 information-driven bars."""
+import os
+import sys
+
+import numpy as np
+import pandas as pd
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from data.bars import dollar_bars, tick_bars, volume_bars
+
+
+def _ticks(
+    n: int = 20,
+    start: str = "2024-01-01 09:30:00",
+    prices: list[float] | None = None,
+    volumes: list[float] | None = None,
+) -> pd.DataFrame:
+    idx = pd.date_range(start=start, periods=n, freq="1s")
+    if prices is None:
+        prices = (100 + np.arange(n) * 0.1).tolist()
+    if volumes is None:
+        volumes = [100.0] * n
+    return pd.DataFrame({"price": prices, "volume": volumes}, index=idx)
+
+
+# ── dollar_bars ──────────────────────────────────────────────────────────────
+
+def test_dollar_bars_output_has_ohlcv_schema():
+    df = dollar_bars(_ticks(), threshold=10_000.0)
+    assert list(df.columns) == [
+        "Open", "High", "Low", "Close", "Volume", "DollarValue",
+    ]
+
+
+def test_dollar_bars_round_trip_preserves_total_notional():
+    """Sum of bar DollarValue equals sum of tick (price × volume) for
+    all bars *completed* before the final residual."""
+    ticks = _ticks(n=50, prices=[100.0] * 50, volumes=[10.0] * 50)
+    threshold = 2_500.0                     # exactly 2.5 ticks per bar
+    bars = dollar_bars(ticks, threshold)
+    assert not bars.empty
+    # Every complete bar sums to a multiple of ~threshold (give or take
+    # the per-tick granularity of 100 * 10 = 1000).
+    assert bars["DollarValue"].sum() <= (ticks["price"] * ticks["volume"]).sum()
+
+
+def test_dollar_bars_emits_single_bar_when_threshold_just_fits():
+    ticks = _ticks(n=10, prices=[100.0] * 10, volumes=[1.0] * 10)
+    # Total traded notional = 1000
+    bars = dollar_bars(ticks, threshold=1_000.0)
+    assert len(bars) == 1
+    assert bars["Volume"].iloc[0] == pytest.approx(10.0)
+    assert bars["DollarValue"].iloc[0] == pytest.approx(1_000.0)
+
+
+def test_dollar_bars_empty_input_returns_empty_frame():
+    bars = dollar_bars(pd.DataFrame(), threshold=1_000.0)
+    assert bars.empty
+
+
+def test_dollar_bars_below_threshold_returns_empty_frame():
+    ticks = _ticks(n=3, prices=[100.0] * 3, volumes=[1.0] * 3)   # total $300
+    assert dollar_bars(ticks, threshold=10_000.0).empty
+
+
+def test_dollar_bars_threshold_must_be_positive():
+    with pytest.raises(ValueError, match="threshold"):
+        dollar_bars(_ticks(), threshold=0.0)
+
+
+def test_dollar_bars_timestamp_is_last_tick_in_bar():
+    ticks = _ticks(n=10, prices=[100.0] * 10, volumes=[1.0] * 10)
+    bars = dollar_bars(ticks, threshold=500.0)   # every 5 ticks → 2 bars
+    assert len(bars) == 2
+    assert bars.index[0] == ticks.index[4]
+    assert bars.index[1] == ticks.index[9]
+
+
+def test_dollar_bars_ohlc_matches_first_last_min_max():
+    prices = [100.0, 105.0, 98.0, 103.0, 101.0]
+    ticks = _ticks(n=5, prices=prices, volumes=[1.0] * 5)
+    bars = dollar_bars(ticks, threshold=505.0)   # total = 100+105+98+103+101
+    assert len(bars) == 1
+    row = bars.iloc[0]
+    assert row["Open"] == pytest.approx(100.0)
+    assert row["High"] == pytest.approx(105.0)
+    assert row["Low"] == pytest.approx(98.0)
+    assert row["Close"] == pytest.approx(101.0)
+
+
+def test_dollar_bars_sorts_unsorted_index():
+    ticks = _ticks(n=5, prices=[100.0] * 5, volumes=[1.0] * 5)
+    shuffled = ticks.iloc[[2, 0, 4, 1, 3]]
+    bars = dollar_bars(shuffled, threshold=500.0)
+    assert len(bars) == 1
+    assert bars.index[0] == ticks.index[4]
+
+
+def test_dollar_bars_raises_on_missing_columns():
+    bad = pd.DataFrame({"close": [100.0]}, index=[pd.Timestamp("2024-01-01")])
+    with pytest.raises(ValueError, match="price"):
+        dollar_bars(bad, threshold=100.0)
+
+
+# ── volume_bars ──────────────────────────────────────────────────────────────
+
+def test_volume_bars_splits_on_cumulative_volume():
+    ticks = _ticks(n=6, prices=[100.0] * 6, volumes=[1.0] * 6)
+    bars = volume_bars(ticks, threshold=2.0)       # every 2 ticks
+    assert len(bars) == 3
+    assert (bars["Volume"] == 2.0).all()
+
+
+def test_volume_bars_threshold_must_be_positive():
+    with pytest.raises(ValueError):
+        volume_bars(_ticks(), threshold=-1.0)
+
+
+def test_volume_bars_empty_returns_empty_frame():
+    assert volume_bars(pd.DataFrame(), threshold=100.0).empty
+
+
+def test_volume_bars_round_trip_volume_sums():
+    ticks = _ticks(n=20, prices=[100.0] * 20, volumes=[0.5] * 20)
+    threshold = 2.5
+    bars = volume_bars(ticks, threshold=threshold)
+    # Residual 4 ticks (total 10.0, 4 bars at vol 2.5 each = 10.0) — clean.
+    assert bars["Volume"].sum() == pytest.approx(ticks["volume"].sum())
+
+
+# ── tick_bars ────────────────────────────────────────────────────────────────
+
+def test_tick_bars_uniform_chunks():
+    ticks = _ticks(n=10, prices=list(range(10)), volumes=[1.0] * 10)
+    bars = tick_bars(ticks, n=5)
+    assert len(bars) == 2
+    assert bars.iloc[0]["Open"] == pytest.approx(0)
+    assert bars.iloc[0]["Close"] == pytest.approx(4)
+    assert bars.iloc[1]["Open"] == pytest.approx(5)
+    assert bars.iloc[1]["Close"] == pytest.approx(9)
+
+
+def test_tick_bars_drops_partial_final_bar():
+    ticks = _ticks(n=11)                 # 11 ticks, n=5 → 2 bars, 1 leftover
+    bars = tick_bars(ticks, n=5)
+    assert len(bars) == 2
+
+
+def test_tick_bars_n_larger_than_data_returns_empty():
+    ticks = _ticks(n=3)
+    assert tick_bars(ticks, n=10).empty
+
+
+def test_tick_bars_n_must_be_positive():
+    with pytest.raises(ValueError):
+        tick_bars(_ticks(), n=0)
+
+
+def test_tick_bars_empty_input_returns_empty_frame():
+    assert tick_bars(pd.DataFrame(), n=5).empty
+
+
+def test_tick_bars_dollarvalue_column_populated():
+    ticks = _ticks(n=4, prices=[100.0, 200.0, 150.0, 50.0], volumes=[1.0] * 4)
+    bars = tick_bars(ticks, n=2)
+    assert bars.iloc[0]["DollarValue"] == pytest.approx(300.0)
+    assert bars.iloc[1]["DollarValue"] == pytest.approx(200.0)


### PR DESCRIPTION
## Summary

Adds AFML Ch 2 information-driven bars — tick, volume, and dollar aggregators that sample price discovery more uniformly than time bars do.  All three emit the standard OHLCV schema (plus a `DollarValue` column) so they drop into the existing feature pipeline without downstream changes.

- `data/bars.py`
  - `dollar_bars(tick_df, threshold)` — emit a bar when cumulative `price × volume` crosses each multiple of `threshold`.
  - `volume_bars(tick_df, threshold)` — same on cumulative volume.
  - `tick_bars(tick_df, n)` — emit a bar every `n` ticks.
  - All three linear in input size (`np.cumsum` + `np.searchsorted`).  Final residual that doesn't cross the threshold is dropped to keep the round-trip invariant clean.
- `tests/test_bars.py` — 20 tests covering schema, round-trip total notional/volume preservation, last-tick-wins timestamping, OHLC min/max correctness, unsorted-index normalisation, positive-threshold validation, missing-column validation, partial-tail drop for `tick_bars`, and empty-input handling.
- `ML_BOOK_MAP.md` — AFML Ch 2 flips from ⏳ to ✅.

## Test plan

- [x] `pytest tests/test_bars.py -v` — 20/20 passing
- [x] Full unit suite + coverage gate: **1054 passed, 1 skipped, coverage 79.91%**
- [x] `ruff check .` — clean

Closes #70.