### PR TITLE
feat: Random-Forest long-short alpha strategy (ML4T Ch 11)

### DIFF
--- a/ML_BOOK_MAP.md
+++ b/ML_BOOK_MAP.md
@@ -118,7 +118,7 @@ graph LR
 | 8 — The ML4T Workflow                        | backtest loop                  |   ✅   | `backtester/engine.py:run_signal_backtest`                      |
 | 9 — Time-Series Models                       | GARCH, cointegration           |   ✅   | `analysis/garch.py` (fit_garch) + `analysis/cointegration.py` (engle_granger, screen_cointegrated_pairs) |
 | 10 — Bayesian ML                             | Bayesian linear regression     |   ✅   | `strategies/bayesian_signal.py` (BayesianRidge + predict_with_uncertainty) |
-| 11 — Random Forests                          | long-short strategies          |   🟡   | used internally by `meta_label.py`; no dedicated strategy       |
+| 11 — Random Forests                          | long-short strategies          |   ✅   | `strategies/rf_long_short.py` (RFLongShortSignal + long_short_portfolio) |
 | 12 — Boosting                                | LightGBM / XGBoost             |   ✅   | `strategies/ml_signal.py`                                       |
 | 13 — Unsupervised Learning                   | PCA, k-means, risk factors     |   ✅   | `analysis/unsupervised.py` (PCA loadings + scree; k-means on corr-distance) |
 | 14 — Text Data / Sentiment Analysis          | Vader, VADER                   |   ✅   | `adapters/sentiment/vader_adapter.py`                           |

