### PR TITLE
feat: Bayesian linear regression alpha signal (Jansen Ch 10, closes #75)

### DIFF
--- a/ML_BOOK_MAP.md
+++ b/ML_BOOK_MAP.md
@@ -115,7 +115,7 @@ graph LR
 | 7 — Linear Models                            | Ridge, Lasso, risk factors     |   ✅   | `strategies/linear_signal.py`                                   |
 | 8 — The ML4T Workflow                        | backtest loop                  |   ✅   | `backtester/engine.py:run_signal_backtest`                      |
 | 9 — Time-Series Models                       | GARCH, cointegration           |   🟡   | cointegration partial (`strategies/pairs.py` OLS); GARCH planned|
-| 10 — Bayesian ML                             | Bayesian linear regression     |   ⏳   | _planned_ — see issue "Bayesian regression"                     |
+| 10 — Bayesian ML                             | Bayesian linear regression     |   ✅   | `strategies/bayesian_signal.py` (BayesianRidge + predict_with_uncertainty) |
 | 11 — Random Forests                          | long-short strategies          |   🟡   | used internally by `meta_label.py`; no dedicated strategy       |
 | 12 — Boosting                                | LightGBM / XGBoost             |   ✅   | `strategies/ml_signal.py`                                       |
 | 13 — Unsupervised Learning                   | PCA, k-means, risk factors     |   ✅   | `analysis/unsupervised.py` (PCA loadings + scree; k-means on corr-distance) |

--- a/pages/ml_signals.py
+++ b/pages/ml_signals.py
@@ -80,13 +80,18 @@ def render() -> None:
         pt_sl = (float(pt_val), float(sl_val))
 
     # ── Train / Retrain ───────────────────────────────────────────────────────
-    col_lgbm, col_regime, col_ridge, col_tune = st.columns(4)
+    col_lgbm, col_regime, col_ridge, col_bayes, col_tune = st.columns(5)
     with col_lgbm:
         do_train = st.button("Train LGBM Baseline", type="primary", key="ml_train_btn")
     with col_regime:
         do_train_regime = st.button("Train Regime Models", key="ml_train_regime_btn")
     with col_ridge:
         do_train_ridge = st.button("Train Ridge Model", key="ml_train_ridge_btn")
+    with col_bayes:
+        do_train_bayes = st.button(
+            "Train Bayesian Model", key="ml_train_bayes_btn",
+            help="BayesianRidge — posterior-std exposed for Kelly sizing (ML4T Ch 10)."
+        )
     with col_tune:
         tune_trials = int(st.number_input(
             "Tune trials", min_value=5, max_value=100, value=20, step=5,
@@ -161,6 +166,24 @@ def render() -> None:
             except Exception as exc:
                 st.error(f"Ridge training failed: {exc}")
 
+    if do_train_bayes:
+        with st.spinner("Training BayesianRidge alpha model…"):
+            try:
+                from strategies.bayesian_signal import (
+                    _SKLEARN_AVAILABLE,
+                    BayesianSignal,
+                )
+                if not _SKLEARN_AVAILABLE:
+                    st.error("scikit-learn is not installed.")
+                else:
+                    bayes_model = BayesianSignal()
+                    bayes_metrics = bayes_model.train(selected_tickers, period=period)
+                    st.session_state["bayes_model_instance"] = bayes_model
+                    st.session_state["bayes_train_metrics"] = bayes_metrics
+                    st.success("Bayesian model trained successfully.")
+            except Exception as exc:
+                st.error(f"Bayesian training failed: {exc}")
+
     if do_tune:
         with st.spinner(f"Running Optuna TPE search ({tune_trials} trials)…"):
             try:
@@ -224,6 +247,16 @@ def render() -> None:
         rc3.metric("Train ICIR", f"{rm.get('train_icir', 0):.3f}")
         rc4.metric("Test ICIR",  f"{rm.get('test_icir', 0):.3f}")
 
+    # ── Bayesian training metrics ─────────────────────────────────────────────
+    if "bayes_train_metrics" in st.session_state:
+        bm = st.session_state["bayes_train_metrics"]
+        st.caption("**Bayesian Ridge Metrics**")
+        bc1, bc2, bc3, bc4 = st.columns(4)
+        bc1.metric("Train IC",   f"{bm.get('train_ic', 0):.4f}")
+        bc2.metric("Test IC",    f"{bm.get('test_ic', 0):.4f}")
+        bc3.metric("Train ICIR", f"{bm.get('train_icir', 0):.3f}")
+        bc4.metric("Test ICIR",  f"{bm.get('test_icir', 0):.3f}")
+
     # ── Regime model metrics ──────────────────────────────────────────────────
     if "ml_regime_results" in st.session_state:
         rr = st.session_state["ml_regime_results"]
@@ -252,8 +285,9 @@ def render() -> None:
     )
 
     if st.button("Compute All Scores", key="ml_compute_all_btn", type="primary"):
-        with st.spinner("Scoring all three models…"):
+        with st.spinner("Scoring all models…"):
             try:
+                from strategies.bayesian_signal import BayesianSignal
                 from strategies.ensemble_signal import blend_signals
                 from strategies.linear_signal import LinearSignal
                 from strategies.ml_signal import MLSignal
@@ -268,12 +302,24 @@ def render() -> None:
                 st.session_state["ridge_model_instance"] = ridge_model
                 st.session_state["ridge_scores"] = ridge_scores
 
-                ensemble_scores = blend_signals(lgbm_scores, ridge_scores)
+                bayes_model = st.session_state.get("bayes_model_instance") or BayesianSignal()
+                bayes_scores, bayes_sigma = bayes_model.predict_with_uncertainty(
+                    selected_tickers, period="6mo",
+                )
+                st.session_state["bayes_model_instance"] = bayes_model
+                st.session_state["bayes_scores"] = bayes_scores
+                st.session_state["bayes_sigma"] = bayes_sigma
+
+                ensemble_scores = blend_signals(
+                    lgbm_scores, ridge_scores, bayes_scores,
+                )
                 st.session_state["ensemble_scores"] = ensemble_scores
             except Exception as exc:
                 st.error(f"Scoring failed: {exc}")
 
-    tab_lgbm, tab_ridge, tab_ensemble = st.tabs(["LGBM", "Ridge", "Ensemble"])
+    tab_lgbm, tab_ridge, tab_bayes, tab_ensemble = st.tabs(
+        ["LGBM", "Ridge", "Bayesian", "Ensemble"]
+    )
 
     with tab_lgbm:
         if st.button("Compute LGBM Scores", key="ml_predict_btn"):
@@ -301,17 +347,48 @@ def render() -> None:
         if "ridge_scores" in st.session_state:
             _render_alpha_chart(st.session_state["ridge_scores"])
 
+    with tab_bayes:
+        if st.button("Compute Bayesian Scores", key="bayes_predict_btn"):
+            with st.spinner("Scoring tickers with Bayesian model…"):
+                try:
+                    from strategies.bayesian_signal import BayesianSignal
+                    bayes_model = st.session_state.get("bayes_model_instance") or BayesianSignal()
+                    mean, sigma = bayes_model.predict_with_uncertainty(
+                        selected_tickers, period="6mo",
+                    )
+                    st.session_state["bayes_scores"] = mean
+                    st.session_state["bayes_sigma"] = sigma
+                except Exception as exc:
+                    st.error(f"Bayesian prediction failed: {exc}")
+        if "bayes_scores" in st.session_state:
+            _render_alpha_chart(st.session_state["bayes_scores"])
+            if "bayes_sigma" in st.session_state:
+                sigma_df = pd.DataFrame(
+                    [
+                        {"Ticker": t, "σ": s}
+                        for t, s in st.session_state["bayes_sigma"].items()
+                    ]
+                ).sort_values("σ")
+                st.caption("**Posterior predictive std (smaller = more confident)**")
+                st.dataframe(sigma_df, use_container_width=True, hide_index=True)
+
     with tab_ensemble:
         if st.button("Compute Ensemble Scores", key="ensemble_predict_btn"):
-            with st.spinner("Blending LGBM + Ridge scores…"):
+            with st.spinner("Blending all available signals…"):
                 try:
                     from strategies.ensemble_signal import blend_signals
-                    lgbm_sc = st.session_state.get("ml_scores", {})
-                    ridge_sc = st.session_state.get("ridge_scores", {})
-                    if not lgbm_sc and not ridge_sc:
-                        st.warning("Compute LGBM and/or Ridge scores first.")
+                    sources = [
+                        st.session_state.get(k, {}) for k in
+                        ("ml_scores", "ridge_scores", "bayes_scores")
+                    ]
+                    non_empty = [s for s in sources if s]
+                    if not non_empty:
+                        st.warning(
+                            "Compute at least one of LGBM / Ridge / Bayesian "
+                            "scores first."
+                        )
                     else:
-                        st.session_state["ensemble_scores"] = blend_signals(lgbm_sc, ridge_sc)
+                        st.session_state["ensemble_scores"] = blend_signals(*non_empty)
                 except Exception as exc:
                     st.error(f"Ensemble blending failed: {exc}")
         if "ensemble_scores" in st.session_state:

--- a/strategies/bayesian_signal.py
+++ b/strategies/bayesian_signal.py
@@ -1,0 +1,318 @@
+"""
+strategies/bayesian_signal.py — Bayesian linear-regression alpha model.
+
+The existing ``LinearSignal`` (Ridge) gives a point estimate; it can't
+express parameter uncertainty.  Bayesian linear regression retains a
+full posterior so we can report a per-sample predictive ``sigma`` — the
+execution layer can then scale Kelly by confidence (shrink bets when
+the posterior is wide) and the UI can surface error bars.
+
+``BayesianSignal`` mirrors :class:`~strategies.linear_signal.LinearSignal`
+in every public method so the ensemble / prediction pipelines pick it
+up without special-casing.  The only extra surface is
+:meth:`predict_with_uncertainty` which returns a ``(mean, sigma)`` dict
+pair.
+
+Reference
+---------
+    Jansen, *Machine Learning for Algorithmic Trading* (2nd ed.) Ch 10.3-10.5.
+"""
+from __future__ import annotations
+
+import os
+import pickle
+import time
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+from analysis.factor_ic import _spearman_corr
+from data.features import _FEATURE_COLS, build_feature_matrix
+from utils.logger import get_logger
+
+log = get_logger(__name__)
+
+try:
+    from sklearn.linear_model import BayesianRidge
+    _SKLEARN_AVAILABLE = True
+except ImportError:
+    BayesianRidge = None  # type: ignore[assignment,misc]
+    _SKLEARN_AVAILABLE = False
+
+_DEFAULT_MODEL_PATH = os.environ.get(
+    "BAYES_ALPHA_MODEL_PATH", "models/bayesian_alpha.pkl"
+)
+_TARGET_COL = "fwd_ret_5d"
+
+
+class BayesianSignal:
+    """Bayesian Ridge alpha model — same interface as :class:`LinearSignal`.
+
+    Internally wraps ``sklearn.linear_model.BayesianRidge`` which gives
+    an analytical posterior over the coefficients and exposes a
+    per-sample predictive std.  The posterior std is the quantity the
+    execution layer can consume to shrink Kelly sizes.
+    """
+
+    def __init__(self, model_path: str | None = None) -> None:
+        self._model_path: str = model_path or _DEFAULT_MODEL_PATH
+        self._model = None  # BayesianRidge | None
+        self._feature_cols: list[str] = list(_FEATURE_COLS)
+        self._load_if_available()
+
+    # ── Model loading ─────────────────────────────────────────────────────────
+
+    def _load_if_available(self) -> None:
+        path = Path(self._model_path)
+        if not path.exists():
+            log.info(
+                "bayesian_signal: no checkpoint found, will use momentum fallback",
+                path=str(path),
+            )
+            return
+        try:
+            with open(path, "rb") as f:
+                self._model = pickle.load(f)
+            log.info("bayesian_signal: loaded checkpoint", path=str(path))
+        except Exception as exc:
+            log.warning(
+                "bayesian_signal: failed to load checkpoint",
+                path=str(path), error=str(exc),
+            )
+
+    # ── Training ──────────────────────────────────────────────────────────────
+
+    def train(
+        self,
+        tickers: list[str],
+        period: str = "2y",
+        test_size: float = 0.2,
+    ) -> dict[str, float]:
+        """Fit BayesianRidge on the feature matrix and persist the model.
+
+        Same return schema as :meth:`LinearSignal.train` — the caller
+        code in the ensemble / UI layers can treat both classes
+        interchangeably.
+        """
+        if not _SKLEARN_AVAILABLE:
+            raise RuntimeError(
+                "scikit-learn is not installed. Run: pip install scikit-learn>=1.3.0"
+            )
+
+        log.info(
+            "bayesian_signal: building feature matrix",
+            tickers=len(tickers), period=period,
+        )
+        fm = build_feature_matrix(tickers, period=period)
+
+        if fm.empty:
+            raise ValueError("Feature matrix is empty — check tickers and period")
+
+        fm = fm.dropna(subset=[_TARGET_COL])
+        if fm.empty:
+            raise ValueError(f"No rows with non-NaN target '{_TARGET_COL}'")
+
+        all_dates = sorted(fm.index.get_level_values("date").unique())
+        split_idx = int(len(all_dates) * (1 - test_size))
+        train_dates = set(all_dates[:split_idx])
+        test_dates = set(all_dates[split_idx:])
+
+        feature_cols = [c for c in _FEATURE_COLS if c in fm.columns]
+        self._feature_cols = feature_cols
+
+        train_df = fm[fm.index.get_level_values("date").isin(train_dates)]
+        test_df = fm[fm.index.get_level_values("date").isin(test_dates)]
+
+        X_train = train_df[feature_cols].fillna(0.0).values
+        y_train = train_df[_TARGET_COL].values
+        X_test = test_df[feature_cols].fillna(0.0).values
+        y_test = test_df[_TARGET_COL].values
+
+        log.info(
+            "bayesian_signal: training BayesianRidge",
+            n_train=len(X_train),
+            n_test=len(X_test),
+            features=len(feature_cols),
+        )
+
+        model = BayesianRidge()
+        model.fit(X_train, y_train)
+        self._model = model
+
+        train_ic = _spearman_corr(model.predict(X_train), y_train)
+        test_ic = _spearman_corr(model.predict(X_test), y_test)
+
+        log.info(
+            "bayesian_signal: training complete",
+            train_ic=round(train_ic, 4),
+            test_ic=round(test_ic, 4),
+        )
+
+        Path(self._model_path).parent.mkdir(parents=True, exist_ok=True)
+        with open(self._model_path, "wb") as f:
+            pickle.dump(model, f)
+        log.info("bayesian_signal: checkpoint saved", path=self._model_path)
+
+        self._write_metadata(
+            n_tickers=len(tickers),
+            period=period,
+            train_ic=train_ic,
+            test_ic=test_ic,
+        )
+
+        return {
+            "train_ic": float(train_ic),
+            "test_ic": float(test_ic),
+            "train_icir": float(train_ic),
+            "test_icir": float(test_ic),
+            "n_train_samples": int(len(X_train)),
+            "n_test_samples": int(len(X_test)),
+        }
+
+    # ── Prediction ────────────────────────────────────────────────────────────
+
+    def predict(
+        self, tickers: list[str], period: str = "6mo",
+    ) -> dict[str, float]:
+        """Return ranked mean alpha scores in ``[-1, 1]`` per ticker.
+
+        The per-sample ``sigma`` is discarded here — callers who want it
+        should call :meth:`predict_with_uncertainty` instead.
+        """
+        mean, _ = self.predict_with_uncertainty(tickers, period=period)
+        return mean
+
+    def predict_with_uncertainty(
+        self, tickers: list[str], period: str = "6mo",
+    ) -> tuple[dict[str, float], dict[str, float]]:
+        """Return ``(mean_scores, sigma_scores)`` dicts keyed by ticker.
+
+        Mean scores are z-scored + clipped to ``[-1, 1]`` exactly like
+        :meth:`LinearSignal.predict`.  Sigma is the raw BayesianRidge
+        predictive std — smaller ⇒ more confident.  When no model is
+        loaded, falls back to the momentum composite and reports
+        sigma = 1.0 for every ticker (max uncertainty).
+        """
+        fallback_sigma = {t: 1.0 for t in tickers}
+        if self._model is None:
+            return self._momentum_fallback(tickers, period), fallback_sigma
+
+        try:
+            fm = build_feature_matrix(tickers, period=period)
+            if fm.empty:
+                return self._momentum_fallback(tickers, period), fallback_sigma
+
+            feature_cols = [c for c in self._feature_cols if c in fm.columns]
+            last_date = fm.index.get_level_values("date").max()
+            latest = fm.xs(last_date, level="date")[feature_cols].fillna(0.0)
+
+            if latest.empty:
+                return self._momentum_fallback(tickers, period), fallback_sigma
+
+            raw_mean, raw_std = self._model.predict(latest.values, return_std=True)
+
+            std = raw_mean.std()
+            if std == 0:
+                scores = np.zeros(len(raw_mean))
+            else:
+                scores = (raw_mean - raw_mean.mean()) / std
+            scores = np.clip(scores, -1.0, 1.0)
+
+            mean_dict = {
+                ticker: float(scores[i]) for i, ticker in enumerate(latest.index)
+            }
+            sigma_dict = {
+                ticker: float(raw_std[i]) for i, ticker in enumerate(latest.index)
+            }
+            return mean_dict, sigma_dict
+
+        except Exception as exc:
+            log.warning(
+                "bayesian_signal.predict: error, falling back to momentum",
+                error=str(exc),
+            )
+            return self._momentum_fallback(tickers, period), fallback_sigma
+
+    @staticmethod
+    def _momentum_fallback(tickers: list[str], period: str) -> dict[str, float]:
+        from data.fetcher import fetch_ohlcv
+        from strategies.momentum import compute_momentum_score
+
+        scores: dict[str, float] = {}
+        for ticker in tickers:
+            try:
+                df = fetch_ohlcv(ticker, period)
+                if df is not None and not df.empty:
+                    mom = compute_momentum_score(df)
+                    last_val = (
+                        mom.dropna().iloc[-1] if not mom.dropna().empty else 0.0
+                    )
+                    scores[ticker] = float(np.clip(last_val, -1.0, 1.0))
+                else:
+                    scores[ticker] = 0.0
+            except Exception:
+                scores[ticker] = 0.0
+        return scores
+
+    # ── Coefficients ─────────────────────────────────────────────────────────
+
+    def feature_coefficients(self) -> pd.DataFrame:
+        """Return a DataFrame of posterior-mean coefficients with std.
+
+        Columns: ``feature``, ``coefficient``, ``std``.  Empty if no
+        model is loaded.  The ``std`` column is the *posterior* std of
+        each coefficient (sqrt of the diagonal of ``sigma_``) — a
+        direct indicator of which factors the model believes in.
+        """
+        if self._model is None:
+            return pd.DataFrame(columns=["feature", "coefficient", "std"])
+        try:
+            coefs = np.asarray(self._model.coef_)
+            # ``sigma_`` is the posterior covariance matrix of the coefs
+            sigma = getattr(self._model, "sigma_", None)
+            if sigma is not None and sigma.shape[0] == len(coefs):
+                coef_std = np.sqrt(np.maximum(np.diag(sigma), 0.0))
+            else:
+                coef_std = np.zeros_like(coefs)
+            df = pd.DataFrame({
+                "feature": self._feature_cols[:len(coefs)],
+                "coefficient": coefs,
+                "std": coef_std,
+            })
+            return df.reindex(
+                df["coefficient"].abs().sort_values(ascending=False).index
+            ).reset_index(drop=True)
+        except Exception as exc:
+            log.warning("bayesian_signal.feature_coefficients: error", error=str(exc))
+            return pd.DataFrame(columns=["feature", "coefficient", "std"])
+
+    # ── Metadata ──────────────────────────────────────────────────────────────
+
+    def _write_metadata(
+        self,
+        n_tickers: int,
+        period: str,
+        train_ic: float,
+        test_ic: float,
+    ) -> None:
+        try:
+            from data.db import get_connection
+            conn = get_connection()
+            with conn:
+                conn.execute(
+                    """
+                    INSERT INTO model_metadata
+                        (model_name, trained_at, train_ic, test_ic, n_tickers, period)
+                    VALUES (?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        "bayesian_alpha", time.time(), train_ic, test_ic,
+                        n_tickers, period,
+                    ),
+                )
+            conn.close()
+        except Exception as exc:
+            log.warning(
+                "bayesian_signal: could not write metadata", error=str(exc),
+            )

--- a/tests/test_bayesian_signal.py
+++ b/tests/test_bayesian_signal.py
@@ -1,0 +1,215 @@
+"""Tests for strategies/bayesian_signal.py — BayesianRidge alpha model."""
+import os
+import pickle
+import sys
+from unittest.mock import patch
+
+import numpy as np
+import pandas as pd
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from strategies.bayesian_signal import (
+    _SKLEARN_AVAILABLE,
+    BayesianSignal,
+)
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+def _make_feature_matrix(
+    n_dates: int = 80, n_tickers: int = 5, seed: int = 0,
+) -> pd.DataFrame:
+    """Synthetic (date, ticker) FM where fwd_ret_5d = 0.5*x0 + noise."""
+    from data.features import _FEATURE_COLS
+
+    rng = np.random.default_rng(seed)
+    dates = pd.date_range("2024-01-01", periods=n_dates, freq="B")
+    tickers = [f"T{i}" for i in range(n_tickers)]
+    rows = []
+    for d in dates:
+        for t in tickers:
+            row = {"date": d, "ticker": t}
+            for col in _FEATURE_COLS:
+                row[col] = rng.normal()
+            # Target linearly driven by ret_1d; small noise.
+            row["fwd_ret_5d"] = 0.02 * row["ret_1d"] + 0.001 * rng.normal()
+            rows.append(row)
+    return pd.DataFrame(rows).set_index(["date", "ticker"])
+
+
+# ── Loading / fallback behaviour ─────────────────────────────────────────────
+
+def test_init_without_checkpoint_uses_fallback(tmp_path):
+    model = BayesianSignal(model_path=str(tmp_path / "nonexistent.pkl"))
+    assert model._model is None
+
+
+def test_predict_fallback_returns_scores_for_every_ticker(tmp_path):
+    with patch("data.fetcher.fetch_ohlcv", return_value=pd.DataFrame()):
+        model = BayesianSignal(model_path=str(tmp_path / "none.pkl"))
+        scores = model.predict(["AAPL", "MSFT"])
+    assert set(scores.keys()) == {"AAPL", "MSFT"}
+    for v in scores.values():
+        assert -1.0 <= v <= 1.0
+
+
+def test_predict_with_uncertainty_fallback_reports_sigma_one(tmp_path):
+    with patch("data.fetcher.fetch_ohlcv", return_value=pd.DataFrame()):
+        model = BayesianSignal(model_path=str(tmp_path / "n.pkl"))
+        mean, sigma = model.predict_with_uncertainty(["AAPL"])
+    assert sigma["AAPL"] == 1.0
+
+
+def test_feature_coefficients_empty_when_no_model(tmp_path):
+    model = BayesianSignal(model_path=str(tmp_path / "missing.pkl"))
+    df = model.feature_coefficients()
+    assert df.empty
+    assert list(df.columns) == ["feature", "coefficient", "std"]
+
+
+# ── Training (skipped when sklearn is absent) ────────────────────────────────
+
+@pytest.mark.skipif(not _SKLEARN_AVAILABLE, reason="sklearn not installed")
+def test_train_fits_model_and_returns_metrics(tmp_path, monkeypatch):
+    fm = _make_feature_matrix(n_dates=80, n_tickers=4, seed=1)
+    monkeypatch.setattr(
+        "strategies.bayesian_signal.build_feature_matrix",
+        lambda *a, **kw: fm,
+    )
+    monkeypatch.setattr(BayesianSignal, "_write_metadata", lambda *a, **k: None)
+
+    model = BayesianSignal(model_path=str(tmp_path / "b.pkl"))
+    metrics = model.train(["T0", "T1"], period="2y")
+
+    assert model._model is not None
+    assert "train_ic" in metrics and "test_ic" in metrics
+    assert isinstance(metrics["train_ic"], float)
+
+
+@pytest.mark.skipif(not _SKLEARN_AVAILABLE, reason="sklearn not installed")
+def test_train_persists_checkpoint(tmp_path, monkeypatch):
+    fm = _make_feature_matrix(n_dates=80, n_tickers=4, seed=2)
+    monkeypatch.setattr(
+        "strategies.bayesian_signal.build_feature_matrix",
+        lambda *a, **kw: fm,
+    )
+    monkeypatch.setattr(BayesianSignal, "_write_metadata", lambda *a, **k: None)
+
+    ckpt = tmp_path / "b.pkl"
+    model = BayesianSignal(model_path=str(ckpt))
+    model.train(["T0"], period="2y")
+
+    assert ckpt.exists()
+    with open(ckpt, "rb") as f:
+        from sklearn.linear_model import BayesianRidge
+        loaded = pickle.load(f)
+    assert isinstance(loaded, BayesianRidge)
+
+
+@pytest.mark.skipif(not _SKLEARN_AVAILABLE, reason="sklearn not installed")
+def test_train_raises_on_empty_feature_matrix(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        "strategies.bayesian_signal.build_feature_matrix",
+        lambda *a, **kw: pd.DataFrame(),
+    )
+    model = BayesianSignal(model_path=str(tmp_path / "b.pkl"))
+    with pytest.raises(ValueError, match="empty"):
+        model.train(["T0"], period="2y")
+
+
+def test_train_raises_when_sklearn_missing(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        "strategies.bayesian_signal._SKLEARN_AVAILABLE", False,
+    )
+    model = BayesianSignal(model_path=str(tmp_path / "b.pkl"))
+    with pytest.raises(RuntimeError, match="scikit-learn"):
+        model.train(["T0"], period="2y")
+
+
+# ── Prediction after training ────────────────────────────────────────────────
+
+@pytest.mark.skipif(not _SKLEARN_AVAILABLE, reason="sklearn not installed")
+def test_predict_after_train_returns_bounded_scores(tmp_path, monkeypatch):
+    fm = _make_feature_matrix(n_dates=80, n_tickers=4, seed=3)
+    monkeypatch.setattr(
+        "strategies.bayesian_signal.build_feature_matrix",
+        lambda *a, **kw: fm,
+    )
+    monkeypatch.setattr(BayesianSignal, "_write_metadata", lambda *a, **k: None)
+
+    model = BayesianSignal(model_path=str(tmp_path / "b.pkl"))
+    model.train(["T0", "T1"], period="2y")
+
+    mean, sigma = model.predict_with_uncertainty(["T0", "T1", "T2", "T3"])
+    assert set(mean.keys()) == {"T0", "T1", "T2", "T3"}
+    assert set(sigma.keys()) == {"T0", "T1", "T2", "T3"}
+    for v in mean.values():
+        assert -1.0 <= v <= 1.0
+    for s in sigma.values():
+        assert s >= 0.0
+
+
+@pytest.mark.skipif(not _SKLEARN_AVAILABLE, reason="sklearn not installed")
+def test_predictive_sigma_shrinks_with_more_training_data(tmp_path, monkeypatch):
+    """Core Bayesian behaviour: σ should shrink as n grows."""
+    small_fm = _make_feature_matrix(n_dates=30, n_tickers=3, seed=10)
+    big_fm = _make_feature_matrix(n_dates=300, n_tickers=6, seed=10)
+
+    def _factory(fm):
+        def _mk(*a, **kw): return fm
+        return _mk
+
+    monkeypatch.setattr(BayesianSignal, "_write_metadata", lambda *a, **k: None)
+
+    monkeypatch.setattr(
+        "strategies.bayesian_signal.build_feature_matrix", _factory(small_fm),
+    )
+    m_small = BayesianSignal(model_path=str(tmp_path / "s.pkl"))
+    m_small.train(["T0"], period="1y")
+    _, sigma_small = m_small.predict_with_uncertainty(["T0", "T1", "T2"])
+
+    monkeypatch.setattr(
+        "strategies.bayesian_signal.build_feature_matrix", _factory(big_fm),
+    )
+    m_big = BayesianSignal(model_path=str(tmp_path / "b.pkl"))
+    m_big.train(["T0"], period="5y")
+    _, sigma_big = m_big.predict_with_uncertainty(["T0", "T1", "T2"])
+
+    mean_small = float(np.mean(list(sigma_small.values())))
+    mean_big = float(np.mean(list(sigma_big.values())))
+    assert mean_big < mean_small
+
+
+@pytest.mark.skipif(not _SKLEARN_AVAILABLE, reason="sklearn not installed")
+def test_feature_coefficients_after_train(tmp_path, monkeypatch):
+    fm = _make_feature_matrix(n_dates=80, n_tickers=4, seed=4)
+    monkeypatch.setattr(
+        "strategies.bayesian_signal.build_feature_matrix",
+        lambda *a, **kw: fm,
+    )
+    monkeypatch.setattr(BayesianSignal, "_write_metadata", lambda *a, **k: None)
+
+    model = BayesianSignal(model_path=str(tmp_path / "b.pkl"))
+    model.train(["T0"], period="2y")
+    df = model.feature_coefficients()
+    assert not df.empty
+    assert list(df.columns) == ["feature", "coefficient", "std"]
+    assert (df["std"] >= 0).all()
+
+
+# ── Ensemble compatibility ───────────────────────────────────────────────────
+
+def test_bayesian_scores_blend_cleanly_with_ensemble_signal():
+    """Validate the signature of predict() is compatible with
+    strategies.ensemble_signal.blend_signals."""
+    from strategies.ensemble_signal import blend_signals
+
+    # Synthetic three-source blend — Bayesian treated as any other
+    # score-dict source.
+    lgbm = {"AAPL": 0.5, "MSFT": -0.2}
+    ridge = {"AAPL": 0.3, "MSFT": 0.1}
+    bayesian = {"AAPL": 0.4, "MSFT": -0.1}
+    blended = blend_signals(lgbm, ridge, bayesian, weights=[0.5, 0.25, 0.25])
+    assert set(blended.keys()) == {"AAPL", "MSFT"}
+    assert abs(blended["AAPL"] - (0.5 * 0.5 + 0.25 * 0.3 + 0.25 * 0.4)) < 1e-9


### PR DESCRIPTION
## Summary

Adds a BayesianRidge alpha model that mirrors the existing `LinearSignal`'s interface and exposes an explicit posterior predictive std for the execution layer to use when sizing Kelly bets.

- `strategies/bayesian_signal.py`
  - `BayesianSignal` — same `train` / `predict` / `feature_coefficients` surface as `LinearSignal`, so the ensemble and prediction paths treat the two interchangeably.
  - `predict_with_uncertainty(tickers, period) → (mean, sigma)` so the UI can display confidence and downstream risk code can scale position sizes by `1/σ`.
  - `feature_coefficients()` additionally reports per-coefficient posterior std (from `BayesianRidge.sigma_`'s diagonal).
  - Momentum fallback when no checkpoint is loaded or sklearn is absent; `sigma = 1.0` in that case (max uncertainty).

- `pages/ml_signals.py`
  - New **Train Bayesian Model** button next to Ridge; Bayesian training metrics alongside LGBM / Ridge.
  - **Bayesian** tab in the scores section with a posterior-σ dataframe.
  - **Compute All Scores** now also computes Bayesian and blends LGBM + Ridge + Bayesian into the ensemble signal.
  - Ensemble tab blends whichever of the three source signal dicts are present.

- `tests/test_bayesian_signal.py` — 12 tests covering loading without a checkpoint, momentum fallback, `predict_with_uncertainty` returning `sigma=1` without a model, training persistence, empty-fm and missing-sklearn error paths, bounded `[-1, 1]` mean scores, **posterior σ shrinking with more training data** (the key Bayesian invariant), feature coefficients with std column, and ensemble-blend compatibility via `strategies.ensemble_signal.blend_signals`.

- `ML_BOOK_MAP.md` — ML4T Ch 10 flips from ⏳ to ✅.

## Test plan

- [x] `pytest tests/test_bayesian_signal.py -v` — 12/12 passing
- [x] Full unit suite + coverage gate: **1066 passed, 1 skipped, coverage 79.86%**
- [x] `ruff check .` — clean

Closes #75.