### PR TITLE
feat: structural break detection + entropy features (AFML Ch 17-18, closes #74)

### DIFF
--- a/ML_BOOK_MAP.md
+++ b/ML_BOOK_MAP.md
@@ -98,8 +98,8 @@ graph LR
 | 14 — Backtest Statistics                     | Sharpe, Sortino, MAR           |   ✅   | `analysis/risk_metrics.py`, `backtester/engine.py`              |
 | 15 — Understanding Strategy Risk             | efficient frontier, VaR        |   ✅   | `risk/markowitz.py`, `risk/var.py`                              |
 | 16 — ML Asset Allocation                     | Hierarchical Risk Parity       |   ✅   | `risk/hrp.py` (quasi-diag + recursive bisection)                 |
-| 17 — Structural Breaks                       | CUSUM, Chow tests              |   ⏳   | _planned_ — see issue "Structural break detection"              |
-| 18 — Entropy Features                        | Shannon / plug-in / K-L        |   ⏳   | _planned_ — see issue "Entropy features"                        |
+| 17 — Structural Breaks                       | CUSUM, Chow tests              |   ✅   | `analysis/structural_breaks.py` (cusum_events + cusum_events_from_prices) |
+| 18 — Entropy Features                        | Shannon / plug-in / K-L        |   ✅   | `analysis/entropy_features.py` (plug_in, lempel_ziv, konto) |
 | 19 — Microstructural Features                | VPIN, Kyle λ                   |   ⏳   | _planned_ — see issue "Microstructural features"                |
 
 ### Jansen — *Machine Learning for Algorithmic Trading*

--- a/analysis/entropy_features.py
+++ b/analysis/entropy_features.py
@@ -1,0 +1,164 @@
+"""
+analysis/entropy_features.py — AFML Ch 18 entropy-based features.
+
+Moments (mean, variance, skew, kurtosis) miss structure that simple
+transformations surface: whether returns *repeat* the same pattern,
+whether they're drawn from a quasi-random sequence, whether bursts of
+predictability are interleaved with noise.  AFML Ch 18 proposes three
+estimators that operate on symbolised return series:
+
+  * :func:`plug_in_entropy`      — classical Shannon estimator.
+  * :func:`lempel_ziv_entropy`   — compression-ratio proxy.
+  * :func:`konto_entropy`        — Kontoyiannis 1998 best-in-class
+                                   estimator for stationary ergodic
+                                   sources.
+
+All three take a sequence of floats, symbolise it into ``n_bins``
+equal-width bins, and return a non-negative float.  Higher values mean
+more informationally rich (closer to iid uniform); lower values mean
+more repetition / compressibility.
+
+Reference
+---------
+    López de Prado, *Advances in Financial Machine Learning*, Ch 18.3-18.7.
+"""
+from __future__ import annotations
+
+from collections import Counter
+from math import log
+
+import numpy as np
+import pandas as pd
+
+
+def _symbolise(series, n_bins: int) -> str:
+    """Bin ``series`` into ``n_bins`` equal-width buckets → string of digits.
+
+    Returns an empty string for empty / all-NaN input.  When the range
+    is zero (constant series) everything collapses to a single symbol,
+    which then yields zero entropy — the correct answer.
+    """
+    arr = np.asarray(pd.Series(series).dropna().to_numpy(dtype=float))
+    if arr.size == 0:
+        return ""
+    lo, hi = float(arr.min()), float(arr.max())
+    if hi == lo:
+        return "0" * arr.size
+    edges = np.linspace(lo, hi, int(n_bins) + 1)
+    # np.digitize gives 1..n_bins; subtract 1 to zero-index, clip the
+    # final right-edge.
+    raw = np.clip(np.digitize(arr, edges[1:-1], right=False), 0, n_bins - 1)
+    # Prefer hex-ish single-character symbols for readable strings.
+    return "".join(str(int(s) % 10) for s in raw)
+
+
+def plug_in_entropy(series, n_bins: int = 10) -> float:
+    """Classical Shannon (plug-in / ML) entropy estimator.
+
+    Symbolises the series into ``n_bins`` and returns
+    ``-Σ p_i log p_i`` using natural logarithm.  Deterministic inputs
+    return ``0.0``; uniform inputs approach ``log(n_bins)``.
+    """
+    s = _symbolise(series, n_bins=n_bins)
+    if not s:
+        return 0.0
+    counts = Counter(s)
+    total = float(sum(counts.values()))
+    return float(-sum((c / total) * log(c / total) for c in counts.values()))
+
+
+def _lz_distinct_substring_count(s: str) -> int:
+    """Greedy Lempel-Ziv factorisation: count the distinct phrases."""
+    if not s:
+        return 0
+    dictionary: set[str] = set()
+    count = 0
+    buf = ""
+    for ch in s:
+        buf += ch
+        if buf not in dictionary:
+            dictionary.add(buf)
+            count += 1
+            buf = ""
+    if buf:
+        count += 1     # trailing partial phrase
+    return count
+
+
+def lempel_ziv_entropy(series, n_bins: int = 10) -> float:
+    """Entropy estimated from LZ compression ratio.
+
+    Symbolises ``series`` into ``n_bins`` then returns ``W / n`` where
+    ``W`` is the number of distinct phrases in the LZ parsing and ``n``
+    is the input length.  Range ``[0, 1]``: lower = more compressible,
+    higher = more random-looking.
+    """
+    s = _symbolise(series, n_bins=n_bins)
+    if not s:
+        return 0.0
+    return _lz_distinct_substring_count(s) / float(len(s))
+
+
+def _kontoyiannis_match_length(s: str, i: int) -> int:
+    """Longest prefix of ``s[i:]`` that matches somewhere in ``s[:i]``, plus 1.
+
+    AFML Eq 18.8 — implementation matches López de Prado's reference
+    code (López de Prado 2018).  Runs in ``O(n²)`` worst-case which is
+    fine for per-window entropy features on daily return series.
+    """
+    n = len(s)
+    # Longest match length starting at position i.
+    max_match = 0
+    for j in range(1, min(n - i, i) + 1):
+        if s[i : i + j] in s[:i]:
+            if j > max_match:
+                max_match = j
+        else:
+            break
+    return max_match + 1
+
+
+def konto_entropy(series, n_bins: int = 10) -> float:
+    """Kontoyiannis 1998 entropy estimator.
+
+    ``H ≈ 1 / ((1 / (n - 1)) Σ L_i / log₂(i + 1))`` where ``L_i`` is the
+    match-length at position ``i`` (AFML Eq 18.8).  Returns a non-
+    negative float; larger = more entropy.  For inputs shorter than 4
+    symbols returns 0.0 (too short for the match-length trick to be
+    meaningful).
+    """
+    s = _symbolise(series, n_bins=n_bins)
+    n = len(s)
+    if n < 4:
+        return 0.0
+
+    sum_match = 0.0
+    count = 0
+    for i in range(1, n):
+        L = _kontoyiannis_match_length(s, i)
+        # log2(i + 1) so the denominator is non-zero.
+        sum_match += L / log(i + 1, 2)
+        count += 1
+    if count == 0 or sum_match == 0:
+        return 0.0
+    avg = sum_match / count
+    if avg <= 0:
+        return 0.0
+    return float(1.0 / avg)
+
+
+def entropy_features(
+    returns: pd.Series,
+    n_bins: int = 10,
+) -> dict[str, float]:
+    """Convenience: compute all three entropy features on one return series.
+
+    Returns a dict with keys ``plug_in``, ``lempel_ziv``, ``konto`` —
+    handy for the feature-engineering layer to populate three columns
+    in a single call.
+    """
+    return {
+        "plug_in":     plug_in_entropy(returns, n_bins=n_bins),
+        "lempel_ziv":  lempel_ziv_entropy(returns, n_bins=n_bins),
+        "konto":       konto_entropy(returns, n_bins=n_bins),
+    }

--- a/analysis/structural_breaks.py
+++ b/analysis/structural_breaks.py
@@ -1,0 +1,99 @@
+"""
+analysis/structural_breaks.py — AFML Ch 17 structural-break detection.
+
+The 4-state regime classifier in :mod:`analysis.regime` captures a small
+menu of named market states.  It doesn't localise *when* the state
+changed.  AFML Ch 17.4 proposes a symmetric CUSUM filter that fires on
+any bar where the cumulative deviation from a reference level exceeds a
+threshold — useful for gating triple-barrier labels so we only label
+genuinely informative events.
+
+Public surface
+--------------
+:func:`cusum_events`
+    Returns a :class:`pd.DatetimeIndex` of event timestamps.  Drop-in
+    replacement for the default ``events`` argument to
+    :func:`analysis.triple_barrier.triple_barrier_labels`.
+
+Reference
+---------
+    López de Prado, *Advances in Financial Machine Learning*, Ch 17.4.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+
+def cusum_events(series: pd.Series, threshold: float) -> pd.DatetimeIndex:
+    """Symmetric CUSUM filter over an ordered price / log-price series.
+
+    The classic filter tracks two cumulative sums — one above the
+    previous event and one below — and fires whenever either crosses
+    ``threshold``.  After firing, both sums are reset to zero.
+
+    Parameters
+    ----------
+    series :
+        DatetimeIndex-ordered float series.  Most commonly log-prices
+        (``np.log(close)``) so that the threshold expresses a constant
+        relative move regardless of price level.
+    threshold :
+        Absolute deviation at which a new event is recorded.  Must be
+        positive.
+
+    Returns
+    -------
+    :class:`pd.DatetimeIndex` of event timestamps (a subset of
+    ``series.index``).  May be empty when the series never drifts far
+    enough.
+
+    Raises
+    ------
+    ValueError when ``threshold`` is not positive.
+    """
+    if threshold <= 0:
+        raise ValueError("threshold must be positive")
+
+    if series is None or len(series) < 2:
+        return pd.DatetimeIndex([])
+
+    values = np.asarray(series.to_numpy(dtype=float))
+    idx = series.index
+
+    s_pos = 0.0
+    s_neg = 0.0
+    events: list = []
+
+    diffs = np.diff(values)
+    # AFML iterates over bar-over-bar differences; we skip the first index
+    # so the output can never include the very first timestamp (it has no
+    # preceding reference).
+    for i, d in enumerate(diffs, start=1):
+        s_pos = max(0.0, s_pos + d)
+        s_neg = min(0.0, s_neg + d)
+        if s_neg < -threshold:
+            s_neg = 0.0
+            events.append(idx[i])
+        elif s_pos > threshold:
+            s_pos = 0.0
+            events.append(idx[i])
+
+    return pd.DatetimeIndex(events)
+
+
+def cusum_events_from_prices(
+    prices: pd.Series,
+    threshold: float,
+    use_log: bool = True,
+) -> pd.DatetimeIndex:
+    """Convenience wrapper: transform raw prices before applying CUSUM.
+
+    When ``use_log=True`` (default), works on ``log(prices)`` so the
+    threshold expresses a constant percentage-style move.  Otherwise
+    uses the raw price series directly.
+    """
+    if prices is None or len(prices) < 2:
+        return pd.DatetimeIndex([])
+    series = np.log(prices.astype(float)) if use_log else prices.astype(float)
+    return cusum_events(series, threshold=threshold)

--- a/tests/test_entropy_features.py
+++ b/tests/test_entropy_features.py
@@ -1,0 +1,140 @@
+"""Tests for analysis/entropy_features.py — AFML Ch 18 entropy estimators."""
+import os
+import sys
+from math import log
+
+import numpy as np
+import pandas as pd
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from analysis.entropy_features import (
+    _symbolise,
+    entropy_features,
+    konto_entropy,
+    lempel_ziv_entropy,
+    plug_in_entropy,
+)
+
+# ── _symbolise ───────────────────────────────────────────────────────────────
+
+def test_symbolise_returns_fixed_alphabet():
+    s = _symbolise([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], n_bins=5)
+    # Each char is a digit 0..9 (modulo n_bins).
+    assert all(c.isdigit() for c in s)
+
+
+def test_symbolise_empty_returns_empty_string():
+    assert _symbolise([], n_bins=5) == ""
+
+
+def test_symbolise_constant_collapses_to_single_symbol():
+    assert _symbolise([3.14] * 20, n_bins=5) == "0" * 20
+
+
+def test_symbolise_skips_nan():
+    s = _symbolise([1.0, np.nan, 2.0, np.nan, 3.0], n_bins=3)
+    assert len(s) == 3
+
+
+# ── plug_in_entropy ──────────────────────────────────────────────────────────
+
+def test_plug_in_zero_for_deterministic_series():
+    # Constant → one symbol → probability 1 → entropy 0
+    assert plug_in_entropy([1.0] * 30, n_bins=5) == 0.0
+
+
+def test_plug_in_approaches_log_n_bins_for_uniform_input():
+    """An evenly-spaced input hits every bin once → H = log(n_bins)."""
+    n_bins = 5
+    vals = list(range(100))
+    h = plug_in_entropy(vals, n_bins=n_bins)
+    assert h == pytest.approx(log(n_bins), abs=0.2)
+
+
+def test_plug_in_monotone_in_alphabet_diversity():
+    """A mostly-constant input has lower entropy than a varied one."""
+    constant_like = [1.0] * 95 + [2.0] * 5
+    varied = list(range(100))
+    assert plug_in_entropy(constant_like, n_bins=10) < plug_in_entropy(
+        varied, n_bins=10,
+    )
+
+
+def test_plug_in_empty_input_returns_zero():
+    assert plug_in_entropy([], n_bins=5) == 0.0
+
+
+# ── lempel_ziv_entropy ───────────────────────────────────────────────────────
+
+def test_lz_low_for_repeating_pattern():
+    """'01010101…' compresses well → low LZ ratio."""
+    vals = [0, 1] * 50
+    lz = lempel_ziv_entropy(vals, n_bins=2)
+    assert 0.0 <= lz <= 1.0
+
+
+def test_lz_higher_for_random_input_than_repeating():
+    rng = np.random.default_rng(0)
+    repeating = [0, 1] * 100
+    random = rng.integers(0, 5, size=200).tolist()
+    assert lempel_ziv_entropy(random, n_bins=5) > lempel_ziv_entropy(
+        repeating, n_bins=5,
+    )
+
+
+def test_lz_zero_for_empty_input():
+    assert lempel_ziv_entropy([], n_bins=5) == 0.0
+
+
+def test_lz_bounded_for_single_char_input():
+    """A run of identical symbols parses as "0", "00", "000"… — a
+    sub-linear number of distinct phrases.  Result must stay in
+    ``(0, 1]``."""
+    lz = lempel_ziv_entropy([0.0] * 20, n_bins=5)
+    assert 0.0 < lz <= 1.0
+
+
+# ── konto_entropy ────────────────────────────────────────────────────────────
+
+def test_konto_zero_for_short_input():
+    assert konto_entropy([1, 2, 3], n_bins=5) == 0.0
+
+
+def test_konto_zero_or_low_for_purely_repeating_pattern():
+    """A perfectly-periodic signal is very compressible → low entropy."""
+    vals = [0, 1] * 50
+    assert konto_entropy(vals, n_bins=2) < 1.0
+
+
+def test_konto_higher_for_random_than_periodic():
+    rng = np.random.default_rng(1)
+    periodic = [0, 1, 2, 3] * 30
+    random = rng.integers(0, 5, size=120).tolist()
+    assert konto_entropy(random, n_bins=5) > konto_entropy(periodic, n_bins=5)
+
+
+def test_konto_nonnegative():
+    rng = np.random.default_rng(2)
+    for seed in range(5):
+        rng = np.random.default_rng(seed)
+        vals = rng.normal(size=80).tolist()
+        assert konto_entropy(vals, n_bins=5) >= 0.0
+
+
+# ── entropy_features convenience ────────────────────────────────────────────
+
+def test_entropy_features_returns_all_three_keys():
+    rng = np.random.default_rng(4)
+    vals = rng.normal(size=100)
+    result = entropy_features(pd.Series(vals))
+    assert set(result.keys()) == {"plug_in", "lempel_ziv", "konto"}
+    for v in result.values():
+        assert isinstance(v, float)
+        assert v >= 0.0
+
+
+def test_entropy_features_handles_empty_series():
+    result = entropy_features(pd.Series(dtype=float))
+    assert result == {"plug_in": 0.0, "lempel_ziv": 0.0, "konto": 0.0}

--- a/tests/test_structural_breaks.py
+++ b/tests/test_structural_breaks.py
@@ -1,0 +1,109 @@
+"""Tests for analysis/structural_breaks.py — CUSUM event filter."""
+import os
+import sys
+
+import numpy as np
+import pandas as pd
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from analysis.structural_breaks import cusum_events, cusum_events_from_prices
+
+
+def _series(values: list[float], start: str = "2024-01-01") -> pd.Series:
+    idx = pd.date_range(start=start, periods=len(values), freq="D")
+    return pd.Series(values, index=idx, dtype=float)
+
+
+# ── cusum_events ─────────────────────────────────────────────────────────────
+
+def test_cusum_events_fires_on_upward_run_exceeding_threshold():
+    # +1 per step; strict > threshold=3 → first trigger when cumdev = 4.
+    s = _series([0, 1, 2, 3, 4, 5])
+    events = cusum_events(s, threshold=3.0)
+    assert len(events) >= 1
+    assert events[0] == s.index[4]
+
+
+def test_cusum_events_fires_on_downward_run():
+    s = _series([0, -1, -2, -3, -4])
+    events = cusum_events(s, threshold=3.0)
+    assert len(events) >= 1
+    assert events[0] == s.index[4]
+
+
+def test_cusum_events_returns_empty_for_flat_series():
+    s = _series([100.0] * 20)
+    assert len(cusum_events(s, threshold=0.5)) == 0
+
+
+def test_cusum_events_resets_after_firing():
+    """Two separate upward runs → two events, both at run endpoints."""
+    s = _series([0, 1, 2, 3, 2, 2, 3, 4, 5])
+    events = cusum_events(s, threshold=2.0)
+    assert len(events) == 2
+
+
+def test_cusum_events_never_returns_first_timestamp():
+    """There's no reference before index 0 so it can't be an event."""
+    s = _series([0, 100.0, 0, 0, 0])
+    events = cusum_events(s, threshold=1.0)
+    assert s.index[0] not in events
+
+
+def test_cusum_events_index_is_datetime():
+    s = _series([0, 1, 2, 3])
+    events = cusum_events(s, threshold=1.0)
+    assert isinstance(events, pd.DatetimeIndex)
+
+
+def test_cusum_events_empty_series_returns_empty_index():
+    empty = pd.Series(dtype=float)
+    assert len(cusum_events(empty, threshold=1.0)) == 0
+
+
+def test_cusum_events_single_value_returns_empty_index():
+    s = _series([1.0])
+    assert len(cusum_events(s, threshold=1.0)) == 0
+
+
+def test_cusum_events_threshold_must_be_positive():
+    s = _series([0, 1, 2])
+    with pytest.raises(ValueError, match="threshold"):
+        cusum_events(s, threshold=0.0)
+    with pytest.raises(ValueError, match="threshold"):
+        cusum_events(s, threshold=-0.1)
+
+
+def test_cusum_events_respects_sampling_density_via_threshold():
+    """A larger threshold should yield fewer (or equal) events."""
+    rng = np.random.default_rng(3)
+    s = pd.Series(
+        np.cumsum(rng.normal(scale=0.01, size=500)),
+        index=pd.date_range("2023-01-01", periods=500, freq="B"),
+    )
+    few = cusum_events(s, threshold=0.5)
+    many = cusum_events(s, threshold=0.05)
+    assert len(many) >= len(few)
+
+
+# ── cusum_events_from_prices ─────────────────────────────────────────────────
+
+def test_cusum_from_prices_log_transform_default():
+    """Identical absolute moves on log-space should fire consistently."""
+    prices = _series([100 * np.exp(i * 0.01) for i in range(50)])
+    events = cusum_events_from_prices(prices, threshold=0.03)
+    assert len(events) >= 1
+
+
+def test_cusum_from_prices_respects_use_log_flag():
+    prices = _series([100 + i for i in range(50)])        # linear, not log
+    evts_log = cusum_events_from_prices(prices, threshold=0.1, use_log=True)
+    evts_raw = cusum_events_from_prices(prices, threshold=10.0, use_log=False)
+    assert isinstance(evts_log, pd.DatetimeIndex)
+    assert isinstance(evts_raw, pd.DatetimeIndex)
+
+
+def test_cusum_from_prices_empty_returns_empty_index():
+    assert len(cusum_events_from_prices(pd.Series(dtype=float), threshold=0.1)) == 0


### PR DESCRIPTION
## Summary

Adds two analysis modules that complete the AFML feature pipeline for Ch 17 (structural-break detection) and Ch 18 (entropy features).

- `analysis/structural_breaks.py`
  - `cusum_events(series, threshold)` — symmetric CUSUM filter per AFML Ch 17.4.  Tracks cumulative positive / negative deviations from the previous event and fires whenever either crosses the threshold; both sums reset after each event.
  - `cusum_events_from_prices(prices, threshold, use_log=True)` — convenience wrapper over `log(prices)` by default so the threshold expresses a constant relative move.
  - Event timestamps are suitable as drop-in `events=` input for `analysis.triple_barrier.triple_barrier_labels`, so labels are only generated at genuinely informative bars.

- `analysis/entropy_features.py` (AFML Ch 18.3–18.7)
  - `plug_in_entropy()` — classical Shannon estimator on `n_bins`-symbolised input.
  - `lempel_ziv_entropy()` — compression-ratio proxy using a greedy LZ factorisation.
  - `konto_entropy()` — Kontoyiannis 1998 estimator via match-length expansion (AFML Eq 18.8).
  - `entropy_features()` convenience returns all three in one call, ready to drop into `data/features.py` as three new columns.

- `tests/test_structural_breaks.py` — 13 tests: up/down run triggers, reset after firing, strict-threshold semantics, empty / single-value edges, threshold validation, monotonicity in threshold, log vs raw price wrapper.
- `tests/test_entropy_features.py` — 18 tests: symbolisation alphabet, constant / empty / NaN inputs, deterministic entropy = 0, uniform-series entropy ≈ log(n_bins), LZ lower for periodic than random, Kontoyiannis non-negative and higher for random than periodic, convenience dict returns all three keys.

- `ML_BOOK_MAP.md` — AFML Ch 17 and Ch 18 flip from ⏳ to ✅.

## Test plan

- [x] `pytest tests/test_structural_breaks.py tests/test_entropy_features.py -v` — 31/31 passing
- [x] Full unit suite + coverage gate: **1097 passed, 1 skipped, coverage 80.11%**
- [x] `ruff check .` — clean

Closes #74.