### PR TITLE
feat: word2vec embeddings on text corpora (ML4T Ch 16)

### DIFF
--- a/ML_BOOK_MAP.md
+++ b/ML_BOOK_MAP.md
@@ -123,7 +123,7 @@ graph LR
 | 13 — Unsupervised Learning                   | PCA, k-means, risk factors     |   ✅   | `analysis/unsupervised.py` (PCA loadings + scree; k-means on corr-distance) |
 | 14 — Text Data / Sentiment Analysis          | Vader, VADER                   |   ✅   | `adapters/sentiment/vader_adapter.py`                           |
 | 15 — Topic Modeling                          | LDA on news                    |   ✅   | `analysis/topic_modeling.py` (fit_lda + infer_topics + top_terms_per_topic + ticker_topic_distribution) |
-| 16 — Word Embeddings                         | word2vec on filings            |   ⏳   | _planned_ — see issue "Word embeddings on filings"              |
+| 16 — Word Embeddings                         | word2vec on filings            |   ✅   | `analysis/word_embeddings.py` (train_embeddings + document_embedding + nearest_terms via gensim) |
 | 17 — Deep Learning for Trading               | Keras / PyTorch intro          |   🟡   | `strategies/dl_signal.py` LSTM alpha (torch-gated); full DL workflow partial |
 | 18 — CNNs                                    | image / chart patterns         |   ⏳   | _planned_ — CNN chart patterns not yet implemented              |
 | 19 — RNNs / LSTM                             | sequence models                |   ✅   | `strategies/dl_signal.py` (_LSTMRegressor + windowed training)  |

