### PR TITLE
feat: add Claude Code skills and slash commands for platform workflows

### DIFF
--- a/.claude/commands/run-agent.md
+++ b/.claude/commands/run-agent.md
@@ -1,0 +1,64 @@
+---
+description: Invoke a specialist trading agent (regime, risk, sentiment, screener, execution) or the meta-agent with a ticker context, and display the AgentSignal.
+argument-hint: <agent_name> <ticker>
+---
+
+Invoke one of the trading agents defined in `agents/` with a minimal context and print the resulting `AgentSignal` (see `agents/base.py:15-48`).
+
+## Arguments
+
+- `<agent_name>`: one of `regime`, `risk`, `sentiment`, `screener`, `execution`, `meta` (case-insensitive).
+- `<ticker>`: symbol, validated against `^[A-Z0-9]{1,6}(\.[A-Z]{1,2})?$` — same regex as `agents/meta_agent.py:25`.
+
+Reject unknown agent names with a list of valid options. Reject malformed tickers with the regex.
+
+## Dispatch
+
+| agent_name | Class | Module |
+|---|---|---|
+| `regime` | `RegimeAgent` | `agents.regime_agent` |
+| `risk` | `RiskAgent` | `agents.risk_agent` |
+| `sentiment` | `SentimentAgent` | `agents.sentiment_agent` |
+| `screener` | `ScreenerAgent` | `agents.screener_agent` |
+| `execution` | `ExecutionAgent` | `agents.execution_agent` |
+| `meta` | `MetaAgent` | `agents.meta_agent` |
+
+## Execution
+
+Run a one-shot Python invocation. For specialists:
+
+```
+python -c "
+import json
+from agents.<module> import <Class>
+agent = <Class>()
+sig = agent.run({'ticker': '<TICKER>'})
+print(json.dumps({
+    'agent': sig.agent_name,
+    'signal': sig.signal,
+    'confidence': sig.confidence,
+    'reasoning': sig.reasoning,
+    'metadata': sig.metadata,
+}, indent=2, default=str))
+"
+```
+
+For `meta`, `MetaAgent.run()` already returns a dict (see `agents/meta_agent.py:136-150`) — dump it directly:
+
+```
+python -c "
+import json
+from agents.meta_agent import MetaAgent
+result = MetaAgent().run({'ticker': '<TICKER>'})
+print(json.dumps(result, indent=2, default=str))
+"
+```
+
+## Output
+
+Show the JSON result as a formatted block. Do not edit files. If the agent raises, show the exception class and message; suggest checking the agent's dependencies (e.g., sentiment needs an LLM provider configured via `LLM_PROVIDER`).
+
+## Notes
+
+- `MetaAgent` reads `AGENT_WEIGHTS` and `AGENT_LLM_ARBITER` from the environment (`agents/meta_agent.py:9-11`). Do not override them from this command.
+- `python -c:*` is pre-approved in `.claude/settings.json`, so this runs without a permission prompt.

--- a/.claude/commands/run-cron.md
+++ b/.claude/commands/run-cron.md
@@ -1,0 +1,59 @@
+---
+description: Manually run a cron job (cron.daily_ml_execute or cron.monthly_ml_retrain) locally with optional ticker override, and summarise the structured log output.
+argument-hint: daily|monthly [TICKER1,TICKER2,...]
+---
+
+Manually trigger one of the ML cron jobs. Mirrors the manual-invocation lines documented in `cron/daily_ml_execute.py:9-11` and `cron/monthly_ml_retrain.py:7-11`.
+
+## Arguments
+
+- First arg (required): `daily` or `monthly`.
+- Second arg (optional): comma-separated ticker list. If present, export `WF_TICKERS=<arg>` **for the subprocess only** — do not mutate the user's shell.
+
+Reject any other first arg with a usage line: `/run-cron daily|monthly [TICKER1,TICKER2,...]`.
+
+## Dispatch
+
+| First arg | Command | Script |
+|---|---|---|
+| `daily` | `python -m cron.daily_ml_execute` | `cron/daily_ml_execute.py` |
+| `monthly` | `python -m cron.monthly_ml_retrain` | `cron/monthly_ml_retrain.py` |
+
+Both are pre-approved in `.claude/settings.json`.
+
+## Pre-flight for `daily`
+
+Before invoking, check that a trained model exists — otherwise `cron/daily_ml_execute.py:59-64` will exit 1:
+
+```
+python -c "import os; p=os.environ.get('LGBM_ALPHA_MODEL_PATH','models/lgbm_alpha.pkl'); import sys; sys.exit(0 if os.path.exists(p) else 1)"
+```
+
+If the model is missing, stop and tell the user to run `/run-cron monthly` first (optionally with the same tickers).
+
+## Env vars to surface
+
+`daily` also reads `ML_SCORE_THRESHOLD` (default 0.3), `ML_MAX_POSITIONS` (default 5), `BROKER_PROVIDER` (default `paper`) — all from `cron/daily_ml_execute.py:17-22`. Before running, print the current values and ask the user whether to override. Default to the existing env; never silently switch to a live broker.
+
+`monthly` reads `ML_TRAIN_PERIOD` (default `2y`) from `cron/monthly_ml_retrain.py:14-17`. Surface the same way.
+
+## Run
+
+Stream output to the user. On success, parse the final structured log line and summarise:
+
+- **daily**: extract `n_actions`, `n_scores`, and the `actions` list from the `daily_ml_execute: complete` log (fields match `cron/daily_ml_execute.py:75-79`). Show a one-screen summary.
+- **monthly**: extract `train_ic`, `test_ic`, `train_icir`, `test_icir`, `n_train`, `n_test` from the `ml_retrain: complete` log (fields match `cron/monthly_ml_retrain.py:55-63`). Show them in a small table.
+
+## On failure
+
+If exit code is non-zero, show the last 20 lines of stderr and propose the next step:
+
+- `lightgbm is not installed` → `pip install lightgbm`.
+- `no trained baseline model found` → run `/run-cron monthly` first.
+- `runtime error` during retraining → check `WF_TICKERS` and network; do not retry silently.
+
+## Guardrails
+
+- Do not switch `BROKER_PROVIDER` away from `paper` without explicit user confirmation — a mis-set broker could place real orders.
+- Do not modify anything under `cron/` or `strategies/` from this command.
+- Do not commit, push, or tag anything.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(ruff check:*)",
+      "Bash(ruff check . --fix)",
+      "Bash(pytest tests/:*)",
+      "Bash(bandit -r . -ll --exclude ./.git,./tests:*)",
+      "Bash(pip-audit -r requirements.txt:*)",
+      "Bash(python -m cron.daily_ml_execute)",
+      "Bash(python -m cron.monthly_ml_retrain)",
+      "Bash(python -c:*)"
+    ]
+  }
+}

