### PR TITLE
feat: LDA topic modeling on text corpora (ML4T Ch 15)

### DIFF
--- a/ML_BOOK_MAP.md
+++ b/ML_BOOK_MAP.md
@@ -122,7 +122,7 @@ graph LR
 | 12 — Boosting                                | LightGBM / XGBoost             |   ✅   | `strategies/ml_signal.py`                                       |
 | 13 — Unsupervised Learning                   | PCA, k-means, risk factors     |   ✅   | `analysis/unsupervised.py` (PCA loadings + scree; k-means on corr-distance) |
 | 14 — Text Data / Sentiment Analysis          | Vader, VADER                   |   ✅   | `adapters/sentiment/vader_adapter.py`                           |
-| 15 — Topic Modeling                          | LDA on news                    |   🟡   | sentiment blend integrated via `strategies/sentiment_signal.py`; LDA topic modeling still planned |
+| 15 — Topic Modeling                          | LDA on news                    |   ✅   | `analysis/topic_modeling.py` (fit_lda + infer_topics + top_terms_per_topic + ticker_topic_distribution) |
 | 16 — Word Embeddings                         | word2vec on filings            |   ⏳   | _planned_ — see issue "Word embeddings on filings"              |
 | 17 — Deep Learning for Trading               | Keras / PyTorch intro          |   🟡   | `strategies/dl_signal.py` LSTM alpha (torch-gated); full DL workflow partial |
 | 18 — CNNs                                    | image / chart patterns         |   ⏳   | _planned_ — CNN chart patterns not yet implemented              |

