### PR TITLE
feat: VPIN and Kyle's lambda microstructural features (AFML Ch 19)

### DIFF
--- a/ML_BOOK_MAP.md
+++ b/ML_BOOK_MAP.md
@@ -26,6 +26,7 @@ graph LR
         F3[analysis/triple_barrier.py<br/>PT/SL/vertical labels]
         F4[data/frac_diff.py<br/>fractional diff]
         F5[data/sentiment.py + adapters<br/>Vader / StockTwits]
+        F6[analysis/microstructure.py<br/>VPIN + Kyle λ]
     end
 
     subgraph Models[Models]
@@ -54,12 +55,13 @@ graph LR
         E4[cron/monthly_ml_retrain.py]
     end
 
-    AFML --> F3 & F4 & M4 & M5 & B1 & B4 & B8
+    AFML --> F3 & F4 & F6 & M4 & M5 & B1 & B4 & B8
     ML4T --> F1 & F2 & F5 & M1 & M2 & M3 & M5 & B2 & B3 & B5 & B6 & B7
 
     F1 --> M1 & M2
     F3 --> M4
     F4 --> F1
+    F6 --> F1
     M1 --> B1 --> B2
     M4 --> B2
     M5 --> M1
@@ -72,7 +74,7 @@ graph LR
 
     classDef done fill:#d5f5e3,stroke:#229954,color:#154360
     classDef planned fill:#fdebd0,stroke:#b9770e,color:#7e5109