--- a/.claude/skills/ml-experiment/SKILL.md
+++ b/.claude/skills/ml-experiment/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: ml-experiment
+description: Guide the user end-to-end through a new ML signal or feature experiment — feature engineering in data/features.py, IC measurement via analysis/factor_ic.py, wiring into strategies/ml_signal.py or ensemble_signal.py, Optuna tuning via strategies/ml_tuning.py, and a backtest via backtester/walk_forward.py. Use when the user wants to experiment with a new alpha, add a feature, try a new ML signal, or tune an existing model.
+---
+
+# ml-experiment — scaffold a new ML signal experiment
+
+The platform already has a full ML pipeline. This skill does **not** re-implement any of it — it chains the existing modules and emits a concise experiment report. Always reuse; never duplicate.
+
+## Pipeline modules (reuse these, do not rewrite)
+
+| Stage | Module | Key API |
+|---|---|---|
+| Features | `data/features.py` | add a function here; the feature list is assembled inside the module |
+| IC / ICIR | `analysis/factor_ic.py` | `compute_ic(df, feature, horizon)` |
+| Baseline model | `strategies/ml_signal.py` | `MLSignal().train(tickers, period)`, `MLSignal().predict(tickers, period)` — LightGBM + regime-conditioning |
+| Ensemble | `strategies/ensemble_signal.py` | use when stacking multiple signals |
+| Tuning | `strategies/ml_tuning.py` | `run_optuna(...)`, `load_best_params(model_name)` — persisted params are picked up automatically by `cron/monthly_ml_retrain.py` |
+| Walk-forward backtest | `backtester/walk_forward.py` | `run_walk_forward(...)` |
+| Tests | `tests/test_ml_signal.py`, `tests/test_features.py` | mock `fetch_ohlcv`; no network |
+
+## Steps
+
+Walk the user through these, one at a time. At each step, print what you changed and what command you ran.
+
+1. **Clarify scope.** Ask: what feature or signal idea, and on which ticker universe? Default universe is `$WF_TICKERS` or `SPY,QQQ,AAPL,MSFT,TSLA` (matches `cron/daily_ml_execute.py:35`).
+2. **Add the feature.** Edit `data/features.py` to add the feature function; register it in the existing feature list. Add or extend a unit test in `tests/test_features.py` that mocks OHLCV — do not hit network.
+3. **Run the feature test.** `pytest tests/test_features.py -v`.
+4. **Measure IC.** Compute `compute_ic` on the configured universe across sensible horizons (1d / 5d / 20d). Convention from `IMPLEMENTATION_SUMMARY.md`: if `|IC| < 0.02` and ICIR is small, reject the feature and stop. Report the IC table.
+5. **Wire into a signal.** If a pure feature, add to `MLSignal`. If combining signals, extend `ensemble_signal.py`. Do **not** modify `cron/monthly_ml_retrain.py` or `cron/daily_ml_execute.py` — they consume whatever `MLSignal` and `load_best_params` return.
+6. **Tune.** Call `strategies.ml_tuning.run_optuna(...)` for N trials (ask; default 30) with purged CV. Persist winners so `monthly_ml_retrain` picks them up on the next schedule.
+7. **Walk-forward backtest.** `run_walk_forward` on the configured universe; report Sharpe, Sortino, max drawdown, turnover.
+8. **Report.** Emit a one-screen experiment report:
+
+   ```
+   Experiment: <feature/signal name>
+   Universe:   <tickers>
+   IC (5d):    <value>   ICIR: <value>
+   Tuned params: <json>
+   Backtest:   Sharpe=<>, Sortino=<>, MaxDD=<>, Turnover=<>
+   Recommendation: <promote to production / further work / reject>
+   ```
+
+## Guardrails
+
+- Never modify anything under `cron/`. The experiment ends at "tuned params saved + backtest reported"; the cron jobs pick up tuned params on their next run.
+- Never hit the network in tests. Mock `data.fetcher.fetch_ohlcv` as other tests in `tests/` do.
+- Keep ruff / pytest / coverage green — after each step, propose running the `pre-push` skill if the user wants to validate before moving on.
+- Never commit or push from this skill.
+
+## Verification before declaring done
+
+Run the `pre-push` skill (or tell the user to). A passing `pre-push` + a backtest report with Sharpe above the current live baseline is the bar for promoting the experiment.

