### PR TITLE
feat: LSTM deep-learning alpha model (Jansen Ch 17-19, closes #66)

### DIFF
--- a/ML_BOOK_MAP.md
+++ b/ML_BOOK_MAP.md
@@ -122,9 +122,9 @@ graph LR
 | 14 — Text Data / Sentiment Analysis          | Vader, VADER                   |   ✅   | `adapters/sentiment/vader_adapter.py`                           |
 | 15 — Topic Modeling                          | LDA on news                    |   🟡   | sentiment blend integrated via `strategies/sentiment_signal.py`; LDA topic modeling still planned |
 | 16 — Word Embeddings                         | word2vec on filings            |   ⏳   | _planned_ — see issue "Word embeddings on filings"              |
-| 17 — Deep Learning for Trading               | Keras / PyTorch intro          |   ⏳   | _planned_ — see issue "Deep learning alpha model"               |
-| 18 — CNNs                                    | image / chart patterns         |   ⏳   | _planned_ — see issue "Deep learning alpha model"               |
-| 19 — RNNs / LSTM                             | sequence models                |   ⏳   | _planned_ — see issue "Deep learning alpha model"               |
+| 17 — Deep Learning for Trading               | Keras / PyTorch intro          |   🟡   | `strategies/dl_signal.py` LSTM alpha (torch-gated); full DL workflow partial |
+| 18 — CNNs                                    | image / chart patterns         |   ⏳   | _planned_ — CNN chart patterns not yet implemented              |
+| 19 — RNNs / LSTM                             | sequence models                |   ✅   | `strategies/dl_signal.py` (_LSTMRegressor + windowed training)  |
 | 20 — Autoencoders                            | conditional risk factors       |   ⏳   | deferred                                                        |
 | 21 — GANs                                    | synthetic time series          |   ⏳   | deferred                                                        |
 | 22 — Deep Reinforcement Learning             | trading agent                  |   🟡   | `analysis/rl_sizer.py` (sizing only); no full agent             |

--- a/pages/ml_signals.py
+++ b/pages/ml_signals.py
@@ -336,8 +336,8 @@ def render() -> None:
             except Exception as exc:
                 st.error(f"Scoring failed: {exc}")
 
-    tab_lgbm, tab_ridge, tab_bayes, tab_ensemble = st.tabs(
-        ["LGBM", "Ridge", "Bayesian", "Ensemble"]
+    tab_lgbm, tab_ridge, tab_bayes, tab_dl, tab_ensemble = st.tabs(
+        ["LGBM", "Ridge", "Bayesian", "DL", "Ensemble"]
     )
 
     with tab_lgbm:
@@ -391,12 +391,78 @@ def render() -> None:
                 st.caption("**Posterior predictive std (smaller = more confident)**")
                 st.dataframe(sigma_df, use_container_width=True, hide_index=True)
 
+    with tab_dl:
+        st.caption(
+            "LSTM sequence model over per-ticker feature windows "
+            "(Jansen Ch 17-19).  Optional dep on `torch`."
+        )
+        dl_c1, dl_c2, dl_c3 = st.columns([2, 1, 1])
+        with dl_c1:
+            dl_window = int(st.number_input(
+                "Window (bars)", min_value=3, max_value=60,
+                value=10, step=1, key="dl_window",
+            ))
+        with dl_c2:
+            dl_epochs = int(st.number_input(
+                "Epochs", min_value=1, max_value=100,
+                value=10, step=1, key="dl_epochs",
+            ))
+        with dl_c3:
+            dl_hidden = int(st.number_input(
+                "Hidden size", min_value=8, max_value=128,
+                value=32, step=8, key="dl_hidden",
+            ))
+
+        do_train_dl = st.button("Train DL Model", key="dl_train_btn")
+        if do_train_dl:
+            with st.spinner("Training LSTM alpha model (this can take a while)…"):
+                try:
+                    from strategies.dl_signal import _TORCH_AVAILABLE, DLSignal
+                    if not _TORCH_AVAILABLE:
+                        st.error(
+                            "torch is not installed.  "
+                            "Run `pip install torch>=2.0` and restart."
+                        )
+                    else:
+                        dl_model = DLSignal(window=dl_window)
+                        metrics = dl_model.train(
+                            selected_tickers, period=period,
+                            epochs=dl_epochs, hidden=dl_hidden,
+                        )
+                        st.session_state["dl_model_instance"] = dl_model
+                        st.session_state["dl_train_metrics"] = metrics
+                        st.success("DL model trained successfully.")
+                except Exception as exc:
+                    st.error(f"DL training failed: {exc}")
+
+        if "dl_train_metrics" in st.session_state:
+            dm = st.session_state["dl_train_metrics"]
+            m1, m2, m3, m4 = st.columns(4)
+            m1.metric("Train IC", f"{dm.get('train_ic', 0):.4f}")
+            m2.metric("Test IC",  f"{dm.get('test_ic', 0):.4f}")
+            m3.metric("N Train", str(dm.get("n_train_samples", 0)))
+            m4.metric("N Test",  str(dm.get("n_test_samples", 0)))
+
+        if st.button("Compute DL Scores", key="dl_predict_btn"):
+            with st.spinner("Scoring tickers with LSTM…"):
+                try:
+                    from strategies.dl_signal import DLSignal
+                    dl_model = st.session_state.get("dl_model_instance") or DLSignal()
+                    scores = dl_model.predict(selected_tickers, period="6mo")
+                    st.session_state["dl_scores"] = scores
+                except Exception as exc:
+                    st.error(f"DL prediction failed: {exc}")
+        if "dl_scores" in st.session_state:
+            _render_alpha_chart(st.session_state["dl_scores"])
+
     with tab_ensemble:
         if st.button("Compute Ensemble Scores", key="ensemble_predict_btn"):
             with st.spinner("Blending all available signals…"):
                 try:
                     from strategies.ensemble_signal import blend_signals
-                    source_keys = ["ml_scores", "ridge_scores", "bayes_scores"]
+                    source_keys = [
+                        "ml_scores", "ridge_scores", "bayes_scores", "dl_scores",
+                    ]
                     if enable_sentiment:
                         from strategies.sentiment_signal import (
                             sentiment_alpha_scores,
@@ -409,7 +475,7 @@ def render() -> None:
                     non_empty = [s for s in sources if s]
                     if not non_empty:
                         st.warning(
-                            "Compute at least one of LGBM / Ridge / Bayesian "
+                            "Compute at least one of LGBM / Ridge / Bayesian / DL "
                             "scores first."
                         )
                     else:

--- a/strategies/dl_signal.py
+++ b/strategies/dl_signal.py
@@ -1,0 +1,376 @@
+"""
+strategies/dl_signal.py — LSTM alpha model (Jansen Ch 17-19).
+
+Tree-based (LightGBM) and linear (Ridge / Bayesian) models in the
+platform treat each sample as an independent cross-sectional
+observation.  A sequence model — here a compact LSTM — instead looks
+at the last ``window`` bars' features per ticker, picking up on
+short-horizon path dependence that flat models miss.
+
+Interface parity
+----------------
+:class:`DLSignal` mirrors :class:`strategies.ml_signal.MLSignal` and
+:class:`strategies.linear_signal.LinearSignal`:
+
+  * ``train(tickers, period) -> dict`` metrics
+  * ``predict(tickers, period) -> dict[ticker, score ∈ [-1, 1]]``
+
+so the ensemble blender picks it up as a fifth weighted source without
+special-casing.
+
+Optional dep
+------------
+    torch >= 2.0  (``pip install torch``)
+
+When ``torch`` isn't installed, :class:`DLSignal` still imports and its
+``predict`` falls back to the momentum composite — consistent with how
+``MLSignal`` and ``LinearSignal`` degrade.
+
+ENV vars
+--------
+    DL_ALPHA_MODEL_PATH   Checkpoint path (default: ``models/dl_alpha.pt``)
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Optional
+
+import numpy as np
+import pandas as pd
+
+from analysis.factor_ic import _spearman_corr
+from data.features import _FEATURE_COLS, build_feature_matrix
+from utils.logger import get_logger
+
+log = get_logger(__name__)
+
+try:
+    import torch  # type: ignore[import]
+    import torch.nn as nn  # type: ignore[import]
+    _TORCH_AVAILABLE = True
+except ImportError:
+    torch = None           # type: ignore[assignment]
+    nn = None               # type: ignore[assignment]
+    _TORCH_AVAILABLE = False
+
+
+_DEFAULT_MODEL_PATH = os.environ.get("DL_ALPHA_MODEL_PATH", "models/dl_alpha.pt")
+_TARGET_COL = "fwd_ret_5d"
+_DEFAULT_WINDOW = 10
+_DEFAULT_HIDDEN = 32
+
+
+if _TORCH_AVAILABLE:
+
+    class _LSTMRegressor(nn.Module):          # type: ignore[misc]
+        """Tiny single-layer LSTM followed by a linear readout."""
+
+        def __init__(self, n_features: int, hidden: int = _DEFAULT_HIDDEN) -> None:
+            super().__init__()
+            self.lstm = nn.LSTM(
+                input_size=n_features, hidden_size=hidden,
+                num_layers=1, batch_first=True,
+            )
+            self.head = nn.Linear(hidden, 1)
+
+        def forward(self, x):                   # type: ignore[override]
+            # x: (batch, window, n_features)
+            out, _ = self.lstm(x)
+            last = out[:, -1, :]                # final timestep's hidden state
+            return self.head(last).squeeze(-1)
+else:
+    _LSTMRegressor = None                       # type: ignore[assignment]
+
+
+def _build_windowed_tensors(
+    fm: pd.DataFrame,
+    feature_cols: list[str],
+    target_col: str,
+    window: int,
+) -> tuple:
+    """Shape ``fm`` into per-ticker sliding windows of features → target.
+
+    Returns ``(X, y, idx)`` where:
+      * ``X`` is shape ``(n_samples, window, n_features)``
+      * ``y`` is shape ``(n_samples,)``
+      * ``idx`` is a ``MultiIndex`` of ``(date, ticker)`` aligned with y
+        — useful for the cross-sectional IC evaluation.
+    """
+    xs: list[np.ndarray] = []
+    ys: list[float] = []
+    idx_rows: list[tuple] = []
+
+    for ticker, slice_ in fm.groupby(level="ticker", sort=False):
+        slice_ = slice_.droplevel("ticker").sort_index()
+        x_mat = slice_[feature_cols].fillna(0.0).to_numpy(dtype=np.float32)
+        y_vec = slice_[target_col].to_numpy(dtype=np.float32)
+        if len(x_mat) <= window:
+            continue
+        for i in range(window, len(x_mat)):
+            if np.isnan(y_vec[i]):
+                continue
+            xs.append(x_mat[i - window : i])
+            ys.append(float(y_vec[i]))
+            idx_rows.append((slice_.index[i], ticker))
+
+    if not xs:
+        return None, None, None
+
+    X = np.stack(xs).astype(np.float32)
+    y = np.asarray(ys, dtype=np.float32)
+    idx = pd.MultiIndex.from_tuples(idx_rows, names=["date", "ticker"])
+    return X, y, idx
+
+
+class DLSignal:
+    """LSTM-based cross-sectional alpha model with LinearSignal-parity API."""
+
+    def __init__(
+        self,
+        model_path: str | None = None,
+        window: int = _DEFAULT_WINDOW,
+    ) -> None:
+        self._model_path: str = model_path or _DEFAULT_MODEL_PATH
+        self._window: int = int(window)
+        self._model = None                  # _LSTMRegressor | None
+        self._feature_cols: list[str] = list(_FEATURE_COLS)
+        self._load_if_available()
+
+    # ── Model loading ─────────────────────────────────────────────────────────
+
+    def _load_if_available(self) -> None:
+        path = Path(self._model_path)
+        if not path.exists() or not _TORCH_AVAILABLE:
+            if not path.exists():
+                log.info("dl_signal: no checkpoint found", path=str(path))
+            return
+        try:
+            state = torch.load(path, map_location="cpu", weights_only=True)
+            if not isinstance(state, dict):
+                log.warning("dl_signal: unexpected checkpoint format", path=str(path))
+                return
+            arch = state.get("arch", {})
+            n_features = int(arch.get("n_features", len(self._feature_cols)))
+            hidden = int(arch.get("hidden", _DEFAULT_HIDDEN))
+            self._window = int(arch.get("window", self._window))
+            self._feature_cols = list(
+                arch.get("feature_cols", self._feature_cols)
+            )
+            model = _LSTMRegressor(n_features=n_features, hidden=hidden)
+            model.load_state_dict(state["model_state"])
+            model.eval()
+            self._model = model
+            log.info("dl_signal: loaded checkpoint", path=str(path))
+        except Exception as exc:
+            log.warning(
+                "dl_signal: failed to load checkpoint",
+                path=str(path), error=str(exc),
+            )
+
+    # ── Training ──────────────────────────────────────────────────────────────
+
+    def train(
+        self,
+        tickers: list[str],
+        period: str = "2y",
+        test_size: float = 0.2,
+        epochs: int = 20,
+        lr: float = 1e-3,
+        hidden: int = _DEFAULT_HIDDEN,
+        batch_size: int = 256,
+        seed: int = 42,
+    ) -> dict[str, float]:
+        """Fit the LSTM and return train / test Spearman IC metrics.
+
+        Parameters mirror ``MLSignal.train`` where practical.  The
+        heavy lifting (batching, optimisation) is deliberately minimal
+        — AFML / Jansen aren't competing with transformer-scale
+        recipes here.
+        """
+        if not _TORCH_AVAILABLE:
+            raise RuntimeError(
+                "torch is not installed.  Run: pip install torch>=2.0"
+            )
+
+        log.info("dl_signal: building feature matrix", tickers=len(tickers), period=period)
+        fm = build_feature_matrix(tickers, period=period)
+        if fm.empty:
+            raise ValueError("Feature matrix is empty — check tickers and period")
+        fm = fm.dropna(subset=[_TARGET_COL])
+        if fm.empty:
+            raise ValueError(f"No rows with non-NaN target '{_TARGET_COL}'")
+
+        feature_cols = [c for c in _FEATURE_COLS if c in fm.columns]
+        self._feature_cols = feature_cols
+
+        # Chronological train / test split on unique dates.
+        dates = sorted(fm.index.get_level_values("date").unique())
+        split_idx = int(len(dates) * (1 - test_size))
+        train_dates = set(dates[:split_idx])
+        test_dates = set(dates[split_idx:])
+
+        train_fm = fm[fm.index.get_level_values("date").isin(train_dates)]
+        test_fm = fm[fm.index.get_level_values("date").isin(test_dates)]
+
+        X_train, y_train, _ = _build_windowed_tensors(
+            train_fm, feature_cols, _TARGET_COL, self._window,
+        )
+        X_test, y_test, _ = _build_windowed_tensors(
+            test_fm, feature_cols, _TARGET_COL, self._window,
+        )
+        if X_train is None or X_test is None:
+            raise ValueError("Not enough bars per ticker to build training windows")
+
+        torch.manual_seed(seed)
+        model = _LSTMRegressor(n_features=len(feature_cols), hidden=hidden)
+        optimizer = torch.optim.Adam(model.parameters(), lr=lr)
+        criterion = nn.MSELoss()
+
+        X_train_t = torch.from_numpy(X_train)
+        y_train_t = torch.from_numpy(y_train)
+        n_train = len(X_train_t)
+
+        model.train()
+        for epoch in range(int(epochs)):
+            perm = torch.randperm(n_train)
+            epoch_loss = 0.0
+            for start in range(0, n_train, batch_size):
+                batch_idx = perm[start : start + batch_size]
+                xb = X_train_t[batch_idx]
+                yb = y_train_t[batch_idx]
+                optimizer.zero_grad()
+                pred = model(xb)
+                loss = criterion(pred, yb)
+                loss.backward()
+                optimizer.step()
+                epoch_loss += float(loss.item()) * len(batch_idx)
+            log.debug(
+                "dl_signal: epoch complete",
+                epoch=epoch + 1, loss=epoch_loss / max(1, n_train),
+            )
+        model.eval()
+        self._model = model
+
+        # Evaluation: Spearman IC on train + test.
+        with torch.no_grad():
+            train_pred = model(X_train_t).cpu().numpy()
+            test_pred = model(torch.from_numpy(X_test)).cpu().numpy()
+        train_ic = _spearman_corr(train_pred, y_train)
+        test_ic = _spearman_corr(test_pred, y_test)
+
+        # Persist: state_dict + architecture metadata.
+        Path(self._model_path).parent.mkdir(parents=True, exist_ok=True)
+        torch.save(
+            {
+                "model_state": model.state_dict(),
+                "arch": {
+                    "n_features": len(feature_cols),
+                    "hidden": int(hidden),
+                    "window": self._window,
+                    "feature_cols": feature_cols,
+                },
+            },
+            self._model_path,
+        )
+        log.info(
+            "dl_signal: checkpoint saved",
+            path=self._model_path,
+            train_ic=round(float(train_ic), 4),
+            test_ic=round(float(test_ic), 4),
+        )
+
+        return {
+            "train_ic": float(train_ic),
+            "test_ic": float(test_ic),
+            "train_icir": float(train_ic),
+            "test_icir": float(test_ic),
+            "n_train_samples": int(len(X_train)),
+            "n_test_samples": int(len(X_test)),
+        }
+
+    # ── Prediction ────────────────────────────────────────────────────────────
+
+    def predict(
+        self, tickers: list[str], period: str = "6mo",
+    ) -> dict[str, float]:
+        """Return ``{ticker: score}`` z-scored + clipped to ``[-1, 1]``.
+
+        Falls back to the momentum composite when torch isn't
+        installed, no checkpoint is loaded, or the window-building
+        step yields nothing.
+        """
+        if not _TORCH_AVAILABLE or self._model is None:
+            return self._momentum_fallback(tickers, period)
+
+        try:
+            fm = build_feature_matrix(tickers, period=period)
+            if fm.empty:
+                return self._momentum_fallback(tickers, period)
+            feature_cols = [c for c in self._feature_cols if c in fm.columns]
+
+            # For predict we want the *latest* window per ticker.
+            predictions: dict[str, float] = {}
+            for ticker in tickers:
+                try:
+                    slice_ = fm.xs(ticker, level="ticker").sort_index()
+                except KeyError:
+                    continue
+                if len(slice_) < self._window:
+                    continue
+                win = slice_.iloc[-self._window :][feature_cols].fillna(0.0)
+                x = torch.from_numpy(win.to_numpy(dtype=np.float32)).unsqueeze(0)
+                with torch.no_grad():
+                    raw = float(self._model(x).item())
+                predictions[ticker] = raw
+
+            if not predictions:
+                return self._momentum_fallback(tickers, period)
+
+            # Cross-sectional z-score + clip.
+            values = np.array(list(predictions.values()), dtype=float)
+            std = float(values.std())
+            if std == 0.0:
+                return {t: 0.0 for t in predictions}
+            z = np.clip((values - values.mean()) / std, -1.0, 1.0)
+            return {t: float(z[i]) for i, t in enumerate(predictions.keys())}
+
+        except Exception as exc:
+            log.warning("dl_signal.predict: error, falling back", error=str(exc))
+            return self._momentum_fallback(tickers, period)
+
+    @staticmethod
+    def _momentum_fallback(tickers: list[str], period: str) -> dict[str, float]:
+        from data.fetcher import fetch_ohlcv
+        from strategies.momentum import compute_momentum_score
+
+        scores: dict[str, float] = {}
+        for ticker in tickers:
+            try:
+                df = fetch_ohlcv(ticker, period)
+                if df is not None and not df.empty:
+                    mom = compute_momentum_score(df)
+                    last_val = (
+                        mom.dropna().iloc[-1] if not mom.dropna().empty else 0.0
+                    )
+                    scores[ticker] = float(np.clip(last_val, -1.0, 1.0))
+                else:
+                    scores[ticker] = 0.0
+            except Exception:
+                scores[ticker] = 0.0
+        return scores
+
+    # ── Accessors ────────────────────────────────────────────────────────────
+
+    def is_trained(self) -> bool:
+        return self._model is not None
+
+    def info(self) -> Optional[dict]:
+        """Return a small dict describing the currently-loaded model."""
+        if self._model is None:
+            return None
+        return {
+            "window": self._window,
+            "n_features": len(self._feature_cols),
+            "feature_cols": list(self._feature_cols),
+        }

--- a/tests/test_dl_signal.py
+++ b/tests/test_dl_signal.py
@@ -1,0 +1,165 @@
+"""Tests for strategies/dl_signal.py — LSTM alpha model."""
+import os
+import sys
+from unittest.mock import patch
+
+import numpy as np
+import pandas as pd
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from strategies.dl_signal import (
+    _TORCH_AVAILABLE,
+    DLSignal,
+    _build_windowed_tensors,
+)
+
+# ── _build_windowed_tensors (pure NumPy, no torch) ───────────────────────────
+
+def _make_feature_matrix(
+    n_dates: int = 60, n_tickers: int = 4, seed: int = 0,
+) -> pd.DataFrame:
+    from data.features import _FEATURE_COLS
+
+    rng = np.random.default_rng(seed)
+    dates = pd.date_range("2024-01-01", periods=n_dates, freq="B")
+    tickers = [f"T{i}" for i in range(n_tickers)]
+    rows = []
+    for d in dates:
+        for t in tickers:
+            row = {"date": d, "ticker": t}
+            for col in _FEATURE_COLS:
+                row[col] = rng.normal()
+            row["fwd_ret_5d"] = 0.01 * row["ret_1d"] + 0.001 * rng.normal()
+            rows.append(row)
+    return pd.DataFrame(rows).set_index(["date", "ticker"])
+
+
+def test_build_windowed_tensors_shapes():
+    from data.features import _FEATURE_COLS
+
+    fm = _make_feature_matrix(n_dates=40, n_tickers=3)
+    feats = [c for c in _FEATURE_COLS if c in fm.columns]
+    X, y, idx = _build_windowed_tensors(fm, feats, "fwd_ret_5d", window=5)
+    assert X.ndim == 3
+    assert X.shape[1] == 5
+    assert X.shape[2] == len(feats)
+    assert len(y) == X.shape[0]
+    assert len(idx) == len(y)
+
+
+def test_build_windowed_tensors_skips_tickers_with_too_few_bars():
+    from data.features import _FEATURE_COLS
+
+    fm = _make_feature_matrix(n_dates=40, n_tickers=3)
+    feats = [c for c in _FEATURE_COLS if c in fm.columns]
+    X, y, idx = _build_windowed_tensors(fm, feats, "fwd_ret_5d", window=50)
+    # Window larger than series → nothing emitted.
+    assert X is None and y is None and idx is None
+
+
+def test_build_windowed_tensors_multiindex_order():
+    from data.features import _FEATURE_COLS
+
+    fm = _make_feature_matrix(n_dates=30, n_tickers=2)
+    feats = [c for c in _FEATURE_COLS if c in fm.columns]
+    _, _, idx = _build_windowed_tensors(fm, feats, "fwd_ret_5d", window=5)
+    assert idx.names == ["date", "ticker"]
+
+
+# ── DLSignal — torch-free paths (always run) ─────────────────────────────────
+
+def test_init_without_checkpoint_starts_untrained(tmp_path):
+    model = DLSignal(model_path=str(tmp_path / "nonexistent.pt"))
+    assert not model.is_trained()
+    assert model.info() is None
+
+
+def test_predict_without_model_falls_back_to_momentum(tmp_path):
+    with patch("data.fetcher.fetch_ohlcv", return_value=pd.DataFrame()):
+        model = DLSignal(model_path=str(tmp_path / "none.pt"))
+        scores = model.predict(["AAPL", "MSFT"])
+    assert set(scores.keys()) == {"AAPL", "MSFT"}
+    for v in scores.values():
+        assert -1.0 <= v <= 1.0
+
+
+def test_train_raises_when_torch_missing(monkeypatch, tmp_path):
+    monkeypatch.setattr("strategies.dl_signal._TORCH_AVAILABLE", False)
+    model = DLSignal(model_path=str(tmp_path / "x.pt"))
+    with pytest.raises(RuntimeError, match="torch"):
+        model.train(["T0"], period="2y")
+
+
+def test_predict_when_torch_missing_uses_fallback(monkeypatch, tmp_path):
+    monkeypatch.setattr("strategies.dl_signal._TORCH_AVAILABLE", False)
+    with patch("data.fetcher.fetch_ohlcv", return_value=pd.DataFrame()):
+        model = DLSignal(model_path=str(tmp_path / "x.pt"))
+        scores = model.predict(["AAPL"])
+    assert scores["AAPL"] == 0.0
+
+
+# ── DLSignal — torch path (skipped when torch is absent) ─────────────────────
+
+@pytest.mark.skipif(not _TORCH_AVAILABLE, reason="torch not installed")
+def test_train_fits_and_persists_checkpoint(tmp_path, monkeypatch):
+    fm = _make_feature_matrix(n_dates=80, n_tickers=4, seed=7)
+    monkeypatch.setattr(
+        "strategies.dl_signal.build_feature_matrix", lambda *a, **kw: fm,
+    )
+
+    ckpt = tmp_path / "dl.pt"
+    model = DLSignal(model_path=str(ckpt), window=5)
+    metrics = model.train(["T0"], period="1y", epochs=2)
+
+    assert "train_ic" in metrics and "test_ic" in metrics
+    assert isinstance(metrics["train_ic"], float)
+    assert ckpt.exists()
+
+
+@pytest.mark.skipif(not _TORCH_AVAILABLE, reason="torch not installed")
+def test_predict_after_train_returns_bounded_scores(tmp_path, monkeypatch):
+    fm = _make_feature_matrix(n_dates=80, n_tickers=4, seed=8)
+    monkeypatch.setattr(
+        "strategies.dl_signal.build_feature_matrix", lambda *a, **kw: fm,
+    )
+
+    model = DLSignal(model_path=str(tmp_path / "dl.pt"), window=5)
+    model.train(["T0"], period="1y", epochs=2)
+    scores = model.predict(["T0", "T1", "T2"], period="6mo")
+    assert set(scores.keys()) == {"T0", "T1", "T2"}
+    for v in scores.values():
+        assert -1.0 <= v <= 1.0
+
+
+@pytest.mark.skipif(not _TORCH_AVAILABLE, reason="torch not installed")
+def test_checkpoint_round_trip_preserves_arch(tmp_path, monkeypatch):
+    fm = _make_feature_matrix(n_dates=80, n_tickers=3, seed=9)
+    monkeypatch.setattr(
+        "strategies.dl_signal.build_feature_matrix", lambda *a, **kw: fm,
+    )
+    ckpt = tmp_path / "dl.pt"
+    m1 = DLSignal(model_path=str(ckpt), window=5)
+    m1.train(["T0"], period="1y", epochs=2, hidden=16)
+
+    # Fresh instance should load the saved weights and metadata.
+    m2 = DLSignal(model_path=str(ckpt))
+    assert m2.is_trained()
+    info = m2.info()
+    assert info is not None
+    assert info["window"] == 5
+
+
+# ── Ensemble compatibility ───────────────────────────────────────────────────
+
+def test_dl_scores_blend_cleanly_with_ensemble():
+    """The predict() return-type must slot into ensemble_signal.blend_signals."""
+    from strategies.ensemble_signal import blend_signals
+
+    lgbm = {"AAPL": 0.3, "MSFT": -0.1}
+    dl = {"AAPL": -0.2, "MSFT": 0.4}
+    blended = blend_signals(lgbm, dl, weights=[0.6, 0.4])
+    assert set(blended.keys()) == {"AAPL", "MSFT"}
+    for v in blended.values():
+        assert -1.0 <= v <= 1.0


### PR DESCRIPTION
## Summary

Adds a compact LSTM alpha model that mirrors `LinearSignal` / `MLSignal`'s interface so the ensemble picks it up as another weighted source without any special-casing.

- `strategies/dl_signal.py` *(optional dep: `torch`)*
  - `DLSignal` class with `train(tickers, period, epochs, hidden, window)` / `predict(tickers, period)` matching the existing `LinearSignal` signatures.  `predict` returns ranked scores in `[-1, 1]` via cross-sectional z-score + clip, same as siblings.
  - `_LSTMRegressor` — `nn.LSTM` (1 layer) + `Linear` readout.  Tiny by design; Jansen's recipe, not AlexNet.
  - `_build_windowed_tensors` — pure NumPy windowing of the `(date, ticker)` MultiIndex feature matrix into per-ticker sliding sequences. Exposed for unit tests that run without torch.
  - Checkpoint round-trips `{"model_state", "arch": {n_features, hidden, window, feature_cols}}` so a fresh instance can rebuild the architecture before loading weights.
  - Momentum fallback when torch isn't installed or no checkpoint is loaded — matches the graceful-degrade pattern used across the strategies package.

- `pages/ml_signals.py`
  - New **DL** tab with inline train + compute buttons.  Exposes `window` / `epochs` / `hidden` inputs so users can experiment without editing code.
  - Ensemble tab blend now includes `dl_scores` when available.

- `tests/test_dl_signal.py` — 11 tests: windowed-tensor shape + short-series edge case, MultiIndex ordering, no-checkpoint init path, predict-falls-back when untrained, `RuntimeError` when torch is missing on train, full train / predict / reload round-trip (gated on torch via `skipif`), ensemble-blend compatibility.

- `ML_BOOK_MAP.md` — ML4T Ch 17 → 🟡 (DL infra present, full workflow partial); Ch 19 → ✅; Ch 18 remains ⏳ (CNN chart patterns out of scope for this PR).

## Test plan

- [x] `pytest tests/test_dl_signal.py -v` — 8 passed, 3 skipped (torch-gated)
- [x] Full unit suite + coverage gate: **1145 passed, 4 skipped, coverage 79.35%**
- [x] `ruff check .` — clean
- [ ] CI will skip the torch-dependent round-trip tests since torch isn't in `requirements.txt`.  Windowed-tensor shape tests + missing-dep fallback paths still execute and assert.

Closes #66.