--- a/analysis/topic_modeling.py
+++ b/analysis/topic_modeling.py
@@ -1,0 +1,201 @@
+"""
+analysis/topic_modeling.py — Latent Dirichlet Allocation on text corpora.
+
+Implements the topic-modelling pipeline from Jansen, *Machine Learning
+for Algorithmic Trading* (2nd ed.) Chapter 15: build a bag-of-words
+representation of a news / filing corpus, fit ``LatentDirichletAllocation``
+over a small number of topics, and project new documents onto that
+topic basis.  Per-ticker topic distributions become alpha features
+(or sentiment-blender inputs) without dragging in heavy NLP deps —
+``sklearn`` is already pinned in ``requirements.txt``.
+
+Public surface
+--------------
+``LDAResult``                — dataclass bundling the fitted vectorizer + LDA
+``fit_lda(docs, n_topics)``  — train on a corpus
+``infer_topics(result, docs)`` — project documents to topic-distribution rows
+``top_terms_per_topic(result, n)`` — interpretability helper
+``ticker_topic_distribution(result, docs_by_ticker)`` — per-ticker feature row
+
+Reference
+---------
+    Jansen, *Machine Learning for Algorithmic Trading* (2nd ed.) Ch 15.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Mapping, Sequence
+
+import numpy as np
+
+from utils.logger import get_logger
+
+log = get_logger(__name__)
+
+try:
+    from sklearn.decomposition import LatentDirichletAllocation
+    from sklearn.feature_extraction.text import CountVectorizer
+    _SKLEARN_AVAILABLE = True
+except ImportError:
+    LatentDirichletAllocation = None  # type: ignore[assignment,misc]
+    CountVectorizer = None  # type: ignore[assignment,misc]
+    _SKLEARN_AVAILABLE = False
+
+
+@dataclass(frozen=True)
+class LDAResult:
+    """Fitted LDA artefacts.  Keep ``vectorizer`` and ``model`` together
+    so :func:`infer_topics` can apply the same vocabulary to new docs."""
+
+    vectorizer: object   # CountVectorizer
+    model: object        # LatentDirichletAllocation
+    n_topics: int
+
+
+def _require_sklearn() -> None:
+    if not _SKLEARN_AVAILABLE:
+        raise RuntimeError(
+            "scikit-learn is not installed. Run: pip install scikit-learn>=1.3.0"
+        )
+
+
+def fit_lda(
+    documents: Sequence[str],
+    n_topics: int = 10,
+    max_features: int = 5000,
+    min_df: int = 2,
+    max_df: float = 0.95,
+    random_state: int = 42,
+    max_iter: int = 20,
+) -> LDAResult:
+    """Fit an LDA model over a bag-of-words representation of ``documents``.
+
+    Parameters
+    ----------
+    documents :
+        Iterable of raw text documents (one per news item / filing /
+        ticker-day, depending on the caller's granularity).
+    n_topics :
+        Number of latent topics to learn.
+    max_features :
+        Vocabulary size cap passed to :class:`CountVectorizer`.
+    min_df, max_df :
+        Document-frequency bounds for vocabulary pruning.
+    random_state, max_iter :
+        Forwarded to :class:`LatentDirichletAllocation`.
+
+    Returns
+    -------
+    :class:`LDAResult` containing the fitted vectorizer + model.
+
+    Raises
+    ------
+    ValueError
+        If ``documents`` is empty or the vocabulary collapses to nothing
+        after pruning (e.g. all-stopword corpus).
+    """
+    _require_sklearn()
+
+    docs = [d for d in documents if d and d.strip()]
+    if not docs:
+        raise ValueError("fit_lda: no non-empty documents")
+
+    vectorizer = CountVectorizer(
+        max_features=max_features,
+        min_df=min_df,
+        max_df=max_df,
+        stop_words="english",
+    )
+    try:
+        X = vectorizer.fit_transform(docs)
+    except ValueError as exc:
+        raise ValueError(f"fit_lda: vectorisation failed ({exc})") from exc
+
+    if X.shape[1] == 0:
+        raise ValueError("fit_lda: empty vocabulary after pruning")
+
+    model = LatentDirichletAllocation(
+        n_components=int(n_topics),
+        random_state=random_state,
+        max_iter=max_iter,
+        learning_method="batch",
+    )
+    model.fit(X)
+
+    log.info(
+        "topic_modeling.fit_lda complete",
+        n_docs=len(docs), vocab=X.shape[1], n_topics=n_topics,
+    )
+    return LDAResult(vectorizer=vectorizer, model=model, n_topics=int(n_topics))
+
+
+def infer_topics(result: LDAResult, documents: Sequence[str]) -> np.ndarray:
+    """Project ``documents`` onto the fitted topic basis.
+
+    Returns a ``(len(documents), n_topics)`` array whose rows sum to
+    ``1`` (LDA topic distributions). Empty / whitespace-only documents
+    yield a uniform ``1/n_topics`` row so callers always get a row per
+    input.
+    """
+    _require_sklearn()
+    if not documents:
+        return np.zeros((0, result.n_topics), dtype=float)
+
+    cleaned: list[str] = []
+    placeholder_idx: list[int] = []
+    for i, d in enumerate(documents):
+        if d and d.strip():
+            cleaned.append(d)
+        else:
+            placeholder_idx.append(i)
+            cleaned.append("")  # keep positional alignment
+
+    out = np.full((len(documents), result.n_topics),
+                  fill_value=1.0 / result.n_topics, dtype=float)
+
+    real_idx = [i for i in range(len(documents)) if i not in set(placeholder_idx)]
+    if real_idx:
+        X = result.vectorizer.transform([cleaned[i] for i in real_idx])
+        if X.nnz == 0:
+            # No known vocabulary at all → leave uniform rows.
+            return out
+        scores = result.model.transform(X)  # already row-normalised
+        for k, i in enumerate(real_idx):
+            out[i] = scores[k]
+    return out
+
+
+def top_terms_per_topic(result: LDAResult, n: int = 10) -> list[list[str]]:
+    """Return the ``n`` highest-weight vocabulary terms for each topic.
+
+    Useful for human-readable topic labels / dashboard tooltips.
+    """
+    _require_sklearn()
+    vocab = np.array(result.vectorizer.get_feature_names_out())
+    components = np.asarray(result.model.components_)
+    out: list[list[str]] = []
+    for row in components:
+        idx = np.argsort(row)[::-1][:n]
+        out.append([str(t) for t in vocab[idx]])
+    return out
+
+
+def ticker_topic_distribution(
+    result: LDAResult,
+    docs_by_ticker: Mapping[str, Sequence[str]],
+) -> dict[str, np.ndarray]:
+    """Aggregate per-ticker topic exposure.
+
+    For each ticker the per-document topic distributions are averaged
+    into a single ``(n_topics,)`` vector summing to ``1``. Tickers with
+    no usable documents get a uniform ``1/n_topics`` row.
+    """
+    out: dict[str, np.ndarray] = {}
+    uniform = np.full(result.n_topics, 1.0 / result.n_topics)
+    for ticker, docs in docs_by_ticker.items():
+        if not docs:
+            out[ticker] = uniform.copy()
+            continue
+        per_doc = infer_topics(result, list(docs))
+        out[ticker] = per_doc.mean(axis=0) if per_doc.size else uniform.copy()
+    return out

--- a/tests/test_topic_modeling.py
+++ b/tests/test_topic_modeling.py
@@ -1,0 +1,139 @@
+"""Tests for analysis/topic_modeling.py — LDA over text corpora."""
+from __future__ import annotations
+
+import os
+import sys
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+try:
+    import sklearn  # noqa: F401
+    _SKLEARN = True
+except ImportError:
+    _SKLEARN = False
+
+skip_no_sklearn = pytest.mark.skipif(not _SKLEARN, reason="scikit-learn not installed")
+
+
+# Two clearly-separable topic clusters so LDA can recover them.
+_FINANCE_DOCS = [
+    "earnings revenue profit margin shareholders dividend",
+    "balance sheet revenue earnings shareholders",
+    "guidance dividend profit revenue cash flow",
+    "earnings beat revenue forecast guidance",
+    "dividend payout shareholders profit margin",
+]
+_TECH_DOCS = [
+    "machine learning neural network gpu training",
+    "deep learning gpu training inference model",
+    "transformer architecture attention training inference",
+    "neural network gpu inference model deployment",
+    "machine learning model training deployment pipeline",
+]
+_CORPUS = _FINANCE_DOCS + _TECH_DOCS
+
+
+# ── Guard against missing sklearn ─────────────────────────────────────────────
+
+def test_fit_lda_raises_without_sklearn():
+    from analysis import topic_modeling
+    with patch("analysis.topic_modeling._SKLEARN_AVAILABLE", False):
+        with pytest.raises(RuntimeError, match="scikit-learn"):
+            topic_modeling.fit_lda(["hello world"], n_topics=2)
+
+
+def test_fit_lda_rejects_empty_corpus():
+    from analysis.topic_modeling import fit_lda
+    if not _SKLEARN:
+        pytest.skip("sklearn not installed")
+    with pytest.raises(ValueError, match="non-empty"):
+        fit_lda([], n_topics=2)
+    with pytest.raises(ValueError, match="non-empty"):
+        fit_lda(["", "  ", "\n"], n_topics=2)
+
+
+# ── Happy-path LDA ────────────────────────────────────────────────────────────
+
+@skip_no_sklearn
+def test_fit_and_infer_topic_distributions_sum_to_one():
+    from analysis.topic_modeling import fit_lda, infer_topics
+    result = fit_lda(_CORPUS, n_topics=2, min_df=1)
+    dists = infer_topics(result, _CORPUS)
+    assert dists.shape == (len(_CORPUS), 2)
+    np.testing.assert_allclose(dists.sum(axis=1), np.ones(len(_CORPUS)), atol=1e-6)
+
+
+@skip_no_sklearn
+def test_lda_separates_two_obvious_topic_clusters():
+    """With finance vs. tech corpora and n_topics=2, each cluster should
+    concentrate mass on a different topic."""
+    from analysis.topic_modeling import fit_lda, infer_topics
+    result = fit_lda(_CORPUS, n_topics=2, min_df=1)
+    fin = infer_topics(result, _FINANCE_DOCS)
+    tech = infer_topics(result, _TECH_DOCS)
+    # Finance docs should agree on a dominant topic; tech docs should agree on the OTHER topic.
+    fin_topic = int(np.argmax(fin.mean(axis=0)))
+    tech_topic = int(np.argmax(tech.mean(axis=0)))
+    assert fin_topic != tech_topic
+
+
+@skip_no_sklearn
+def test_top_terms_per_topic_returns_known_terms():
+    from analysis.topic_modeling import fit_lda, top_terms_per_topic
+    result = fit_lda(_CORPUS, n_topics=2, min_df=1)
+    top = top_terms_per_topic(result, n=5)
+    assert len(top) == 2
+    flat = {t for topic in top for t in topic}
+    # Some recognisable corpus terms should make it into the top lists.
+    assert flat & {"revenue", "earnings", "dividend",
+                   "training", "model", "neural", "inference"}
+
+
+@skip_no_sklearn
+def test_infer_topics_empty_input_returns_empty_matrix():
+    from analysis.topic_modeling import fit_lda, infer_topics
+    result = fit_lda(_CORPUS, n_topics=3, min_df=1)
+    out = infer_topics(result, [])
+    assert out.shape == (0, 3)
+
+
+@skip_no_sklearn
+def test_infer_topics_blank_documents_get_uniform_row():
+    from analysis.topic_modeling import fit_lda, infer_topics
+    result = fit_lda(_CORPUS, n_topics=4, min_df=1)
+    out = infer_topics(result, ["", "   "])
+    np.testing.assert_allclose(out, np.full((2, 4), 0.25))
+
+
+@skip_no_sklearn
+def test_infer_topics_all_oov_returns_uniform():
+    """A document whose tokens are entirely out-of-vocabulary should not
+    crash; it just yields the uniform fallback."""
+    from analysis.topic_modeling import fit_lda, infer_topics
+    result = fit_lda(_CORPUS, n_topics=3, min_df=1)
+    out = infer_topics(result, ["zyzzyx qqqqqq"])
+    # nnz == 0 path → entire row stays at uniform 1/3.
+    np.testing.assert_allclose(out, np.full((1, 3), 1.0 / 3.0))
+
+
+@skip_no_sklearn
+def test_ticker_topic_distribution_averages_per_ticker():
+    from analysis.topic_modeling import fit_lda, ticker_topic_distribution
+    result = fit_lda(_CORPUS, n_topics=2, min_df=1)
+    dist = ticker_topic_distribution(result, {
+        "FIN": _FINANCE_DOCS,
+        "TECH": _TECH_DOCS,
+        "EMPTY": [],
+    })
+    assert set(dist) == {"FIN", "TECH", "EMPTY"}
+    for vec in dist.values():
+        assert vec.shape == (2,)
+        np.testing.assert_allclose(vec.sum(), 1.0, atol=1e-6)
+    # Empty bucket falls back to uniform.
+    np.testing.assert_allclose(dist["EMPTY"], np.array([0.5, 0.5]))
+    # FIN and TECH should differ in their dominant topic.
+    assert int(np.argmax(dist["FIN"])) != int(np.argmax(dist["TECH"]))


### PR DESCRIPTION
## Summary
- New `analysis/topic_modeling.py`: thin wrapper over `sklearn.feature_extraction.text.CountVectorizer` + `sklearn.decomposition.LatentDirichletAllocation` providing a typed `LDAResult` plus `fit_lda`, `infer_topics`, `top_terms_per_topic`, and `ticker_topic_distribution`.
- `ticker_topic_distribution` produces an `(n_topics,)` per-ticker feature vector ready to feed into the existing sentiment / blender pipeline once a real corpus path is wired up.
- Marks ML4T Ch 15 ✅ in `ML_BOOK_MAP.md` (was 🟡).

## Test plan
- [x] 9 tests in `tests/test_topic_modeling.py`: missing-sklearn guard, empty-corpus rejection, distribution rows summing to 1, two-cluster topic separation, top-term recovery, empty-input edge cases, all-OOV fallback, per-ticker averaging.
- [x] `ruff check .` clean
- [x] `bandit -ll` zero issues

https://claude.ai/code/session_01Gu3iR1MKU5D7zCv8HdbuQu