--- a/.claude/skills/pre-push/SKILL.md
+++ b/.claude/skills/pre-push/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: pre-push
+description: Run the same gates as CI (ruff, pytest with 76% coverage, bandit HIGH, pip-audit) against the current working tree and report pass/fail per stage. Use when the user asks to validate changes before push, check CI locally, run the pre-push checks, or verify the branch is CI-clean.
+---
+
+# pre-push — mirror CI gates locally
+
+This skill runs the same four gates that `.github/workflows/ci.yml` enforces, so a failure here means a failure on CI. Run them **in order** and stop at the first failure unless the user said "run all regardless".
+
+## Stages
+
+Run each via Bash, capture stdout/stderr, and report `PASS` or `FAIL` with a one-line summary.
+
+### 1. Lint
+
+```
+ruff check .
+```
+
+Source: `.github/workflows/ci.yml:22-23`. Fails CI on any violation. On failure, suggest `ruff check . --fix` and show the first 10 lines of the diagnostic.
+
+### 2. Unit tests + coverage (76% gate)
+
+```
+pytest tests/ -m "not integration" --cov=. --cov-fail-under=76 --cov-report=term-missing
+```
+
+Source: `.github/workflows/ci.yml:73-79`. On failure, report which tests failed (first 5) and, if the failure is coverage-only, print the files with the lowest coverage from the term-missing report.
+
+### 3. Bandit (HIGH severity only)
+
+```
+bandit -r . -ll --exclude ./.git,./tests -f json -o /tmp/bandit-report.json
+python -c "import json,sys; r=json.load(open('/tmp/bandit-report.json')); highs=[i for i in r['results'] if i['issue_severity']=='HIGH']; print(f'{len(highs)} HIGH severity issues'); [print(f\"  {i['filename']}:{i['line_number']} {i['test_id']} {i['issue_text']}\") for i in highs]; sys.exit(1 if highs else 0)"
+```
+
+Source: `.github/workflows/ci.yml:33-36`. Only HIGH severity fails CI — MEDIUM/LOW are reported but tolerated. Print any HIGH findings with file:line.
+
+### 4. Dependency audit
+
+```
+pip-audit -r requirements.txt --ignore-vuln PYSEC-2022-42969
+```
+
+Source: `.github/workflows/ci.yml:37-38`. `PYSEC-2022-42969` is intentionally ignored. If a new vulnerability appears, suggest pinning the affected package.
+
+## Reporting
+
+At the end, print a summary table:
+
+```
+Stage                    | Result
+-------------------------+--------
+1. ruff                  | PASS
+2. pytest (cov >= 76%)   | PASS
+3. bandit HIGH           | PASS
+4. pip-audit             | PASS
+```
+
+If everything passes, say explicitly: "Ready to push — CI should be green." If anything failed, stop at the first failure, summarise the failure, and propose the specific fix. Do not push, commit, or modify files as part of this skill.
+
+## Notes
+
+- All four commands are in `.claude/settings.json`'s allowlist — they run without a permission prompt.
+- The skill is read-only on the codebase. It never runs `ruff check . --fix` on its own — it only suggests it.
+- If the user has uncommitted changes, proceed anyway; CI would see them after commit+push.


### PR DESCRIPTION
Add .claude/ tooling covering the four workflows developers iterate on
daily:

- skills/pre-push: mirror CI gates locally (ruff, pytest w/ 76% cov,
  bandit HIGH, pip-audit) so failures are caught before push.
- skills/ml-experiment: chain the existing ML pipeline (data/features,
  factor_ic, ml_signal, ml_tuning, walk_forward) into a guided
  experiment flow that emits a one-screen report; reuses existing
  modules, never duplicates them.
- commands/run-agent: /run-agent <name> <ticker> invokes any of the
  five specialists or the meta-agent and prints the AgentSignal.
- commands/run-cron: /run-cron daily|monthly [tickers] triggers
  cron.daily_ml_execute or cron.monthly_ml_retrain with env-var
  surfacing, pre-flight model check, and log parsing.

settings.json allowlists just the known-safe local commands these
skills invoke (ruff, pytest tests/, bandit, pip-audit, python -m cron.*,
python -c). No broker, push, or commit permissions are added.