--- a/strategies/rf_long_short.py
+++ b/strategies/rf_long_short.py
@@ -1,0 +1,274 @@
+"""
+strategies/rf_long_short.py — Random-Forest cross-sectional long-short alpha.
+
+Implements the long-short trading strategy from Jansen, *Machine Learning
+for Algorithmic Trading* (2nd ed.) Chapter 11: predict forward returns
+with a RandomForestRegressor over the same engineered feature matrix
+used by ml_signal/linear_signal, then form a portfolio that goes long
+the top-quantile names and short the bottom-quantile names.
+
+Same public surface as MLSignal / LinearSignal: ``train()``, ``predict()``,
+plus an extra :meth:`long_short_portfolio` helper that turns the
+per-ticker alpha scores into ±1 / 0 cross-sectional weights.
+
+ENV vars
+--------
+    RF_LS_MODEL_PATH      path to model pickle (default: models/rf_long_short.pkl)
+"""
+from __future__ import annotations
+
+import os
+import pickle
+import time
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+from analysis.factor_ic import _spearman_corr
+from data.features import _FEATURE_COLS, build_feature_matrix
+from utils.logger import get_logger
+
+log = get_logger(__name__)
+
+# ── Optional scikit-learn import ──────────────────────────────────────────────
+try:
+    from sklearn.ensemble import RandomForestRegressor
+    _SKLEARN_AVAILABLE = True
+except ImportError:
+    RandomForestRegressor = None  # type: ignore[assignment,misc]
+    _SKLEARN_AVAILABLE = False
+
+_DEFAULT_MODEL_PATH = os.environ.get("RF_LS_MODEL_PATH", "models/rf_long_short.pkl")
+_TARGET_COL = "fwd_ret_5d"
+
+
+class RFLongShortSignal:
+    """Random-Forest regressor + cross-sectional long-short portfolio builder."""
+
+    def __init__(self, model_path: str | None = None) -> None:
+        self._model_path: str = model_path or _DEFAULT_MODEL_PATH
+        self._model = None  # RandomForestRegressor | None
+        self._feature_cols: list[str] = list(_FEATURE_COLS)
+        self._load_if_available()
+
+    # ── Model loading ─────────────────────────────────────────────────────────
+
+    def _load_if_available(self) -> None:
+        path = Path(self._model_path)
+        if not path.exists():
+            log.info("rf_long_short: no checkpoint found", path=str(path))
+            return
+        try:
+            with open(path, "rb") as f:
+                self._model = pickle.load(f)
+            log.info("rf_long_short: loaded checkpoint", path=str(path))
+        except Exception as exc:
+            log.warning("rf_long_short: failed to load checkpoint", path=str(path), error=str(exc))
+
+    # ── Training ──────────────────────────────────────────────────────────────
+
+    def train(
+        self,
+        tickers: list[str],
+        period: str = "2y",
+        test_size: float = 0.2,
+        n_estimators: int = 200,
+        max_depth: int | None = 6,
+        random_state: int = 42,
+    ) -> dict[str, float]:
+        """Fit a RandomForestRegressor on the cross-sectional feature matrix.
+
+        Parameters mirror :class:`strategies.linear_signal.LinearSignal.train`
+        except for the RF-specific ``n_estimators``, ``max_depth``,
+        ``random_state``. Returns a dict with train/test IC + ICIR + sample
+        counts.
+        """
+        if not _SKLEARN_AVAILABLE:
+            raise RuntimeError(
+                "scikit-learn is not installed. Run: pip install scikit-learn>=1.3.0"
+            )
+
+        log.info("rf_long_short: building feature matrix", tickers=len(tickers), period=period)
+        fm = build_feature_matrix(tickers, period=period)
+        if fm.empty:
+            raise ValueError("Feature matrix is empty — check tickers and period")
+
+        fm = fm.dropna(subset=[_TARGET_COL])
+        if fm.empty:
+            raise ValueError(f"No rows with non-NaN target '{_TARGET_COL}'")
+
+        all_dates = sorted(fm.index.get_level_values("date").unique())
+        split_idx = int(len(all_dates) * (1 - test_size))
+        train_dates = set(all_dates[:split_idx])
+        test_dates = set(all_dates[split_idx:])
+
+        feature_cols = [c for c in _FEATURE_COLS if c in fm.columns]
+        self._feature_cols = feature_cols
+
+        train_df = fm[fm.index.get_level_values("date").isin(train_dates)]
+        test_df = fm[fm.index.get_level_values("date").isin(test_dates)]
+
+        X_train = train_df[feature_cols].fillna(0.0).values
+        y_train = train_df[_TARGET_COL].values
+        X_test = test_df[feature_cols].fillna(0.0).values
+        y_test = test_df[_TARGET_COL].values
+
+        log.info(
+            "rf_long_short: training RandomForest",
+            n_train=len(X_train), n_test=len(X_test),
+            features=len(feature_cols), n_estimators=n_estimators, max_depth=max_depth,
+        )
+
+        model = RandomForestRegressor(
+            n_estimators=n_estimators,
+            max_depth=max_depth,
+            random_state=random_state,
+            n_jobs=-1,
+        )
+        model.fit(X_train, y_train)
+        self._model = model
+
+        train_ic = _spearman_corr(model.predict(X_train), y_train)
+        test_ic = _spearman_corr(model.predict(X_test), y_test)
+
+        Path(self._model_path).parent.mkdir(parents=True, exist_ok=True)
+        with open(self._model_path, "wb") as f:
+            pickle.dump(model, f)
+        log.info(
+            "rf_long_short: training complete",
+            train_ic=round(train_ic, 4), test_ic=round(test_ic, 4), path=self._model_path,
+        )
+
+        self._write_metadata(
+            n_tickers=len(tickers), period=period,
+            train_ic=train_ic, test_ic=test_ic,
+        )
+
+        return {
+            "train_ic": float(train_ic),
+            "test_ic": float(test_ic),
+            "train_icir": float(train_ic),
+            "test_icir": float(test_ic),
+            "n_train_samples": int(len(X_train)),
+            "n_test_samples": int(len(X_test)),
+        }
+
+    # ── Prediction ────────────────────────────────────────────────────────────
+
+    def predict(self, tickers: list[str], period: str = "6mo") -> dict[str, float]:
+        """Per-ticker alpha scores in ``[-1, 1]`` for the latest date."""
+        if self._model is None:
+            return self._momentum_fallback(tickers, period)
+
+        try:
+            fm = build_feature_matrix(tickers, period=period)
+            if fm.empty:
+                return self._momentum_fallback(tickers, period)
+
+            feature_cols = [c for c in self._feature_cols if c in fm.columns]
+            last_date = fm.index.get_level_values("date").max()
+            latest = fm.xs(last_date, level="date")[feature_cols].fillna(0.0)
+            if latest.empty:
+                return self._momentum_fallback(tickers, period)
+
+            raw = self._model.predict(latest.values)
+            std = raw.std()
+            scores = np.zeros_like(raw) if std == 0 else (raw - raw.mean()) / std
+            scores = np.clip(scores, -1.0, 1.0)
+            return {ticker: float(scores[i]) for i, ticker in enumerate(latest.index)}
+        except Exception as exc:
+            log.warning("rf_long_short.predict: error, falling back to momentum", error=str(exc))
+            return self._momentum_fallback(tickers, period)
+
+    # ── Long-short portfolio (Ch 11 specialty) ────────────────────────────────
+
+    def long_short_portfolio(
+        self,
+        tickers: list[str],
+        period: str = "6mo",
+        top_pct: float = 0.2,
+    ) -> dict[str, int]:
+        """Return ``+1`` (long), ``-1`` (short), ``0`` (flat) per ticker.
+
+        Cross-sectional dollar-neutral construction: long the top
+        ``top_pct`` of tickers by predicted score, short the bottom
+        ``top_pct``, flat on the rest. ``top_pct`` is clipped to
+        ``(0, 0.5]``.
+        """
+        top_pct = max(min(float(top_pct), 0.5), 1e-6)
+        scores = self.predict(tickers, period=period)
+        if not scores:
+            return {t: 0 for t in tickers}
+
+        ordered = sorted(scores.items(), key=lambda kv: kv[1], reverse=True)
+        n = len(ordered)
+        k = max(1, int(round(n * top_pct)))
+
+        weights: dict[str, int] = {t: 0 for t in scores}
+        for ticker, _ in ordered[:k]:
+            weights[ticker] = 1
+        for ticker, _ in ordered[-k:]:
+            # Avoid double-assigning a single-ticker universe to both legs
+            if weights[ticker] == 0:
+                weights[ticker] = -1
+        return weights
+
+    # ── Fallback & metadata (unchanged from sibling strategies) ───────────────
+
+    @staticmethod
+    def _momentum_fallback(tickers: list[str], period: str) -> dict[str, float]:
+        from data.fetcher import fetch_ohlcv
+        from strategies.momentum import compute_momentum_score
+
+        scores: dict[str, float] = {}
+        for ticker in tickers:
+            try:
+                df = fetch_ohlcv(ticker, period)
+                if df is not None and not df.empty:
+                    mom = compute_momentum_score(df)
+                    last_val = mom.dropna().iloc[-1] if not mom.dropna().empty else 0.0
+                    scores[ticker] = float(np.clip(last_val, -1.0, 1.0))
+                else:
+                    scores[ticker] = 0.0
+            except Exception:
+                scores[ticker] = 0.0
+        return scores
+
+    def feature_importances(self) -> pd.DataFrame:
+        """RF feature importances sorted descending (empty if no model)."""
+        if self._model is None:
+            return pd.DataFrame(columns=["feature", "importance"])
+        try:
+            imp = self._model.feature_importances_
+            df = pd.DataFrame({
+                "feature": self._feature_cols[:len(imp)],
+                "importance": imp,
+            })
+            return df.sort_values("importance", ascending=False).reset_index(drop=True)
+        except Exception as exc:
+            log.warning("rf_long_short.feature_importances: error", error=str(exc))
+            return pd.DataFrame(columns=["feature", "importance"])
+
+    def _write_metadata(
+        self,
+        n_tickers: int,
+        period: str,
+        train_ic: float,
+        test_ic: float,
+    ) -> None:
+        try:
+            from data.db import get_connection
+            conn = get_connection()
+            with conn:
+                conn.execute(
+                    """
+                    INSERT INTO model_metadata
+                        (model_name, trained_at, train_ic, test_ic, n_tickers, period)
+                    VALUES (?, ?, ?, ?, ?, ?)
+                    """,
+                    ("rf_long_short", time.time(), train_ic, test_ic, n_tickers, period),
+                )
+            conn.close()
+        except Exception as exc:
+            log.warning("rf_long_short: could not write metadata", error=str(exc))