-    class F1,F2,F3,F4,F5,M1,M2,M3,M4,M5,B1,B2,B3,B4,B5,B6,B7,B8,E1,E2,E3,E4 done
+    class F1,F2,F3,F4,F5,F6,M1,M2,M3,M4,M5,B1,B2,B3,B4,B5,B6,B7,B8,E1,E2,E3,E4 done
 ```
 
 ---
@@ -100,7 +102,7 @@ graph LR
 | 16 — ML Asset Allocation                     | Hierarchical Risk Parity       |   ✅   | `risk/hrp.py` (quasi-diag + recursive bisection)                 |
 | 17 — Structural Breaks                       | CUSUM, Chow tests              |   ✅   | `analysis/structural_breaks.py` (cusum_events + cusum_events_from_prices) |
 | 18 — Entropy Features                        | Shannon / plug-in / K-L        |   ✅   | `analysis/entropy_features.py` (plug_in, lempel_ziv, konto) |
-| 19 — Microstructural Features                | VPIN, Kyle λ                   |   ⏳   | _planned_ — see issue "Microstructural features"                |
+| 19 — Microstructural Features                | VPIN, Kyle λ                   |   ✅   | `analysis/microstructure.py` (bvc_buy_fraction + vpin + kyle_lambda) |
 
 ### Jansen — *Machine Learning for Algorithmic Trading*
 

--- a/analysis/microstructure.py
+++ b/analysis/microstructure.py
@@ -1,0 +1,140 @@
+"""
+analysis/microstructure.py — AFML Ch 19 microstructural features.
+
+Two daily-bar estimators of informed trading / liquidity that can be
+computed without tick-level data:
+
+  * :func:`bvc_buy_fraction` — Bulk Volume Classification (Easley, López
+    de Prado, O'Hara 2012): the estimated buy-side fraction of a bar's
+    volume, derived from the standardised return via the Normal CDF.
+  * :func:`vpin` — Volume-Synchronized Probability of Informed Trading
+    over a rolling window of ``window`` daily bars, using BVC to split
+    each bar's volume into buy / sell halves.
+  * :func:`kyle_lambda` — rolling estimate of Kyle's price-impact
+    coefficient ``λ`` regressing ``|r_t|`` on signed dollar volume.
+
+All three are O(n) vectorised pandas operations and return a
+date-indexed ``pd.Series`` aligned with the input.
+
+Reference
+---------
+    López de Prado, *Advances in Financial Machine Learning*, Ch 19.
+    Easley, López de Prado & O'Hara, "Flow Toxicity and Liquidity in a
+    High-Frequency World," *Review of Financial Studies* 25 (2012).
+"""
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+from scipy.stats import norm
+
+from utils.logger import get_logger
+
+log = get_logger(__name__)
+
+
+def bvc_buy_fraction(returns: pd.Series, window: int = 50) -> pd.Series:
+    """Estimate the buy-side fraction of each bar's volume from returns.
+
+    For bar ``t`` the BVC rule (Easley et al. 2012) is::
+
+        buy_frac_t = Φ(r_t / (σ_r · √2))
+
+    where ``σ_r`` is the rolling standard deviation of returns over the
+    last ``window`` bars. Interpretation: if the bar's return is much
+    more positive than its recent volatility allows, the bar was likely
+    driven by buyers.
+
+    Parameters
+    ----------
+    returns : pd.Series
+        Simple per-bar returns, date-indexed.
+    window  : int, default 50
+        Rolling window length for the volatility scaler.
+
+    Returns
+    -------
+    pd.Series
+        Values in ``[0, 1]``. NaN for the first ``window - 1`` bars or
+        wherever rolling std is zero/NaN.
+    """
+    r = pd.Series(returns, dtype=float)
+    sigma = r.rolling(window, min_periods=window).std(ddof=0)
+    sigma = sigma.replace(0.0, np.nan)
+    z = r / (sigma * np.sqrt(2.0))
+    frac = pd.Series(norm.cdf(z.to_numpy()), index=r.index)
+    frac[z.isna()] = np.nan
+    return frac
+
+
+def vpin(close: pd.Series, volume: pd.Series, window: int = 50) -> pd.Series:
+    """VPIN over a rolling window of daily bars using BVC classification.
+
+    Each bar contributes ``|buy_vol - sell_vol| = |2·buy_frac - 1| · V``.
+    VPIN is the ratio of that order-flow imbalance to total volume over
+    the trailing ``window`` bars — a toxicity / informed-flow proxy.
+
+    Parameters
+    ----------
+    close  : pd.Series
+        Close prices, date-indexed.
+    volume : pd.Series
+        Share volume per bar, date-indexed, aligned with ``close``.
+    window : int, default 50
+        Rolling window length (number of bars per VPIN observation).
+
+    Returns
+    -------
+    pd.Series
+        VPIN in ``[0, 1]``. NaN until ``window`` bars have accumulated.
+    """
+    close = pd.Series(close, dtype=float)
+    volume = pd.Series(volume, dtype=float)
+    returns = close.pct_change()
+    buy_frac = bvc_buy_fraction(returns, window=window)
+
+    imbalance = (2.0 * buy_frac - 1.0).abs() * volume
+    roll_imbalance = imbalance.rolling(window, min_periods=window).sum()
+    roll_volume = volume.rolling(window, min_periods=window).sum()
+    out = roll_imbalance / roll_volume.replace(0.0, np.nan)
+    return out
+
+
+def kyle_lambda(close: pd.Series, volume: pd.Series, window: int = 21) -> pd.Series:
+    """Rolling Kyle's λ from daily OHLCV.
+
+    Estimates the price-impact coefficient ``λ`` via the OLS slope of
+    bar returns on signed dollar-volume over a trailing window::
+
+        q_t = sgn(r_t) · p_t · V_t                 # tick-rule order flow
+        λ   = Cov(r, q) / Var(q)
+
+    Because ``sgn(r_t)`` matches ``sgn(r_t)`` by construction, this
+    recovers ``λ ≈ E[|r|·p·V] / E[(p·V)²]`` — the daily-bar analogue of
+    Kyle's λ (AFML §19.4.3). A larger ``λ`` means a given order flow
+    moves the price more — i.e. lower liquidity.
+
+    Parameters
+    ----------
+    close  : pd.Series
+        Close prices, date-indexed.
+    volume : pd.Series
+        Share volume per bar, date-indexed, aligned with ``close``.
+    window : int, default 21
+        Rolling window (~1 trading month).
+
+    Returns
+    -------
+    pd.Series
+        λ estimates, date-indexed. NaN until ``window`` bars are
+        available or when the regressor has zero variance.
+    """
+    close = pd.Series(close, dtype=float)
+    volume = pd.Series(volume, dtype=float)
+    returns = close.pct_change()
+    signed_dv = np.sign(returns) * volume * close
+
+    cov = returns.rolling(window, min_periods=window).cov(signed_dv)
+    var = signed_dv.rolling(window, min_periods=window).var(ddof=0)
+    out = cov / var.replace(0.0, np.nan)
+    return out

--- a/data/features.py
+++ b/data/features.py
@@ -15,6 +15,8 @@ Input features (cross-sectionally z-scored across tickers per date):
     realised_vol_21d                       — annualised realised volatility (21d)
     vol_ratio_20d                          — Volume / 20-day rolling mean Volume
     vol_zscore_20d                         — (Volume − mean) / std over 20-day window
+    vpin_50d                               — Volume-Synchronized PIN via BVC over 50 bars
+    kyle_lambda_21d                        — Rolling Kyle's λ (price-impact coefficient)
 
 Forward return targets (NOT z-scored; NaN for last n rows of each ticker):
     fwd_ret_1d, fwd_ret_5d, fwd_ret_10d, fwd_ret_21d
@@ -43,6 +45,7 @@ _FEATURE_COLS = [
     "ret_1d", "ret_5d", "ret_10d", "ret_21d",
     "skew_21d", "kurt_21d", "autocorr_1", "realised_vol_21d",
     "vol_ratio_20d", "vol_zscore_20d",
+    "vpin_50d", "kyle_lambda_21d",
 ]
 _FWD_COLS = ["fwd_ret_1d", "fwd_ret_5d", "fwd_ret_10d", "fwd_ret_21d"]
 _TB_LABEL_COLS = ["tb_bin", "tb_ret", "tb_target", "tb_t1"]
@@ -89,6 +92,12 @@ def _single_ticker_features(
     vol_std = volume.rolling(20).std()
     out["vol_ratio_20d"] = volume / vol_mean
     out["vol_zscore_20d"] = (volume - vol_mean) / vol_std.replace(0, np.nan)
+
+    # ── Microstructural features (AFML Ch 19) ─────────────────────────────────
+    from analysis.microstructure import kyle_lambda, vpin
+
+    out["vpin_50d"] = vpin(close, volume, window=50)
+    out["kyle_lambda_21d"] = kyle_lambda(close, volume, window=21)
 
     # ── Forward return labels (shift(-n) so label sits on the entry date) ─────
     for n in (1, 5, 10, 21):

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -183,3 +183,29 @@ def test_realised_vol_is_finite():
 
     valid = fm["realised_vol_21d"].dropna()
     assert np.isfinite(valid).all(), "Z-scored realised vol contains non-finite values"
+
+
+def test_microstructural_columns_present_and_z_scored():
+    """vpin_50d and kyle_lambda_21d appear in the matrix and are cross-sectionally z-scored."""
+    tickers = ["AAPL", "MSFT", "GOOGL", "AMZN", "META"]
+    with patch("data.features.fetch_ohlcv", side_effect=_mock_fetch):
+        fm = build_feature_matrix(tickers, period="2y")
+
+    assert "vpin_50d" in fm.columns
+    assert "kyle_lambda_21d" in fm.columns
+
+    date_counts = fm.groupby(level="date").size()
+    full_dates = date_counts[date_counts == len(tickers)].index
+    if len(full_dates) == 0:
+        pytest.skip("No date with all tickers — skip z-score check")
+
+    sample_date = full_dates[len(full_dates) // 2]
+    group = fm.xs(sample_date, level="date")
+
+    for col in ("vpin_50d", "kyle_lambda_21d"):
+        col_vals = group[col].dropna()
+        if len(col_vals) >= 3:
+            assert abs(col_vals.mean()) < 0.5, (
+                f"Cross-sectional mean of {col} on {sample_date} = {col_vals.mean():.4f}, "
+                "expected near 0 after z-scoring"
+            )

--- a/tests/test_microstructure.py
+++ b/tests/test_microstructure.py
@@ -1,0 +1,126 @@
+"""Tests for analysis/microstructure.py — VPIN and Kyle's lambda."""
+import os
+import sys
+
+import numpy as np
+import pandas as pd
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from analysis.microstructure import bvc_buy_fraction, kyle_lambda, vpin
+
+
+def _index(n: int) -> pd.DatetimeIndex:
+    return pd.date_range("2022-01-01", periods=n, freq="B")
+
+
+# ── bvc_buy_fraction ───────────────────────────────────────────────────────────
+
+def test_bvc_buy_fraction_bounds():
+    np.random.seed(0)
+    rets = pd.Series(np.random.randn(200) * 0.01, index=_index(200))
+    frac = bvc_buy_fraction(rets, window=50)
+    valid = frac.dropna()
+    assert len(valid) > 100
+    assert (valid >= 0.0).all() and (valid <= 1.0).all()
+
+
+def test_bvc_buy_fraction_monotone_in_return():
+    """Larger positive return → larger estimated buy fraction."""
+    np.random.seed(1)
+    rets = pd.Series(np.random.randn(200) * 0.01, index=_index(200))
+    # Replace last bar with a very large positive shock
+    rets.iloc[-1] = 0.10
+    frac = bvc_buy_fraction(rets, window=50)
+    # That bar's fraction should be close to 1 and strictly above the median
+    assert frac.iloc[-1] > frac.dropna().median()
+    assert frac.iloc[-1] > 0.9
+
+
+def test_bvc_buy_fraction_nan_warmup():
+    rets = pd.Series(np.zeros(30), index=_index(30))
+    frac = bvc_buy_fraction(rets, window=50)
+    assert frac.isna().all()
+
+
+# ── vpin ──────────────────────────────────────────────────────────────────────
+
+def test_vpin_in_unit_interval():
+    np.random.seed(2)
+    n = 300
+    close = pd.Series(100 + np.cumsum(np.random.randn(n) * 0.5), index=_index(n))
+    volume = pd.Series(
+        np.random.randint(1_000_000, 5_000_000, n).astype(float), index=_index(n)
+    )
+    out = vpin(close, volume, window=50)
+    valid = out.dropna()
+    assert len(valid) > 100
+    assert (valid >= 0.0).all() and (valid <= 1.0).all()
+
+
+def test_vpin_trending_exceeds_noise():
+    """A strongly trending series has higher VPIN than pure noise."""
+    n = 300
+    idx = _index(n)
+    np.random.seed(3)
+
+    # Trending series: deterministic +0.5 per bar with tiny noise
+    trend_close = pd.Series(100 + 0.5 * np.arange(n) + np.random.randn(n) * 0.05, index=idx)
+    # Noisy series: zero-drift Gaussian walk
+    np.random.seed(4)
+    noise_close = pd.Series(100 + np.cumsum(np.random.randn(n) * 0.5), index=idx)
+
+    vol = pd.Series(1_000_000.0, index=idx)
+
+    v_trend = vpin(trend_close, vol, window=50).dropna().mean()
+    v_noise = vpin(noise_close, vol, window=50).dropna().mean()
+    assert v_trend > v_noise
+
+
+def test_vpin_warmup_is_nan():
+    n = 60
+    close = pd.Series(100 + np.arange(n, dtype=float), index=_index(n))
+    vol = pd.Series(1_000_000.0, index=_index(n))
+    out = vpin(close, vol, window=50)
+    # First (window - 1) + 1 rows involve warmup of pct_change → std → rolling sum
+    assert out.iloc[:50].isna().all()
+
+
+# ── kyle_lambda ───────────────────────────────────────────────────────────────
+
+def test_kyle_lambda_recovers_planted_slope():
+    """Plant r_t = λ · sgn · V · p and verify the rolling estimator recovers λ."""
+    n = 250
+    idx = _index(n)
+    np.random.seed(5)
+    shocks = np.random.choice([-1.0, 1.0], size=n)
+    vol = pd.Series(np.random.uniform(1e5, 1e6, n), index=idx)
+    price = 100.0
+    planted_lambda = 1e-10
+    returns = planted_lambda * shocks * vol.to_numpy() * price
+    close = pd.Series(price * np.cumprod(1.0 + returns), index=idx)
+
+    out = kyle_lambda(close, vol, window=50).dropna()
+    # Estimator should recover a positive λ close to the planted value.
+    assert out.mean() > 0
+    # Within one order of magnitude of the plant.
+    ratio = out.median() / planted_lambda
+    assert 0.1 < ratio < 10.0, f"recovered λ ratio out of range: {ratio}"
+
+
+def test_kyle_lambda_zero_variance_regressor_is_nan():
+    """Constant price (zero returns) → signed_dv identically zero → NaN, not DivByZero."""
+    n = 60
+    close = pd.Series(100.0, index=_index(n))
+    vol = pd.Series(1_000_000.0, index=_index(n))
+    out = kyle_lambda(close, vol, window=21)
+    # No exception; result is all NaN
+    assert out.isna().all()
+
+
+def test_kyle_lambda_warmup_is_nan():
+    n = 30
+    close = pd.Series(100 + np.arange(n, dtype=float), index=_index(n))
+    vol = pd.Series(1_000_000.0, index=_index(n))
+    out = kyle_lambda(close, vol, window=21)
+    assert out.iloc[:20].isna().all()


### PR DESCRIPTION
Adds BVC-based VPIN and a rolling Kyle's lambda estimator in
analysis/microstructure.py, wires them into data/features.py so every
ML strategy that reads _FEATURE_COLS (ml_signal, linear_signal,
bayesian_signal, dl_signal) picks them up automatically, and marks
AFML Chapter 19 complete in ML_BOOK_MAP.md.

The implementation uses daily bars (intraday ticks are not available
via yfinance); AFML Section 19.4.2 recommends Bulk Volume
Classification as the tick-rule-free fallback for VPIN, which is
exactly what bvc_buy_fraction() applies.

https://claude.ai/code/session_01Gu3iR1MKU5D7zCv8HdbuQu