### PR TITLE
feat: macro / alt-data provider + FRED adapter (ML4T Ch 3)

### DIFF
--- a/ML_BOOK_MAP.md
+++ b/ML_BOOK_MAP.md
@@ -110,7 +110,7 @@ graph LR
 |----------------------------------------------|--------------------------------|:------:|-----------------------------------------------------------------|
 | 1 — ML for Trading                           | idea → execution               |   ✅   | architecture per `PLAN.md`                                      |
 | 2 — Market & Fundamental Data                | OHLCV, adjusted prices         |   ✅   | `data/fetcher.py`, `adapters/market_data/`                      |
-| 3 — Alternative Data                         | sentiment, macro               |   🟡   | `adapters/sentiment/` (Vader, StockTwits); no macro yet         |
+| 3 — Alternative Data                         | sentiment, macro               |   ✅   | `adapters/sentiment/` (Vader, StockTwits) + `adapters/macro/` (FRED, mock), `data/macro.py` cache |
 | 4 — Financial Feature Engineering            | factors, momentum, value       |   ✅   | `data/features.py`, `strategies/indicators.py`                  |
 | 5 — Portfolio Optimization & Performance     | Markowitz, efficient frontier  |   ✅   | `risk/markowitz.py`                                             |
 | 6 — The Machine Learning Process             | CV, HPO, pipelines             |   ✅   | `backtester/walk_forward.py`, `strategies/ml_tuning.py`         |

--- a/adapters/macro/__init__.py
+++ b/adapters/macro/__init__.py
@@ -1,0 +1,1 @@
+"""Macro / alternative-data adapters (Jansen Ch 3)."""

--- a/adapters/macro/fred_adapter.py
+++ b/adapters/macro/fred_adapter.py
@@ -1,0 +1,79 @@
+"""
+adapters/macro/fred_adapter.py — MacroDataProvider backed by the FRED REST API.
+
+Reads ``FRED_API_KEY`` from the environment and pulls observations for
+the requested series. Returns an empty :class:`pandas.Series` on any
+HTTP / parse failure so callers can degrade gracefully (the same
+contract sentiment adapters honour).
+
+API reference: https://fred.stlouisfed.org/docs/api/fred/series_observations.html
+"""
+from __future__ import annotations
+
+import json
+import os
+import urllib.parse
+import urllib.request
+
+import pandas as pd
+
+from utils.logger import get_logger
+
+log = get_logger(__name__)
+
+_BASE = "https://api.stlouisfed.org/fred/series/observations"
+
+
+class FREDAdapter:
+    """Pull macro series from the St. Louis Fed FRED API."""
+
+    def __init__(self, api_key: str | None = None, timeout: float = 10.0) -> None:
+        self._api_key = api_key or os.environ.get("FRED_API_KEY", "")
+        self._timeout = timeout
+
+    def get_series(
+        self,
+        series_id: str,
+        start: str | None = None,
+        end: str | None = None,
+    ) -> pd.Series:
+        if not self._api_key:
+            log.warning("fred_adapter: no FRED_API_KEY configured")
+            return pd.Series(dtype=float, name=series_id)
+
+        params: dict[str, str] = {
+            "series_id": series_id,
+            "api_key": self._api_key,
+            "file_type": "json",
+        }
+        if start:
+            params["observation_start"] = start
+        if end:
+            params["observation_end"] = end
+
+        url = f"{_BASE}?{urllib.parse.urlencode(params)}"
+        try:
+            req = urllib.request.Request(url, headers={"User-Agent": "quant-platform/1.0"})
+            with urllib.request.urlopen(req, timeout=self._timeout) as resp:  # noqa: S310 - https only
+                payload = json.loads(resp.read())
+        except Exception as exc:
+            log.warning("fred_adapter: fetch failed", series_id=series_id, error=str(exc))
+            return pd.Series(dtype=float, name=series_id)
+
+        observations = payload.get("observations", [])
+        if not observations:
+            return pd.Series(dtype=float, name=series_id)
+
+        dates: list[pd.Timestamp] = []
+        values: list[float] = []
+        for obs in observations:
+            raw = obs.get("value", ".")
+            if raw in (".", "", None):
+                continue
+            try:
+                values.append(float(raw))
+                dates.append(pd.Timestamp(obs["date"]))
+            except (ValueError, KeyError):
+                continue
+
+        return pd.Series(values, index=pd.DatetimeIndex(dates), name=series_id, dtype=float)