--- a/analysis/word_embeddings.py
+++ b/analysis/word_embeddings.py
@@ -1,0 +1,164 @@
+"""
+analysis/word_embeddings.py — word2vec embeddings for text corpora.
+
+Implements the embedding-training pipeline from Jansen, *Machine
+Learning for Algorithmic Trading* (2nd ed.) Chapter 16: train a
+``word2vec`` model on a corpus (earnings calls / 10-K risk-factor
+sections / news headlines) and project new documents to a fixed-size
+vector by averaging the word vectors of the tokens that appear in the
+vocabulary.
+
+``gensim`` is the canonical implementation in the book.  We import it
+through a try/except gate so the rest of the platform keeps working on
+machines that don't have it installed (mirrors the torch gating in
+:mod:`strategies.dl_signal`).
+
+Public surface
+--------------
+``EmbeddingResult``      — dataclass bundling the trained Word2Vec model
+``train_embeddings``     — fit on a list of raw text documents
+``document_embedding``   — average-pool word vectors for one document
+``nearest_terms``        — top-k closest vocabulary terms to a given term
+
+Reference
+---------
+    Jansen, *Machine Learning for Algorithmic Trading* (2nd ed.) Ch 16.4.
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Sequence
+
+import numpy as np
+
+from utils.logger import get_logger
+
+log = get_logger(__name__)
+
+try:
+    from gensim.models import Word2Vec  # type: ignore[import]
+    _GENSIM_AVAILABLE = True
+except ImportError:
+    Word2Vec = None  # type: ignore[assignment,misc]
+    _GENSIM_AVAILABLE = False
+
+
+_TOKEN_RE = re.compile(r"[a-z][a-z0-9_]+")
+
+
+def _tokenise(text: str) -> list[str]:
+    """Lowercase + alphanumeric tokenisation; drops 1-character tokens."""
+    return _TOKEN_RE.findall(text.lower())
+
+
+@dataclass(frozen=True)
+class EmbeddingResult:
+    """Trained word2vec artefacts."""
+
+    model: object              # gensim.models.Word2Vec
+    vector_size: int
+    vocab_size: int
+
+
+def _require_gensim() -> None:
+    if not _GENSIM_AVAILABLE:
+        raise RuntimeError(
+            "gensim is not installed. Run: pip install 'gensim>=4.3.0'"
+        )
+
+
+def train_embeddings(
+    documents: Sequence[str],
+    vector_size: int = 64,
+    window: int = 5,
+    min_count: int = 2,
+    epochs: int = 10,
+    seed: int = 42,
+    workers: int = 1,
+) -> EmbeddingResult:
+    """Fit a word2vec (skip-gram) model on the supplied corpus.
+
+    Parameters
+    ----------
+    documents :
+        Iterable of raw text documents. Each is tokenised on-the-fly.
+    vector_size :
+        Dimensionality of the embedding space.
+    window :
+        Context window (words) used during training.
+    min_count :
+        Minimum corpus frequency for a token to enter the vocabulary.
+    epochs :
+        Training epochs.
+    seed, workers :
+        Forwarded to :class:`gensim.models.Word2Vec`. ``workers=1``
+        keeps the run deterministic when ``seed`` is set.
+
+    Raises
+    ------
+    RuntimeError
+        If ``gensim`` is not installed.
+    ValueError
+        If the corpus is empty or the vocabulary collapses to nothing
+        after pruning.
+    """
+    _require_gensim()
+
+    sentences = [_tokenise(d) for d in documents if d and d.strip()]
+    sentences = [s for s in sentences if s]
+    if not sentences:
+        raise ValueError("train_embeddings: no usable documents after tokenisation")
+
+    model = Word2Vec(
+        sentences=sentences,
+        vector_size=int(vector_size),
+        window=int(window),
+        min_count=int(min_count),
+        epochs=int(epochs),
+        seed=int(seed),
+        workers=int(workers),
+        sg=1,  # skip-gram (Jansen Ch 16.4.2)
+    )
+    vocab_size = len(model.wv)
+    if vocab_size == 0:
+        raise ValueError("train_embeddings: empty vocabulary after min_count pruning")
+
+    log.info(
+        "word_embeddings.train complete",
+        n_docs=len(sentences), vocab=vocab_size, vector_size=vector_size,
+    )
+    return EmbeddingResult(model=model, vector_size=int(vector_size), vocab_size=vocab_size)
+
+
+def document_embedding(result: EmbeddingResult, document: str) -> np.ndarray:
+    """Average-pool the trained word vectors over a document's tokens.
+
+    Returns a ``(vector_size,)`` array; the zero vector when no token
+    overlaps the trained vocabulary (so callers always get a well-formed
+    feature even for cold-start documents).
+    """
+    _require_gensim()
+    tokens = _tokenise(document or "")
+    wv = result.model.wv  # type: ignore[attr-defined]
+    vectors = [wv[t] for t in tokens if t in wv]
+    if not vectors:
+        return np.zeros(result.vector_size, dtype=float)
+    return np.mean(np.stack(vectors), axis=0).astype(float)
+
+
+def nearest_terms(
+    result: EmbeddingResult,
+    term: str,
+    k: int = 5,
+) -> list[tuple[str, float]]:
+    """Top-``k`` vocabulary terms closest to ``term`` by cosine similarity.
+
+    Returns an empty list when ``term`` is out of vocabulary.
+    """
+    _require_gensim()
+    wv = result.model.wv  # type: ignore[attr-defined]
+    token = term.lower()
+    if token not in wv:
+        return []
+    return [(str(t), float(s)) for t, s in wv.most_similar(token, topn=int(k))]

--- a/requirements.txt
+++ b/requirements.txt
@@ -63,3 +63,4 @@ structlog>=24.0.0
 lightgbm>=4.0.0
 scikit-learn>=1.3.0
 scipy>=1.11.0
+gensim>=4.3.0

--- a/tests/test_word_embeddings.py
+++ b/tests/test_word_embeddings.py
@@ -1,0 +1,123 @@
+"""Tests for analysis/word_embeddings.py — word2vec via gensim."""
+from __future__ import annotations
+
+import os
+import sys
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+try:
+    import gensim  # noqa: F401
+    _GENSIM = True
+except ImportError:
+    _GENSIM = False
+
+skip_no_gensim = pytest.mark.skipif(not _GENSIM, reason="gensim not installed")
+
+
+# A toy corpus with two clear "topics" so word2vec can learn separable
+# vectors even at min_count=1 / vector_size=16.
+_CORPUS = [
+    "earnings revenue profit margin shareholders dividend payout cash flow",
+    "earnings beat revenue forecast guidance shareholders dividend",
+    "balance sheet revenue earnings shareholders profit",
+    "guidance dividend profit revenue cash flow shareholders",
+    "machine learning neural network gpu training inference deployment",
+    "deep learning gpu training inference model architecture deployment",
+    "transformer attention mechanism training inference deployment model",
+    "neural network gpu inference model deployment training pipeline",
+] * 4  # repeat to give skip-gram enough context
+
+
+# ── Gating ────────────────────────────────────────────────────────────────────
+
+def test_train_embeddings_raises_without_gensim():
+    from analysis import word_embeddings
+    with patch("analysis.word_embeddings._GENSIM_AVAILABLE", False):
+        with pytest.raises(RuntimeError, match="gensim"):
+            word_embeddings.train_embeddings(["hello world"])
+
+
+def test_document_embedding_raises_without_gensim():
+    from analysis import word_embeddings
+    with patch("analysis.word_embeddings._GENSIM_AVAILABLE", False):
+        with pytest.raises(RuntimeError, match="gensim"):
+            word_embeddings.document_embedding(None, "doc")  # type: ignore[arg-type]
+
+
+def test_nearest_terms_raises_without_gensim():
+    from analysis import word_embeddings
+    with patch("analysis.word_embeddings._GENSIM_AVAILABLE", False):
+        with pytest.raises(RuntimeError, match="gensim"):
+            word_embeddings.nearest_terms(None, "x", k=3)  # type: ignore[arg-type]
+
+
+def test_train_embeddings_rejects_empty_corpus():
+    from analysis.word_embeddings import train_embeddings
+    if not _GENSIM:
+        pytest.skip("gensim not installed")
+    with pytest.raises(ValueError, match="usable"):
+        train_embeddings([])
+    with pytest.raises(ValueError, match="usable"):
+        train_embeddings(["", "  "])
+
+
+# ── gensim happy paths ────────────────────────────────────────────────────────
+
+@skip_no_gensim
+def test_train_embeddings_returns_correct_shape_and_vocab():
+    from analysis.word_embeddings import train_embeddings
+    result = train_embeddings(_CORPUS, vector_size=16, min_count=1, epochs=5)
+    assert result.vector_size == 16
+    assert result.vocab_size > 5
+    # Model exposes the gensim wv API
+    wv = result.model.wv  # type: ignore[attr-defined]
+    assert "revenue" in wv
+    assert wv["revenue"].shape == (16,)
+
+
+@skip_no_gensim
+def test_document_embedding_shape_and_zero_vector_for_oov():
+    from analysis.word_embeddings import document_embedding, train_embeddings
+    result = train_embeddings(_CORPUS, vector_size=16, min_count=1, epochs=3)
+    vec = document_embedding(result, "earnings revenue dividend")
+    assert vec.shape == (16,)
+    assert np.linalg.norm(vec) > 0
+    zero = document_embedding(result, "qqqqqq zyzzyx")
+    assert np.allclose(zero, 0.0)
+    empty = document_embedding(result, "")
+    assert np.allclose(empty, 0.0)
+
+
+@skip_no_gensim
+def test_nearest_terms_returns_in_vocab_results():
+    from analysis.word_embeddings import nearest_terms, train_embeddings
+    result = train_embeddings(_CORPUS, vector_size=16, min_count=1, epochs=5)
+    out = nearest_terms(result, "revenue", k=3)
+    assert len(out) == 3
+    for term, score in out:
+        assert isinstance(term, str)
+        assert -1.0 <= score <= 1.0
+        # Returned terms must come from the trained vocabulary
+        assert term in result.model.wv  # type: ignore[attr-defined]
+
+
+@skip_no_gensim
+def test_nearest_terms_oov_returns_empty_list():
+    from analysis.word_embeddings import nearest_terms, train_embeddings
+    result = train_embeddings(_CORPUS, vector_size=16, min_count=1, epochs=3)
+    assert nearest_terms(result, "zzzzzzzzzzzz", k=5) == []
+
+
+@skip_no_gensim
+def test_document_embedding_average_invariant_to_token_order():
+    """Average-pooling must be order-invariant."""
+    from analysis.word_embeddings import document_embedding, train_embeddings
+    result = train_embeddings(_CORPUS, vector_size=16, min_count=1, epochs=3)
+    a = document_embedding(result, "earnings revenue dividend")
+    b = document_embedding(result, "dividend revenue earnings")
+    np.testing.assert_allclose(a, b, atol=1e-6)


### PR DESCRIPTION
Closes #98.

## Summary
- New `analysis/word_embeddings.py`: thin wrapper over `gensim.models.Word2Vec` with `EmbeddingResult` dataclass + `train_embeddings`, `document_embedding`, `nearest_terms`.
- gensim is **gated** behind `try: import gensim` / `_GENSIM_AVAILABLE` (mirrors `strategies/dl_signal.py`'s torch gating).
- `document_embedding` average-pools vectors → `(vector_size,)` array ready to merge into `data/features.py` outputs once a real corpus path is wired.
- Adds `gensim>=4.3.0` to `requirements.txt`.
- Marks ML4T Ch 16 ✅ in `ML_BOOK_MAP.md`.

## Test plan
- [x] 9 tests in `tests/test_word_embeddings.py`: missing-gensim guards on all three public functions, empty-corpus rejection, vector shape + vocab membership, OOV → zero vector / empty list, order-invariance of document averaging.
- [x] `ruff check .` clean
- [x] `bandit -ll` zero issues

https://claude.ai/code/session_01Gu3iR1MKU5D7zCv8HdbuQu