### PR TITLE
feat: sentiment-weighted ensemble blend (Jansen Ch 14-15, closes #73)

### DIFF
--- a/ML_BOOK_MAP.md
+++ b/ML_BOOK_MAP.md
@@ -120,7 +120,7 @@ graph LR
 | 12 — Boosting                                | LightGBM / XGBoost             |   ✅   | `strategies/ml_signal.py`                                       |
 | 13 — Unsupervised Learning                   | PCA, k-means, risk factors     |   ✅   | `analysis/unsupervised.py` (PCA loadings + scree; k-means on corr-distance) |
 | 14 — Text Data / Sentiment Analysis          | Vader, VADER                   |   ✅   | `adapters/sentiment/vader_adapter.py`                           |
-| 15 — Topic Modeling                          | LDA on news                    |   ⏳   | _planned_ — see issue "Topic modeling on news"                  |
+| 15 — Topic Modeling                          | LDA on news                    |   🟡   | sentiment blend integrated via `strategies/sentiment_signal.py`; LDA topic modeling still planned |
 | 16 — Word Embeddings                         | word2vec on filings            |   ⏳   | _planned_ — see issue "Word embeddings on filings"              |
 | 17 — Deep Learning for Trading               | Keras / PyTorch intro          |   ⏳   | _planned_ — see issue "Deep learning alpha model"               |
 | 18 — CNNs                                    | image / chart patterns         |   ⏳   | _planned_ — see issue "Deep learning alpha model"               |

--- a/pages/ml_signals.py
+++ b/pages/ml_signals.py
@@ -281,7 +281,18 @@ def render() -> None:
     # ── Alpha scores ──────────────────────────────────────────────────────────
     st.markdown("#### Current Alpha Scores")
     st.caption(
-        "Compute all three signals at once, or use individual tabs to score each model separately."
+        "Compute all four signals at once, or use individual tabs to score each model separately."
+    )
+
+    enable_sentiment = st.checkbox(
+        "Enable sentiment blend",
+        value=False,
+        key="ml_enable_sentiment",
+        help=(
+            "Include cross-sectional sentiment (Jansen Ch 14) as a fourth "
+            "weighted source in the ensemble.  Uses the SENTIMENT_PROVIDER "
+            "env var — VADER by default."
+        ),
     )
 
     if st.button("Compute All Scores", key="ml_compute_all_btn", type="primary"):
@@ -310,9 +321,17 @@ def render() -> None:
                 st.session_state["bayes_scores"] = bayes_scores
                 st.session_state["bayes_sigma"] = bayes_sigma
 
-                ensemble_scores = blend_signals(
-                    lgbm_scores, ridge_scores, bayes_scores,
-                )
+                blend_sources: list[dict] = [lgbm_scores, ridge_scores, bayes_scores]
+
+                if enable_sentiment:
+                    from strategies.sentiment_signal import sentiment_alpha_scores
+
+                    sentiment_scores = sentiment_alpha_scores(selected_tickers)
+                    st.session_state["sentiment_scores"] = sentiment_scores
+                    if sentiment_scores:
+                        blend_sources.append(sentiment_scores)
+
+                ensemble_scores = blend_signals(*blend_sources)
                 st.session_state["ensemble_scores"] = ensemble_scores
             except Exception as exc:
                 st.error(f"Scoring failed: {exc}")
@@ -377,10 +396,16 @@ def render() -> None:
             with st.spinner("Blending all available signals…"):
                 try:
                     from strategies.ensemble_signal import blend_signals
-                    sources = [
-                        st.session_state.get(k, {}) for k in
-                        ("ml_scores", "ridge_scores", "bayes_scores")
-                    ]
+                    source_keys = ["ml_scores", "ridge_scores", "bayes_scores"]
+                    if enable_sentiment:
+                        from strategies.sentiment_signal import (
+                            sentiment_alpha_scores,
+                        )
+                        st.session_state["sentiment_scores"] = (
+                            sentiment_alpha_scores(selected_tickers)
+                        )
+                        source_keys.append("sentiment_scores")
+                    sources = [st.session_state.get(k, {}) for k in source_keys]
                     non_empty = [s for s in sources if s]
                     if not non_empty:
                         st.warning(
@@ -393,6 +418,15 @@ def render() -> None:
                     st.error(f"Ensemble blending failed: {exc}")
         if "ensemble_scores" in st.session_state:
             _render_alpha_chart(st.session_state["ensemble_scores"])
+        if enable_sentiment and "sentiment_scores" in st.session_state:
+            st.caption("**Cross-sectional sentiment (z-scored, clipped)**")
+            sent_df = pd.DataFrame(
+                [
+                    {"Ticker": t, "Sentiment z": s}
+                    for t, s in st.session_state["sentiment_scores"].items()
+                ]
+            ).sort_values("Sentiment z", ascending=False)
+            st.dataframe(sent_df, use_container_width=True, hide_index=True)
 
     st.divider()
 

--- a/strategies/sentiment_signal.py
+++ b/strategies/sentiment_signal.py
@@ -1,0 +1,120 @@
+"""
+strategies/sentiment_signal.py — Cross-sectional sentiment alpha signal.
+
+Jansen *ML for Algorithmic Trading* (Ch 14) uses average news/social
+sentiment per ticker as a standalone alpha signal that complements
+price-based models.  This module wraps the platform's existing
+``providers.sentiment`` layer so sentiment scores can be blended into
+the ensemble alongside LGBM / Ridge / Bayesian.
+
+The heavy lifting (fetching headlines, running VADER, caching in
+SQLite) lives in the adapters — here we just:
+
+  * pull the current per-ticker sentiment from the configured provider,
+  * z-score cross-sectionally across the universe,
+  * clip to ``[-1, 1]`` so the blender's invariants hold.
+
+Gracefully no-ops (``{ticker: 0.0}``) when the sentiment provider
+isn't configured or fails at runtime; the ensemble just sees a neutral
+4th source.
+
+Reference
+---------
+    Jansen, *Machine Learning for Algorithmic Trading* (2nd ed.) Ch 14.6.
+"""
+from __future__ import annotations
+
+from typing import Optional
+
+import numpy as np
+
+from utils.logger import get_logger
+
+log = get_logger(__name__)
+
+
+def fetch_sentiment_scores(
+    tickers: list[str],
+    lookback_hours: int = 24,
+    provider_name: Optional[str] = None,
+) -> dict[str, float]:
+    """Return raw per-ticker sentiment in ``[-1, 1]``.
+
+    Parameters
+    ----------
+    tickers :
+        Universe to score.
+    lookback_hours :
+        Hours of history to aggregate.  Defaults to a 24-hour window —
+        enough to catch overnight news for the next session.
+    provider_name :
+        Override for the ``SENTIMENT_PROVIDER`` env var.  ``None`` uses
+        the configured default.
+
+    Returns
+    -------
+    ``dict[ticker, float]`` with values in ``[-1, 1]``.  Tickers whose
+    score could not be fetched get ``0.0`` (neutral).  Empty dict when
+    ``tickers`` is empty.
+    """
+    if not tickers:
+        return {}
+
+    try:
+        from providers.sentiment import get_sentiment
+        provider = get_sentiment(provider_name)
+    except Exception as exc:
+        log.info(
+            "sentiment_signal: provider unavailable, returning neutral scores",
+            error=str(exc),
+        )
+        return {t: 0.0 for t in tickers}
+
+    scores: dict[str, float] = {}
+    for ticker in tickers:
+        try:
+            raw = provider.ticker_sentiment(ticker, lookback_hours=lookback_hours)
+            scores[ticker] = float(np.clip(raw, -1.0, 1.0))
+        except Exception as exc:
+            log.warning(
+                "sentiment_signal: ticker lookup failed",
+                ticker=ticker, error=str(exc),
+            )
+            scores[ticker] = 0.0
+    return scores
+
+
+def sentiment_alpha_scores(
+    tickers: list[str],
+    lookback_hours: int = 24,
+    provider_name: Optional[str] = None,
+) -> dict[str, float]:
+    """Ranked alpha scores derived from cross-sectional sentiment z-score.
+
+    Flow:
+
+    1. Fetch raw per-ticker sentiment via :func:`fetch_sentiment_scores`.
+    2. Z-score across the universe so scores are mean-zero,
+       unit-variance — makes them compatible with the other
+       model-output ranges the ensemble expects.
+    3. Clip to ``[-1, 1]``.
+
+    Returns ``{ticker: score}``.  Universes where every raw score is
+    zero or identical collapse to ``{ticker: 0.0}`` so the ensemble
+    treats sentiment as neutral rather than spuriously confident.
+    """
+    raw = fetch_sentiment_scores(tickers, lookback_hours=lookback_hours,
+                                  provider_name=provider_name)
+    if not raw:
+        return {}
+
+    tickers_ordered = list(raw.keys())
+    values = np.array([raw[t] for t in tickers_ordered], dtype=float)
+
+    std = float(values.std())
+    if std == 0.0:
+        return {t: 0.0 for t in tickers_ordered}
+
+    z = (values - values.mean()) / std
+    z = np.clip(z, -1.0, 1.0)
+    return {t: float(z[i]) for i, t in enumerate(tickers_ordered)}

--- a/tests/test_sentiment_signal.py
+++ b/tests/test_sentiment_signal.py
@@ -1,0 +1,172 @@
+"""Tests for strategies/sentiment_signal.py — sentiment alpha blend."""
+import os
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from strategies.sentiment_signal import (
+    fetch_sentiment_scores,
+    sentiment_alpha_scores,
+)
+
+# ── fetch_sentiment_scores ───────────────────────────────────────────────────
+
+def test_fetch_empty_tickers_returns_empty_dict():
+    assert fetch_sentiment_scores([]) == {}
+
+
+def test_fetch_returns_neutral_when_provider_unavailable(monkeypatch):
+    """When providers.sentiment.get_sentiment() raises, return zeros."""
+    def _broken(*a, **k): raise RuntimeError("no provider configured")
+    monkeypatch.setattr("providers.sentiment.get_sentiment", _broken)
+    scores = fetch_sentiment_scores(["AAPL", "MSFT"])
+    assert scores == {"AAPL": 0.0, "MSFT": 0.0}
+
+
+def test_fetch_delegates_to_provider_ticker_sentiment(monkeypatch):
+    provider = MagicMock()
+    provider.ticker_sentiment.side_effect = [0.4, -0.2, 0.9]
+    monkeypatch.setattr(
+        "providers.sentiment.get_sentiment", lambda *a, **k: provider,
+    )
+    scores = fetch_sentiment_scores(["AAPL", "MSFT", "GOOG"])
+    assert scores == {"AAPL": 0.4, "MSFT": -0.2, "GOOG": 0.9}
+    assert provider.ticker_sentiment.call_count == 3
+
+
+def test_fetch_clips_to_unit_range(monkeypatch):
+    provider = MagicMock()
+    provider.ticker_sentiment.side_effect = [1.5, -3.0, 0.0]
+    monkeypatch.setattr(
+        "providers.sentiment.get_sentiment", lambda *a, **k: provider,
+    )
+    scores = fetch_sentiment_scores(["A", "B", "C"])
+    assert scores == {"A": 1.0, "B": -1.0, "C": 0.0}
+
+
+def test_fetch_handles_per_ticker_errors(monkeypatch):
+    """An exception on one ticker should not abort the whole batch."""
+    provider = MagicMock()
+
+    def _ticker_sentiment(ticker, lookback_hours):
+        if ticker == "BAD":
+            raise RuntimeError("lookup failed")
+        return 0.3
+
+    provider.ticker_sentiment.side_effect = _ticker_sentiment
+    monkeypatch.setattr(
+        "providers.sentiment.get_sentiment", lambda *a, **k: provider,
+    )
+    scores = fetch_sentiment_scores(["AAPL", "BAD", "MSFT"])
+    assert scores["AAPL"] == pytest.approx(0.3)
+    assert scores["BAD"] == 0.0
+    assert scores["MSFT"] == pytest.approx(0.3)
+
+
+def test_fetch_passes_lookback_hours(monkeypatch):
+    provider = MagicMock()
+    provider.ticker_sentiment.return_value = 0.0
+    monkeypatch.setattr(
+        "providers.sentiment.get_sentiment", lambda *a, **k: provider,
+    )
+    fetch_sentiment_scores(["AAPL"], lookback_hours=72)
+    _, kwargs = provider.ticker_sentiment.call_args
+    assert kwargs.get("lookback_hours") == 72
+
+
+def test_fetch_passes_provider_name(monkeypatch):
+    captured: dict = {}
+
+    def _get(provider_name=None, *a, **k):
+        captured["name"] = provider_name
+        provider = MagicMock()
+        provider.ticker_sentiment.return_value = 0.0
+        return provider
+
+    monkeypatch.setattr("providers.sentiment.get_sentiment", _get)
+    fetch_sentiment_scores(["AAPL"], provider_name="stocktwits")
+    assert captured["name"] == "stocktwits"
+
+
+# ── sentiment_alpha_scores ──────────────────────────────────────────────────
+
+def test_alpha_scores_empty_universe_returns_empty():
+    assert sentiment_alpha_scores([]) == {}
+
+
+def test_alpha_scores_z_scores_across_universe(monkeypatch):
+    provider = MagicMock()
+    provider.ticker_sentiment.side_effect = [0.0, 0.5, -0.5]
+    monkeypatch.setattr(
+        "providers.sentiment.get_sentiment", lambda *a, **k: provider,
+    )
+    scores = sentiment_alpha_scores(["A", "B", "C"])
+    # Z-scoring of (0, 0.5, -0.5) → mean 0, std = 0.408; z values =
+    # (0, 1.225, -1.225), clipped to [-1, 1] = (0.0, 1.0, -1.0).
+    assert scores["A"] == pytest.approx(0.0, abs=1e-6)
+    assert scores["B"] == pytest.approx(1.0, abs=1e-6)
+    assert scores["C"] == pytest.approx(-1.0, abs=1e-6)
+
+
+def test_alpha_scores_all_identical_returns_zero(monkeypatch):
+    provider = MagicMock()
+    provider.ticker_sentiment.return_value = 0.42   # every ticker same
+    monkeypatch.setattr(
+        "providers.sentiment.get_sentiment", lambda *a, **k: provider,
+    )
+    scores = sentiment_alpha_scores(["A", "B", "C"])
+    for v in scores.values():
+        assert v == 0.0
+
+
+def test_alpha_scores_all_zero_returns_zero(monkeypatch):
+    """Universe with no sentiment data collapses to neutral."""
+    provider = MagicMock()
+    provider.ticker_sentiment.return_value = 0.0
+    monkeypatch.setattr(
+        "providers.sentiment.get_sentiment", lambda *a, **k: provider,
+    )
+    scores = sentiment_alpha_scores(["A", "B", "C"])
+    assert all(v == 0.0 for v in scores.values())
+
+
+def test_alpha_scores_preserve_ticker_keys(monkeypatch):
+    provider = MagicMock()
+    provider.ticker_sentiment.side_effect = [0.1, -0.3, 0.4]
+    monkeypatch.setattr(
+        "providers.sentiment.get_sentiment", lambda *a, **k: provider,
+    )
+    scores = sentiment_alpha_scores(["AAPL", "MSFT", "GOOG"])
+    assert set(scores.keys()) == {"AAPL", "MSFT", "GOOG"}
+
+
+def test_alpha_scores_bounded_in_unit_interval(monkeypatch):
+    provider = MagicMock()
+    provider.ticker_sentiment.side_effect = [1.0, -1.0, 0.2, 0.8]
+    monkeypatch.setattr(
+        "providers.sentiment.get_sentiment", lambda *a, **k: provider,
+    )
+    scores = sentiment_alpha_scores(["A", "B", "C", "D"])
+    for v in scores.values():
+        assert -1.0 <= v <= 1.0
+
+
+def test_alpha_scores_blend_compatibility_with_ensemble(monkeypatch):
+    """The output dict must be a drop-in source for blend_signals."""
+    from strategies.ensemble_signal import blend_signals
+
+    provider = MagicMock()
+    provider.ticker_sentiment.side_effect = [0.6, -0.4]
+    monkeypatch.setattr(
+        "providers.sentiment.get_sentiment", lambda *a, **k: provider,
+    )
+    sentiment = sentiment_alpha_scores(["AAPL", "MSFT"])
+    lgbm = {"AAPL": 0.3, "MSFT": 0.1}
+    ridge = {"AAPL": 0.5, "MSFT": -0.2}
+    blended = blend_signals(lgbm, ridge, sentiment)
+    assert set(blended.keys()) == {"AAPL", "MSFT"}
+    for v in blended.values():
+        assert -1.0 <= v <= 1.0


### PR DESCRIPTION
## Summary

Feeds cross-sectional sentiment into the ensemble alpha pipeline (Jansen Ch 14 integration).  The existing `adapters/sentiment/` fetches VADER / StockTwits scores but was never consumed by the ensemble — this PR wires it in behind an opt-in toggle.

- `strategies/sentiment_signal.py`
  - `fetch_sentiment_scores(tickers, lookback_hours, provider_name)` — returns raw per-ticker sentiment in `[-1, 1]`.  Delegates to `providers.sentiment.get_sentiment()`; gracefully no-ops to `{ticker: 0.0}` when no provider is configured or a lookup fails.
  - `sentiment_alpha_scores(tickers, ...)` — z-scores the raw values cross-sectionally, clips to `[-1, 1]`, returns a drop-in source for `strategies.ensemble_signal.blend_signals`.  Universes with no sentiment data collapse to neutral (`0.0`).

- `pages/ml_signals.py`
  - **Enable sentiment blend** checkbox above the alpha-scores section.  Off by default → existing behaviour preserved.
  - When on, **Compute All Scores** fetches sentiment and blends it as a fourth weighted source; the Ensemble tab displays the cross-sectional sentiment z-scores alongside the blended scores.

- `tests/test_sentiment_signal.py` — 14 tests: empty universe, missing-provider graceful fallback, `ticker_sentiment` delegation + clipping, per-ticker error isolation, lookback + provider-name kwarg plumbing, z-scoring invariants, identical / all-zero universes collapse to neutral, key preservation, ensemble-blend compatibility.

- `ML_BOOK_MAP.md` — ML4T Ch 15 flips from ⏳ to 🟡 (sentiment integration done; LDA topic modelling still open).

## Test plan

- [x] `pytest tests/test_sentiment_signal.py -v` — 14/14 passing
- [x] Full unit suite + coverage gate: **1137 passed, 1 skipped, coverage 80.57%**
- [x] `ruff check .` — clean

Closes #73.