--- a/adapters/macro/mock_adapter.py
+++ b/adapters/macro/mock_adapter.py
@@ -1,0 +1,44 @@
+"""
+adapters/macro/mock_adapter.py — deterministic MacroDataProvider for tests.
+
+Returns a synthetic but reproducible time series for any series_id.
+Used when ``MACRO_PROVIDER=mock`` (the default when ``FRED_API_KEY`` is
+unset) so unit tests, CI runs, and local development never hit the
+real FRED endpoint.
+"""
+from __future__ import annotations
+
+import hashlib
+
+import numpy as np
+import pandas as pd
+
+
+class MockMacroAdapter:
+    """Deterministic per-series synthetic macro data."""
+
+    def get_series(
+        self,
+        series_id: str,
+        start: str | None = None,
+        end: str | None = None,
+    ) -> pd.Series:
+        start_ts = pd.Timestamp(start) if start else pd.Timestamp("2020-01-01")
+        end_ts = pd.Timestamp(end) if end else pd.Timestamp("2024-12-31")
+        idx = pd.date_range(start_ts, end_ts, freq="B")
+        if len(idx) == 0:
+            return pd.Series(dtype=float, name=series_id)
+
+        seed = int(
+            hashlib.sha1(series_id.encode("utf-8"), usedforsecurity=False).hexdigest()[:8],
+            16,
+        ) % 2**32
+        rng = np.random.default_rng(seed)
+        # Mean-reverting AR(1) around a series-specific level.
+        level = (seed % 50) + 1.0
+        eps = rng.standard_normal(len(idx))
+        values = np.empty(len(idx))
+        values[0] = level
+        for t in range(1, len(idx)):
+            values[t] = 0.95 * values[t - 1] + 0.05 * level + eps[t] * 0.1
+        return pd.Series(values, index=idx, name=series_id, dtype=float)