--- a/tests/test_rf_long_short.py
+++ b/tests/test_rf_long_short.py
@@ -1,0 +1,205 @@
+"""Tests for strategies/rf_long_short.py — Random-Forest long-short alpha."""
+from __future__ import annotations
+
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pandas as pd
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+
+def _make_feature_matrix(n_dates: int = 40, tickers: list[str] | None = None) -> pd.DataFrame:
+    if tickers is None:
+        tickers = ["AAPL", "MSFT"]
+    dates = pd.date_range("2023-01-01", periods=n_dates, freq="B")
+    feature_cols = [
+        "ret_1d", "ret_5d", "ret_10d", "ret_21d",
+        "skew_21d", "kurt_21d", "autocorr_1", "realised_vol_21d",
+        "vol_ratio_20d", "vol_zscore_20d",
+        "vpin_50d", "kyle_lambda_21d",
+    ]
+    rng = np.random.default_rng(42)
+    rows, idx = [], []
+    for date in dates:
+        for ticker in tickers:
+            row = dict(zip(feature_cols, rng.standard_normal(len(feature_cols))))
+            row["fwd_ret_5d"] = rng.standard_normal()
+            rows.append(row)
+            idx.append((date, ticker))
+    mi = pd.MultiIndex.from_tuples(idx, names=["date", "ticker"])
+    return pd.DataFrame(rows, index=mi)
+
+
+def _make_mock_rf(n_features: int = 12):
+    mock = MagicMock()
+    mock.feature_importances_ = np.linspace(0.3, 0.01, n_features)
+    mock.predict.side_effect = lambda X: np.random.default_rng(0).standard_normal(len(X))
+    return mock
+
+
+# ── No-model tests ────────────────────────────────────────────────────────────
+
+def test_feature_importances_empty_without_model():
+    from strategies.rf_long_short import RFLongShortSignal
+    with patch("strategies.rf_long_short.RFLongShortSignal._load_if_available"):
+        model = RFLongShortSignal(model_path="/nonexistent.pkl")
+    df = model.feature_importances()
+    assert df.empty
+    assert list(df.columns) == ["feature", "importance"]
+
+
+def test_predict_no_model_falls_back_to_momentum():
+    from strategies.rf_long_short import RFLongShortSignal
+    with (
+        patch("strategies.rf_long_short.RFLongShortSignal._load_if_available"),
+        patch(
+            "strategies.rf_long_short.RFLongShortSignal._momentum_fallback",
+            return_value={"AAPL": 0.5},
+        ) as mock_fb,
+    ):
+        model = RFLongShortSignal(model_path="/nonexistent.pkl")
+        result = model.predict(["AAPL"], period="6mo")
+    mock_fb.assert_called_once()
+    assert result == {"AAPL": 0.5}
+
+
+def test_train_raises_when_sklearn_missing():
+    from strategies.rf_long_short import RFLongShortSignal
+    with (
+        patch("strategies.rf_long_short._SKLEARN_AVAILABLE", False),
+        patch("strategies.rf_long_short.RFLongShortSignal._load_if_available"),
+    ):
+        model = RFLongShortSignal(model_path="/tmp/x.pkl")
+        with pytest.raises(RuntimeError, match="scikit-learn"):
+            model.train(["AAPL"])
+
+
+# ── Tests using mocked RF (no sklearn required at runtime) ────────────────────
+
+def test_train_returns_metrics_with_mocked_rf():
+    fm = _make_feature_matrix()
+    mock_rf = _make_mock_rf()
+    with (
+        patch("strategies.rf_long_short._SKLEARN_AVAILABLE", True),
+        patch("strategies.rf_long_short.RandomForestRegressor", return_value=mock_rf),
+        patch("strategies.rf_long_short.build_feature_matrix", return_value=fm),
+        patch("strategies.rf_long_short.RFLongShortSignal._load_if_available"),
+        patch("strategies.rf_long_short.RFLongShortSignal._write_metadata"),
+        patch("builtins.open", MagicMock()),
+        patch("strategies.rf_long_short.pickle.dump"),
+        patch("strategies.rf_long_short.Path.mkdir"),
+    ):
+        from strategies.rf_long_short import RFLongShortSignal
+        model = RFLongShortSignal(model_path="models/test_rf.pkl")
+        result = model.train(["AAPL", "MSFT"], period="2y")
+
+    for key in ("train_ic", "test_ic", "train_icir", "test_icir",
+                "n_train_samples", "n_test_samples"):
+        assert key in result
+    assert result["n_train_samples"] > 0
+    assert result["n_test_samples"] > 0
+
+
+def test_predict_scores_in_range_with_mocked_rf():
+    fm = _make_feature_matrix(tickers=["AAPL", "MSFT", "GOOG"])
+    mock_rf = _make_mock_rf()
+    with (
+        patch("strategies.rf_long_short._SKLEARN_AVAILABLE", True),
+        patch("strategies.rf_long_short.RandomForestRegressor", return_value=mock_rf),
+        patch("strategies.rf_long_short.build_feature_matrix", return_value=fm),
+        patch("strategies.rf_long_short.RFLongShortSignal._load_if_available"),
+        patch("strategies.rf_long_short.RFLongShortSignal._write_metadata"),
+        patch("builtins.open", MagicMock()),
+        patch("strategies.rf_long_short.pickle.dump"),
+        patch("strategies.rf_long_short.Path.mkdir"),
+    ):
+        from strategies.rf_long_short import RFLongShortSignal
+        model = RFLongShortSignal(model_path="models/test_rf.pkl")
+        model.train(["AAPL", "MSFT", "GOOG"], period="2y")
+        scores = model.predict(["AAPL", "MSFT", "GOOG"], period="6mo")
+
+    assert set(scores.keys()) == {"AAPL", "MSFT", "GOOG"}
+    for v in scores.values():
+        assert -1.0 <= v <= 1.0
+
+
+def test_feature_importances_sorted_descending():
+    mock_rf = _make_mock_rf()
+    with patch("strategies.rf_long_short.RFLongShortSignal._load_if_available"):
+        from strategies.rf_long_short import RFLongShortSignal
+        model = RFLongShortSignal(model_path="/tmp/x.pkl")
+        model._model = mock_rf
+
+    df = model.feature_importances()
+    assert list(df.columns) == ["feature", "importance"]
+    imps = df["importance"].tolist()
+    assert imps == sorted(imps, reverse=True)
+
+
+# ── long_short_portfolio ──────────────────────────────────────────────────────
+
+def test_long_short_portfolio_dollar_neutral_top_quintile():
+    from strategies.rf_long_short import RFLongShortSignal
+    with patch("strategies.rf_long_short.RFLongShortSignal._load_if_available"):
+        model = RFLongShortSignal(model_path="/tmp/x.pkl")
+
+    # 10 tickers with monotonically increasing scores
+    scores = {f"T{i}": float(i) for i in range(10)}
+    with patch.object(model, "predict", return_value=scores):
+        weights = model.long_short_portfolio(list(scores), top_pct=0.2)
+
+    # 2 longs (top), 2 shorts (bottom), 6 flat
+    longs = [t for t, w in weights.items() if w == 1]
+    shorts = [t for t, w in weights.items() if w == -1]
+    flats = [t for t, w in weights.items() if w == 0]
+    assert sorted(longs) == ["T8", "T9"]
+    assert sorted(shorts) == ["T0", "T1"]
+    assert len(flats) == 6
+
+
+def test_long_short_portfolio_empty_scores_returns_zero_weights():
+    from strategies.rf_long_short import RFLongShortSignal
+    with patch("strategies.rf_long_short.RFLongShortSignal._load_if_available"):
+        model = RFLongShortSignal(model_path="/tmp/x.pkl")
+
+    with patch.object(model, "predict", return_value={}):
+        weights = model.long_short_portfolio(["AAPL", "MSFT"], top_pct=0.2)
+    assert weights == {"AAPL": 0, "MSFT": 0}
+
+
+def test_long_short_portfolio_top_pct_clipped_to_half():
+    """top_pct > 0.5 should not split a 10-ticker universe into 11 picks each side."""
+    from strategies.rf_long_short import RFLongShortSignal
+    with patch("strategies.rf_long_short.RFLongShortSignal._load_if_available"):
+        model = RFLongShortSignal(model_path="/tmp/x.pkl")
+
+    scores = {f"T{i}": float(i) for i in range(10)}
+    with patch.object(model, "predict", return_value=scores):
+        weights = model.long_short_portfolio(list(scores), top_pct=0.99)
+
+    longs = sum(1 for w in weights.values() if w == 1)
+    shorts = sum(1 for w in weights.values() if w == -1)
+    assert longs <= 5 and shorts <= 5
+
+
+# ── Persistence ───────────────────────────────────────────────────────────────
+
+def test_load_if_available_corrupt_file_does_not_raise(tmp_path):
+    bad = tmp_path / "bad.pkl"
+    bad.write_bytes(b"not_a_pickle")
+    from strategies.rf_long_short import RFLongShortSignal
+    model = RFLongShortSignal(model_path=str(bad))
+    assert model._model is None
+
+
+def test_write_metadata_silences_db_errors():
+    from strategies.rf_long_short import RFLongShortSignal
+    with patch("strategies.rf_long_short.RFLongShortSignal._load_if_available"):
+        model = RFLongShortSignal(model_path="/tmp/x.pkl")
+    with patch("data.db.get_connection", side_effect=RuntimeError("no db")):
+        # Must not raise
+        model._write_metadata(n_tickers=3, period="2y", train_ic=0.1, test_ic=0.05)


### PR DESCRIPTION
## Summary
- New `strategies/rf_long_short.py` — `RFLongShortSignal` wrapping `sklearn.ensemble.RandomForestRegressor` over the shared `data/features.py` matrix, with the same `train()` / `predict()` surface as `LinearSignal` / `MLSignal`.
- Adds a `long_short_portfolio(tickers, top_pct=0.2)` helper returning `+1` / `-1` / `0` cross-sectional weights — the long-short construction Jansen Ch 11 highlights.
- Marks ML4T Ch 11 ✅ in `ML_BOOK_MAP.md` (was 🟡, "used internally by meta_label.py").

## Test plan
- [x] 11 new tests in `tests/test_rf_long_short.py` covering: missing-sklearn guard, momentum fallback when no model, mocked-RF training metrics, mocked-RF predictions in `[-1, 1]`, sorted feature importances, top-quintile long-short selection, `top_pct` clamping, empty scores, corrupt-pickle resilience, and silenced DB metadata errors.
- [x] `ruff check .` clean
- [x] `bandit -ll` clean (only the same Medium-severity `pickle.load` advisory as `linear_signal.py`)

https://claude.ai/code/session_01Gu3iR1MKU5D7zCv8HdbuQu