--- a/data/db.py
+++ b/data/db.py
@@ -133,6 +133,17 @@ def init_db() -> None:
             )
         """)
 
+        # ----- Macro / alternative-data series cache (Jansen Ch 3) -----
+        conn.execute("""
+            CREATE TABLE IF NOT EXISTS macro_cache (
+                series_id   TEXT    NOT NULL,
+                obs_date    TEXT    NOT NULL,    -- ISO date 'YYYY-MM-DD'
+                value       REAL,
+                fetched_at  REAL    NOT NULL,    -- Unix timestamp
+                PRIMARY KEY (series_id, obs_date)
+            )
+        """)
+
         # Seed paper_account if absent
         import os
         starting_cash = float(os.getenv("PAPER_STARTING_CASH", "100000"))

--- a/data/macro.py
+++ b/data/macro.py
@@ -1,0 +1,143 @@
+"""
+data/macro.py — Cached macro / alternative-data series.
+
+Mirror of :mod:`data.fetcher` but for macro indicators (FRED, etc.).
+Reads through :func:`providers.macro.get_macro` and stores observations
+in the ``macro_cache`` table of ``quant.db`` so subsequent reads avoid
+the upstream HTTP round-trip.
+
+Public API
+----------
+``fetch_macro_series(series_id, start, end)`` — single series, cached.
+``macro_context_features(dates, series_ids)`` — date-indexed DataFrame
+of multiple series, ready to merge into ``data/features.py`` outputs.
+
+Usage
+-----
+    from data.macro import fetch_macro_series, macro_context_features
+
+    vix = fetch_macro_series("VIXCLS", start="2023-01-01")
+    ctx = macro_context_features(my_dates, ["VIXCLS", "T10Y2Y"])
+"""
+from __future__ import annotations
+
+import time
+from typing import Iterable, Optional
+
+import pandas as pd
+
+from utils.logger import get_logger
+
+log = get_logger(__name__)
+
+_DEFAULT_CONTEXT_SERIES = ("VIXCLS", "T10Y2Y", "DGS10")
+
+
+def _read_cache(series_id: str) -> pd.Series:
+    try:
+        from data.db import get_connection
+    except Exception:
+        return pd.Series(dtype=float, name=series_id)
+    try:
+        conn = get_connection()
+        rows = conn.execute(
+            "SELECT obs_date, value FROM macro_cache WHERE series_id = ? ORDER BY obs_date",
+            (series_id,),
+        ).fetchall()
+    except Exception as exc:
+        log.warning("macro: cache read failed", series_id=series_id, error=str(exc))
+        return pd.Series(dtype=float, name=series_id)
+    if not rows:
+        return pd.Series(dtype=float, name=series_id)
+    dates = pd.DatetimeIndex([r[0] for r in rows])
+    values = [r[1] for r in rows]
+    return pd.Series(values, index=dates, name=series_id, dtype=float)
+
+
+def _write_cache(series_id: str, series: pd.Series) -> None:
+    if series.empty:
+        return
+    try:
+        from data.db import get_connection
+        conn = get_connection()
+        now = time.time()
+        with conn:
+            conn.executemany(
+                """
+                INSERT OR REPLACE INTO macro_cache (series_id, obs_date, value, fetched_at)
+                VALUES (?, ?, ?, ?)
+                """,
+                [
+                    (series_id, ts.date().isoformat(), float(v), now)
+                    for ts, v in series.items()
+                    if pd.notna(v)
+                ],
+            )
+    except Exception as exc:
+        log.warning("macro: cache write failed", series_id=series_id, error=str(exc))
+
+
+def fetch_macro_series(
+    series_id: str,
+    start: str | None = None,
+    end: str | None = None,
+    provider_name: Optional[str] = None,
+    use_cache: bool = True,
+) -> pd.Series:
+    """Return a date-indexed observation series for ``series_id``.
+
+    On a cache hit (and no explicit ``start`` / ``end`` window), the
+    cached series is returned directly. Otherwise the configured
+    :class:`providers.macro.MacroDataProvider` is queried and the
+    result upserted into ``macro_cache``.
+    """
+    if use_cache and start is None and end is None:
+        cached = _read_cache(series_id)
+        if not cached.empty:
+            return cached
+
+    try:
+        from providers.macro import get_macro
+        provider = get_macro(provider_name)
+    except Exception as exc:
+        log.warning("macro: provider unavailable", error=str(exc))
+        return pd.Series(dtype=float, name=series_id)
+
+    try:
+        series = provider.get_series(series_id, start=start, end=end)
+    except Exception as exc:
+        log.warning("macro: provider call failed", series_id=series_id, error=str(exc))
+        return pd.Series(dtype=float, name=series_id)
+
+    if use_cache:
+        _write_cache(series_id, series)
+    return series
+
+
+def macro_context_features(
+    dates: Iterable[pd.Timestamp],
+    series_ids: Iterable[str] = _DEFAULT_CONTEXT_SERIES,
+    provider_name: Optional[str] = None,
+) -> pd.DataFrame:
+    """Build a date-indexed DataFrame with one column per macro series.
+
+    Each series is forward-filled onto the requested ``dates`` so daily
+    panels (which include weekends / holidays missing from FRED) get a
+    valid value. Missing series collapse to NaN columns rather than
+    raising.
+    """
+    idx = pd.DatetimeIndex(sorted(set(pd.Timestamp(d) for d in dates)))
+    if len(idx) == 0:
+        return pd.DataFrame()
+
+    start = idx.min().date().isoformat()
+    end = idx.max().date().isoformat()
+
+    out = pd.DataFrame(index=idx)
+    for sid in series_ids:
+        s = fetch_macro_series(sid, start=start, end=end, provider_name=provider_name)
+        if s.empty:
+            out[sid] = pd.Series(index=idx, dtype=float)
+            continue
+        out[sid] = s.reindex(idx, method="ffill")
+    return out

--- a/providers/macro.py
+++ b/providers/macro.py
@@ -1,0 +1,60 @@
+"""
+providers/macro.py — MacroDataProvider Protocol and factory.
+
+Macro / alternative data is fetched through this layer so the rest of
+the platform can stay agnostic of the upstream source. Currently
+supported back-ends are the FRED public API and a deterministic mock
+adapter for tests / offline runs.
+
+ENV vars
+--------
+    MACRO_PROVIDER   fred | mock  (default: fred when FRED_API_KEY set, else mock)
+    FRED_API_KEY     personal API key from https://fred.stlouisfed.org
+"""
+from __future__ import annotations
+
+import os
+from typing import Optional, Protocol, runtime_checkable
+
+import pandas as pd
+
+
+@runtime_checkable
+class MacroDataProvider(Protocol):
+    """Duck-typed interface for macro / alternative time-series data."""
+
+    def get_series(
+        self,
+        series_id: str,
+        start: str | None = None,
+        end: str | None = None,
+    ) -> pd.Series:
+        """Return a date-indexed series of observations for ``series_id``.
+
+        Implementations should return an empty Series on failure rather
+        than raising — callers are expected to handle missing macro
+        data gracefully.
+        """
+        ...
+
+
+def get_macro(provider: Optional[str] = None) -> MacroDataProvider:
+    """Return a configured :class:`MacroDataProvider`.
+
+    Resolution order: explicit ``provider`` arg → ``MACRO_PROVIDER`` env var
+    → ``fred`` (when ``FRED_API_KEY`` set) → ``mock``.
+    """
+    name = provider or os.environ.get("MACRO_PROVIDER")
+    if not name:
+        name = "fred" if os.environ.get("FRED_API_KEY") else "mock"
+    name = name.lower().strip()
+
+    if name == "fred":
+        from adapters.macro.fred_adapter import FREDAdapter
+        return FREDAdapter()
+    if name == "mock":
+        from adapters.macro.mock_adapter import MockMacroAdapter
+        return MockMacroAdapter()
+    raise ValueError(
+        f"Unknown macro provider: {name!r}. Valid options: fred, mock"
+    )

--- a/tests/test_macro.py
+++ b/tests/test_macro.py
@@ -1,0 +1,204 @@
+"""Tests for providers/macro.py, adapters/macro/*, and data/macro.py."""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+
+# ── Provider factory ──────────────────────────────────────────────────────────
+
+def test_get_macro_defaults_to_mock_when_no_api_key(monkeypatch):
+    monkeypatch.delenv("MACRO_PROVIDER", raising=False)
+    monkeypatch.delenv("FRED_API_KEY", raising=False)
+    from adapters.macro.mock_adapter import MockMacroAdapter
+    from providers.macro import get_macro
+    assert isinstance(get_macro(), MockMacroAdapter)
+
+
+def test_get_macro_picks_fred_when_api_key_present(monkeypatch):
+    monkeypatch.delenv("MACRO_PROVIDER", raising=False)
+    monkeypatch.setenv("FRED_API_KEY", "test-key")
+    from adapters.macro.fred_adapter import FREDAdapter
+    from providers.macro import get_macro
+    assert isinstance(get_macro(), FREDAdapter)
+
+
+def test_get_macro_explicit_override(monkeypatch):
+    monkeypatch.setenv("FRED_API_KEY", "test-key")
+    from adapters.macro.mock_adapter import MockMacroAdapter
+    from providers.macro import get_macro
+    assert isinstance(get_macro("mock"), MockMacroAdapter)
+
+
+def test_get_macro_unknown_raises():
+    from providers.macro import get_macro
+    with pytest.raises(ValueError, match="Unknown macro provider"):
+        get_macro("not-a-thing")
+
+
+# ── Mock adapter ──────────────────────────────────────────────────────────────
+
+def test_mock_adapter_returns_deterministic_series():
+    from adapters.macro.mock_adapter import MockMacroAdapter
+    a, b = MockMacroAdapter(), MockMacroAdapter()
+    s1 = a.get_series("VIXCLS", start="2024-01-01", end="2024-02-01")
+    s2 = b.get_series("VIXCLS", start="2024-01-01", end="2024-02-01")
+    assert not s1.empty
+    pd.testing.assert_series_equal(s1, s2)
+
+
+def test_mock_adapter_different_series_yield_different_values():
+    from adapters.macro.mock_adapter import MockMacroAdapter
+    a = MockMacroAdapter()
+    s1 = a.get_series("VIXCLS", start="2024-01-01", end="2024-02-01")
+    s2 = a.get_series("DGS10", start="2024-01-01", end="2024-02-01")
+    assert not s1.equals(s2)
+
+
+def test_mock_adapter_empty_window():
+    from adapters.macro.mock_adapter import MockMacroAdapter
+    a = MockMacroAdapter()
+    s = a.get_series("X", start="2024-01-10", end="2024-01-09")
+    assert s.empty
+
+
+# ── FRED adapter (mocked HTTP, no network) ────────────────────────────────────
+
+def _fake_response(payload: dict):
+    body = json.dumps(payload).encode("utf-8")
+    mock_resp = MagicMock()
+    mock_resp.read.return_value = body
+    mock_resp.__enter__ = lambda self: self
+    mock_resp.__exit__ = lambda self, exc_type, exc, tb: False
+    return mock_resp
+
+
+def test_fred_adapter_no_api_key_returns_empty(monkeypatch):
+    monkeypatch.delenv("FRED_API_KEY", raising=False)
+    from adapters.macro.fred_adapter import FREDAdapter
+    s = FREDAdapter().get_series("VIXCLS")
+    assert s.empty
+
+
+def test_fred_adapter_parses_observations():
+    from adapters.macro.fred_adapter import FREDAdapter
+    payload = {
+        "observations": [
+            {"date": "2024-01-02", "value": "12.34"},
+            {"date": "2024-01-03", "value": "13.50"},
+            {"date": "2024-01-04", "value": "."},   # missing → skipped
+            {"date": "2024-01-05", "value": "14.10"},
+        ],
+    }
+    with patch(
+        "adapters.macro.fred_adapter.urllib.request.urlopen",
+        return_value=_fake_response(payload),
+    ):
+        adapter = FREDAdapter(api_key="test-key")
+        s = adapter.get_series("VIXCLS", start="2024-01-01", end="2024-01-31")
+
+    assert list(s.index.strftime("%Y-%m-%d")) == ["2024-01-02", "2024-01-03", "2024-01-05"]
+    assert s.tolist() == [12.34, 13.50, 14.10]
+
+
+def test_fred_adapter_handles_http_failure_gracefully():
+    from adapters.macro.fred_adapter import FREDAdapter
+    with patch(
+        "adapters.macro.fred_adapter.urllib.request.urlopen",
+        side_effect=RuntimeError("network down"),
+    ):
+        s = FREDAdapter(api_key="test-key").get_series("VIXCLS")
+    assert s.empty
+
+
+def test_fred_adapter_invalid_value_skipped():
+    from adapters.macro.fred_adapter import FREDAdapter
+    payload = {
+        "observations": [
+            {"date": "2024-01-02", "value": "not-a-number"},
+            {"date": "2024-01-03", "value": "5.0"},
+        ],
+    }
+    with patch(
+        "adapters.macro.fred_adapter.urllib.request.urlopen",
+        return_value=_fake_response(payload),
+    ):
+        s = FREDAdapter(api_key="test-key").get_series("VIXCLS")
+    assert s.tolist() == [5.0]
+
+
+# ── data/macro.py ─────────────────────────────────────────────────────────────
+
+def test_fetch_macro_series_uses_provider_when_cache_empty():
+    from data import macro as data_macro
+
+    fake = pd.Series(
+        [1.0, 2.0],
+        index=pd.DatetimeIndex(["2024-01-01", "2024-01-02"]),
+        name="X",
+        dtype=float,
+    )
+
+    fake_provider = MagicMock()
+    fake_provider.get_series.return_value = fake
+
+    with (
+        patch.object(data_macro, "_read_cache", return_value=pd.Series(dtype=float)),
+        patch.object(data_macro, "_write_cache") as mock_write,
+        patch("providers.macro.get_macro", return_value=fake_provider),
+    ):
+        s = data_macro.fetch_macro_series("X")
+
+    pd.testing.assert_series_equal(s, fake)
+    mock_write.assert_called_once()
+
+
+def test_fetch_macro_series_returns_cache_when_available():
+    from data import macro as data_macro
+    cached = pd.Series([7.0], index=pd.DatetimeIndex(["2024-06-01"]), name="X", dtype=float)
+    with patch.object(data_macro, "_read_cache", return_value=cached):
+        s = data_macro.fetch_macro_series("X")
+    pd.testing.assert_series_equal(s, cached)
+
+
+def test_fetch_macro_series_handles_provider_failure():
+    from data import macro as data_macro
+    with (
+        patch.object(data_macro, "_read_cache", return_value=pd.Series(dtype=float)),
+        patch("providers.macro.get_macro", side_effect=RuntimeError("no provider")),
+    ):
+        s = data_macro.fetch_macro_series("X")
+    assert s.empty
+
+
+def test_macro_context_features_assembles_multi_series():
+    from data import macro as data_macro
+
+    def fake_fetch(series_id, start=None, end=None, provider_name=None, use_cache=True):
+        idx = pd.date_range("2024-01-01", "2024-01-10", freq="B")
+        if series_id == "MISSING":
+            return pd.Series(dtype=float)
+        return pd.Series(range(len(idx)), index=idx, name=series_id, dtype=float)
+
+    with patch.object(data_macro, "fetch_macro_series", side_effect=fake_fetch):
+        df = data_macro.macro_context_features(
+            pd.date_range("2024-01-01", "2024-01-10", freq="B"),
+            ["VIXCLS", "MISSING"],
+        )
+
+    assert "VIXCLS" in df.columns and "MISSING" in df.columns
+    assert df["MISSING"].isna().all()
+    assert df["VIXCLS"].notna().all()
+
+
+def test_macro_context_features_empty_dates_returns_empty_df():
+    from data.macro import macro_context_features
+    out = macro_context_features([])
+    assert out.empty


### PR DESCRIPTION
Closes #97.

## Summary
- New `MacroDataProvider` Protocol (`providers/macro.py`) selectable via `MACRO_PROVIDER` env var (defaults to `mock` when `FRED_API_KEY` is unset, otherwise `fred`).
- `FREDAdapter` (`adapters/macro/fred_adapter.py`): pulls observations from the FRED REST API, returns an empty Series on any failure so callers degrade gracefully.
- `MockMacroAdapter` (`adapters/macro/mock_adapter.py`): deterministic per-series synthetic AR(1) data for tests / offline runs.
- `data/macro.py`: SQLite-cached `fetch_macro_series()` and `macro_context_features()` for assembling multi-series date-indexed DataFrames ready to merge into `data/features.py` outputs.
- `data/db.py`: new `macro_cache` table.
- Marks ML4T Ch 3 ✅ in `ML_BOOK_MAP.md`.

## Test plan
- [x] 16 tests in `tests/test_macro.py` covering provider factory selection, mock adapter determinism, FRED HTTP-mocked happy path / failure / invalid-value handling, cache hit/miss flow, multi-series assembly, and empty inputs.
- [x] `ruff check .` clean
- [x] `bandit -ll`: 0 HIGH (one Medium `urllib.urlopen` advisory, expected for HTTPS fetch).

https://claude.ai/code/session_01Gu3iR1MKU5D7zCv8HdbuQu