### PR TITLE
feat: CNN chart-image alpha (ML4T Ch 18)

### DIFF
--- a/ML_BOOK_MAP.md
+++ b/ML_BOOK_MAP.md
@@ -125,7 +125,7 @@ graph LR
 | 15 — Topic Modeling                          | LDA on news                    |   ✅   | `analysis/topic_modeling.py` (fit_lda + infer_topics + top_terms_per_topic + ticker_topic_distribution) |
 | 16 — Word Embeddings                         | word2vec on filings            |   ✅   | `analysis/word_embeddings.py` (train_embeddings + document_embedding + nearest_terms via gensim) |
 | 17 — Deep Learning for Trading               | Keras / PyTorch intro          |   🟡   | `strategies/dl_signal.py` LSTM alpha (torch-gated); full DL workflow partial |
-| 18 — CNNs                                    | image / chart patterns         |   ⏳   | _planned_ — CNN chart patterns not yet implemented              |
+| 18 — CNNs                                    | image / chart patterns         |   ✅   | `analysis/chart_images.py` (GAF + OHLC raster) + `strategies/cnn_signal.py` (Conv2d alpha) |
 | 19 — RNNs / LSTM                             | sequence models                |   ✅   | `strategies/dl_signal.py` (_LSTMRegressor + windowed training)  |
 | 20 — Autoencoders                            | conditional risk factors       |   ⏳   | deferred                                                        |
 | 21 — GANs                                    | synthetic time series          |   ⏳   | deferred                                                        |

--- a/analysis/chart_images.py
+++ b/analysis/chart_images.py
@@ -1,0 +1,87 @@
+"""
+analysis/chart_images.py — turn OHLCV windows into 2-D image tensors.
+
+Companion to :mod:`strategies.cnn_signal` (Jansen Ch 18).  Two
+transforms are provided:
+
+  * :func:`to_gramian_angular_field` — GAF / GASF image of a 1-D price
+    series (López de Prado-friendly visualisation, used heavily by
+    Jansen Ch 18.4 as a CNN input).
+  * :func:`ohlc_to_pixels` — direct rasterisation of OHLC bars onto a
+    fixed-size grid; cheaper than GAF but preserves price ranges.
+
+Both return ``(H, W)`` ``np.float32`` arrays in ``[0, 1]`` (or
+``[-1, 1]`` for the signed GAF) so callers can stack them into the
+``(n_samples, 1, H, W)`` tensor a Conv2d head expects.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+
+def to_gramian_angular_field(series: pd.Series | np.ndarray, window: int) -> np.ndarray:
+    """Gramian Angular Summation Field (GASF) of the trailing ``window`` values.
+
+    Steps (Jansen Ch 18.4.1):
+
+    1. Take the last ``window`` observations.
+    2. Min-max scale into ``[-1, 1]``.
+    3. Encode each scaled value as the angle ``φ = arccos(x)``.
+    4. Build the ``window × window`` matrix ``cos(φ_i + φ_j)``.
+
+    Returns
+    -------
+    np.ndarray
+        ``(window, window)`` float32 image in ``[-1, 1]``. All-NaN
+        windows yield a zero matrix; constant windows yield a matrix of
+        ones (degenerate but well-defined).
+    """
+    arr = np.asarray(pd.Series(series).to_numpy(dtype=float))[-int(window):]
+    if arr.size < window:
+        return np.zeros((window, window), dtype=np.float32)
+    if not np.isfinite(arr).any():
+        return np.zeros((window, window), dtype=np.float32)
+
+    lo, hi = float(np.nanmin(arr)), float(np.nanmax(arr))
+    if hi == lo:
+        return np.ones((window, window), dtype=np.float32)
+
+    scaled = 2.0 * (arr - lo) / (hi - lo) - 1.0
+    scaled = np.clip(scaled, -1.0, 1.0)
+    phi = np.arccos(scaled)
+    gasf = np.cos(phi[:, None] + phi[None, :])
+    return gasf.astype(np.float32)
+
+
+def ohlc_to_pixels(df: pd.DataFrame, window: int, height: int = 32) -> np.ndarray:
+    """Rasterise the trailing ``window`` OHLC bars onto a ``(height, window)`` grid.
+
+    Each column is one bar; pixel rows are filled between the bar's
+    Low and High (the candle wick) with a darker stripe between Open
+    and Close (the body). Output is float32 in ``[0, 1]``.
+    """
+    needed = {"Open", "High", "Low", "Close"}
+    if not needed.issubset(df.columns) or len(df) < window:
+        return np.zeros((height, window), dtype=np.float32)
+
+    sub = df[list(needed)].iloc[-int(window):].astype(float)
+    lo = float(sub["Low"].min())
+    hi = float(sub["High"].max())
+    if hi == lo:
+        return np.zeros((height, window), dtype=np.float32)
+
+    def _row(value: float) -> int:
+        # Higher prices live near the top of the image (row 0 is top).
+        frac = (value - lo) / (hi - lo)
+        return int(np.clip(round((1.0 - frac) * (height - 1)), 0, height - 1))
+
+    img = np.zeros((height, window), dtype=np.float32)
+    for col, (_, row) in enumerate(sub.iterrows()):
+        wick_top = _row(float(row["High"]))
+        wick_bot = _row(float(row["Low"]))
+        body_top = _row(max(float(row["Open"]), float(row["Close"])))
+        body_bot = _row(min(float(row["Open"]), float(row["Close"])))
+        img[wick_top : wick_bot + 1, col] = 0.5      # wick
+        img[body_top : body_bot + 1, col] = 1.0      # body (darker)
+    return img

--- a/strategies/cnn_signal.py
+++ b/strategies/cnn_signal.py
@@ -1,0 +1,282 @@
+"""
+strategies/cnn_signal.py — CNN over OHLC chart images (Jansen Ch 18).
+
+Predicts ``fwd_ret_5d`` from a small Conv2d head over Gramian Angular
+Field images of the rolling close-price window.  Same public surface
+as :class:`strategies.linear_signal.LinearSignal` /
+:class:`strategies.ml_signal.MLSignal`: ``train()``, ``predict()``,
+plus a fallback to momentum when the model isn't available.
+
+Torch is gated through the same try/except pattern used by
+:mod:`strategies.dl_signal`, so this module imports cleanly even on
+machines without torch installed.
+
+ENV vars
+--------
+    CNN_ALPHA_MODEL_PATH    path to model checkpoint (default: models/cnn_alpha.pt)
+"""
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+from analysis.chart_images import to_gramian_angular_field
+from analysis.factor_ic import _spearman_corr
+from data.features import build_feature_matrix
+from data.fetcher import fetch_ohlcv
+from utils.logger import get_logger
+
+log = get_logger(__name__)
+
+try:
+    import torch  # type: ignore[import]
+    import torch.nn as nn  # type: ignore[import]
+    _TORCH_AVAILABLE = True
+except ImportError:
+    torch = None  # type: ignore[assignment]
+    nn = None  # type: ignore[assignment]
+    _TORCH_AVAILABLE = False
+
+
+_DEFAULT_MODEL_PATH = os.environ.get("CNN_ALPHA_MODEL_PATH", "models/cnn_alpha.pt")
+_TARGET_COL = "fwd_ret_5d"
+_DEFAULT_WINDOW = 16
+
+
+if _TORCH_AVAILABLE:
+
+    class _ChartCNN(nn.Module):  # type: ignore[misc]
+        """Tiny 2-conv CNN reading a single-channel ``(window, window)`` GAF."""
+
+        def __init__(self, window: int = _DEFAULT_WINDOW) -> None:
+            super().__init__()
+            self.features = nn.Sequential(
+                nn.Conv2d(1, 8, kernel_size=3, padding=1),
+                nn.ReLU(),
+                nn.MaxPool2d(2),
+                nn.Conv2d(8, 16, kernel_size=3, padding=1),
+                nn.ReLU(),
+                nn.AdaptiveAvgPool2d((4, 4)),
+            )
+            self.head = nn.Sequential(
+                nn.Flatten(),
+                nn.Linear(16 * 4 * 4, 32),
+                nn.ReLU(),
+                nn.Linear(32, 1),
+            )
+
+        def forward(self, x):  # type: ignore[override]
+            return self.head(self.features(x)).squeeze(-1)
+else:
+    _ChartCNN = None  # type: ignore[assignment]
+
+
+def _build_image_dataset(
+    fm: pd.DataFrame,
+    closes_by_ticker: dict[str, pd.Series],
+    window: int,
+) -> tuple[np.ndarray | None, np.ndarray | None, pd.MultiIndex | None]:
+    """Build aligned ``(N, 1, window, window)`` image tensor + targets.
+
+    For each row of ``fm`` we look up the trailing ``window`` close
+    prices for that ticker and convert to a GAF image. Rows whose
+    trailing window is not yet available, or whose target is NaN, are
+    dropped.
+    """
+    xs: list[np.ndarray] = []
+    ys: list[float] = []
+    idx_rows: list[tuple] = []
+
+    for (date, ticker), row in fm.iterrows():
+        target = float(row.get(_TARGET_COL, np.nan))
+        if not np.isfinite(target):
+            continue
+        closes = closes_by_ticker.get(ticker)
+        if closes is None or len(closes) < window:
+            continue
+        sub = closes.loc[:date].iloc[-window:]
+        if len(sub) < window:
+            continue
+        img = to_gramian_angular_field(sub, window=window)
+        xs.append(img[None, ...])  # add channel axis
+        ys.append(target)
+        idx_rows.append((date, ticker))
+
+    if not xs:
+        return None, None, None
+    X = np.stack(xs).astype(np.float32)
+    y = np.asarray(ys, dtype=np.float32)
+    return X, y, pd.MultiIndex.from_tuples(idx_rows, names=["date", "ticker"])
+
+
+class CNNSignal:
+    """CNN-on-chart-image cross-sectional alpha model."""
+
+    def __init__(
+        self,
+        model_path: str | None = None,
+        window: int = _DEFAULT_WINDOW,
+    ) -> None:
+        self._model_path: str = model_path or _DEFAULT_MODEL_PATH
+        self._window: int = int(window)
+        self._model = None  # _ChartCNN | None
+        self._load_if_available()
+
+    # ── Persistence ───────────────────────────────────────────────────────────
+
+    def _load_if_available(self) -> None:
+        path = Path(self._model_path)
+        if not path.exists() or not _TORCH_AVAILABLE:
+            return
+        try:
+            state = torch.load(path, map_location="cpu", weights_only=True)
+            model = _ChartCNN(window=self._window)
+            model.load_state_dict(state)
+            model.eval()
+            self._model = model
+            log.info("cnn_signal: loaded checkpoint", path=str(path))
+        except Exception as exc:
+            log.warning("cnn_signal: failed to load checkpoint", path=str(path), error=str(exc))
+
+    # ── Training ──────────────────────────────────────────────────────────────
+
+    def train(
+        self,
+        tickers: list[str],
+        period: str = "2y",
+        test_size: float = 0.2,
+        epochs: int = 5,
+        lr: float = 1e-3,
+        batch_size: int = 64,
+    ) -> dict[str, float]:
+        if not _TORCH_AVAILABLE:
+            raise RuntimeError(
+                "PyTorch is not installed. Run: pip install 'torch>=2.0.0'"
+            )
+
+        log.info("cnn_signal: building feature matrix", tickers=len(tickers), period=period)
+        fm = build_feature_matrix(tickers, period=period)
+        if fm.empty:
+            raise ValueError("Feature matrix is empty — check tickers and period")
+        fm = fm.dropna(subset=[_TARGET_COL])
+        if fm.empty:
+            raise ValueError(f"No rows with non-NaN target '{_TARGET_COL}'")
+
+        closes = {t: fetch_ohlcv(t, period)["Close"].astype(float)
+                  for t in tickers if fetch_ohlcv(t, period) is not None}
+
+        X, y, idx = _build_image_dataset(fm, closes, window=self._window)
+        if X is None:
+            raise ValueError("cnn_signal: no usable image samples")
+
+        all_dates = sorted({d for d, _ in idx})
+        split = int(len(all_dates) * (1 - test_size))
+        train_mask = np.array([d in set(all_dates[:split]) for d, _ in idx])
+        test_mask = ~train_mask
+
+        X_t = torch.from_numpy(X)
+        y_t = torch.from_numpy(y)
+
+        model = _ChartCNN(window=self._window)
+        opt = torch.optim.Adam(model.parameters(), lr=lr)
+        loss_fn = nn.MSELoss()
+        for _epoch in range(int(epochs)):
+            model.train()
+            perm = torch.randperm(len(X_t))
+            for start in range(0, len(perm), batch_size):
+                batch = perm[start : start + batch_size]
+                opt.zero_grad()
+                pred = model(X_t[batch])
+                loss = loss_fn(pred, y_t[batch])
+                loss.backward()
+                opt.step()
+
+        model.eval()
+        self._model = model
+        with torch.no_grad():
+            preds = model(X_t).cpu().numpy()
+        train_ic = _spearman_corr(preds[train_mask], y[train_mask]) if train_mask.any() else 0.0
+        test_ic = _spearman_corr(preds[test_mask], y[test_mask]) if test_mask.any() else 0.0
+
+        Path(self._model_path).parent.mkdir(parents=True, exist_ok=True)
+        torch.save(model.state_dict(), self._model_path)
+        self._write_metadata(
+            n_tickers=len(tickers), period=period,
+            train_ic=train_ic, test_ic=test_ic,
+        )
+        return {
+            "train_ic": float(train_ic),
+            "test_ic": float(test_ic),
+            "train_icir": float(train_ic),
+            "test_icir": float(test_ic),
+            "n_train_samples": int(train_mask.sum()),
+            "n_test_samples": int(test_mask.sum()),
+        }
+
+    # ── Prediction ────────────────────────────────────────────────────────────
+
+    def predict(self, tickers: list[str], period: str = "6mo") -> dict[str, float]:
+        if not _TORCH_AVAILABLE or self._model is None:
+            return self._momentum_fallback(tickers, period)
+
+        try:
+            scores: dict[str, float] = {}
+            for ticker in tickers:
+                df = fetch_ohlcv(ticker, period)
+                if df is None or len(df) < self._window:
+                    scores[ticker] = 0.0
+                    continue
+                img = to_gramian_angular_field(df["Close"], window=self._window)
+                tensor = torch.from_numpy(img[None, None, ...].astype(np.float32))
+                with torch.no_grad():
+                    raw = float(self._model(tensor).cpu().item())
+                scores[ticker] = float(np.clip(raw, -1.0, 1.0))
+            return scores
+        except Exception as exc:
+            log.warning("cnn_signal.predict: error, falling back to momentum", error=str(exc))
+            return self._momentum_fallback(tickers, period)
+
+    @staticmethod
+    def _momentum_fallback(tickers: list[str], period: str) -> dict[str, float]:
+        from strategies.momentum import compute_momentum_score
+
+        scores: dict[str, float] = {}
+        for ticker in tickers:
+            try:
+                df = fetch_ohlcv(ticker, period)
+                if df is not None and not df.empty:
+                    mom = compute_momentum_score(df)
+                    last_val = mom.dropna().iloc[-1] if not mom.dropna().empty else 0.0
+                    scores[ticker] = float(np.clip(last_val, -1.0, 1.0))
+                else:
+                    scores[ticker] = 0.0
+            except Exception:
+                scores[ticker] = 0.0
+        return scores
+
+    def _write_metadata(
+        self,
+        n_tickers: int,
+        period: str,
+        train_ic: float,
+        test_ic: float,
+    ) -> None:
+        try:
+            from data.db import get_connection
+            conn = get_connection()
+            with conn:
+                conn.execute(
+                    """
+                    INSERT INTO model_metadata
+                        (model_name, trained_at, train_ic, test_ic, n_tickers, period)
+                    VALUES (?, ?, ?, ?, ?, ?)
+                    """,
+                    ("cnn_alpha", time.time(), train_ic, test_ic, n_tickers, period),
+                )
+            conn.close()
+        except Exception as exc:
+            log.warning("cnn_signal: could not write metadata", error=str(exc))

--- a/tests/test_chart_images.py
+++ b/tests/test_chart_images.py
@@ -1,0 +1,79 @@
+"""Tests for analysis/chart_images.py — GAF + OHLC rasterisation."""
+from __future__ import annotations
+
+import os
+import sys
+
+import numpy as np
+import pandas as pd
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from analysis.chart_images import ohlc_to_pixels, to_gramian_angular_field
+
+
+def test_gaf_returns_correct_shape_and_range():
+    series = pd.Series(np.linspace(100, 110, 32))
+    img = to_gramian_angular_field(series, window=16)
+    assert img.shape == (16, 16)
+    assert img.dtype == np.float32
+    assert (img >= -1.0).all() and (img <= 1.0).all()
+
+
+def test_gaf_short_window_returns_zero_image():
+    img = to_gramian_angular_field(pd.Series([1.0, 2.0]), window=8)
+    assert img.shape == (8, 8)
+    assert (img == 0.0).all()
+
+
+def test_gaf_constant_series_returns_ones():
+    img = to_gramian_angular_field(pd.Series([5.0] * 10), window=10)
+    assert img.shape == (10, 10)
+    assert np.allclose(img, 1.0)
+
+
+def test_gaf_is_symmetric():
+    series = pd.Series(np.sin(np.linspace(0, 2 * np.pi, 20)))
+    img = to_gramian_angular_field(series, window=20)
+    np.testing.assert_allclose(img, img.T, atol=1e-6)
+
+
+def test_ohlc_to_pixels_shape_and_value_range():
+    n = 16
+    df = pd.DataFrame({
+        "Open":  np.linspace(100, 110, n),
+        "High":  np.linspace(101, 111, n),
+        "Low":   np.linspace(99, 109, n),
+        "Close": np.linspace(100.5, 110.5, n),
+    })
+    img = ohlc_to_pixels(df, window=n, height=24)
+    assert img.shape == (24, n)
+    assert img.dtype == np.float32
+    assert (img >= 0.0).all() and (img <= 1.0).all()
+    # At least some pixels are lit (we drew something)
+    assert (img > 0).sum() > 0
+
+
+def test_ohlc_to_pixels_short_input_returns_zero_image():
+    df = pd.DataFrame({
+        "Open": [1.0], "High": [2.0], "Low": [0.5], "Close": [1.5],
+    })
+    img = ohlc_to_pixels(df, window=10, height=20)
+    assert img.shape == (20, 10)
+    assert (img == 0.0).all()
+
+
+def test_ohlc_to_pixels_missing_columns_returns_zero():
+    df = pd.DataFrame({"Open": [1, 2, 3], "Close": [1, 2, 3]})
+    img = ohlc_to_pixels(df, window=3, height=10)
+    assert (img == 0.0).all()
+
+
+def test_ohlc_to_pixels_constant_prices_returns_zero():
+    """Hi == Lo across the whole window collapses to a degenerate image."""
+    df = pd.DataFrame({
+        "Open": [5.0] * 8, "High": [5.0] * 8,
+        "Low": [5.0] * 8, "Close": [5.0] * 8,
+    })
+    img = ohlc_to_pixels(df, window=8, height=10)
+    assert (img == 0.0).all()

--- a/tests/test_cnn_signal.py
+++ b/tests/test_cnn_signal.py
@@ -1,0 +1,169 @@
+"""Tests for strategies/cnn_signal.py — CNN over chart images."""
+from __future__ import annotations
+
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pandas as pd
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+try:
+    import torch  # noqa: F401
+    _TORCH = True
+except ImportError:
+    _TORCH = False
+
+skip_no_torch = pytest.mark.skipif(not _TORCH, reason="torch not installed")
+
+
+def _ohlcv(n: int = 80, seed: int = 1) -> pd.DataFrame:
+    rng = np.random.default_rng(seed)
+    close = 100 + np.cumsum(rng.standard_normal(n) * 0.5)
+    idx = pd.date_range("2024-01-01", periods=n, freq="B")
+    return pd.DataFrame({
+        "Open": close * 0.99, "High": close * 1.01,
+        "Low": close * 0.98, "Close": close,
+        "Volume": rng.integers(1_000_000, 5_000_000, n).astype(float),
+    }, index=idx)
+
+
+def _feature_matrix(tickers: list[str], n_dates: int = 60) -> pd.DataFrame:
+    dates = pd.date_range("2024-01-01", periods=n_dates, freq="B")
+    rows, idx = [], []
+    rng = np.random.default_rng(42)
+    for date in dates:
+        for ticker in tickers:
+            rows.append({"fwd_ret_5d": float(rng.standard_normal()) * 0.01})
+            idx.append((date, ticker))
+    mi = pd.MultiIndex.from_tuples(idx, names=["date", "ticker"])
+    return pd.DataFrame(rows, index=mi)
+
+
+# ── Gating ────────────────────────────────────────────────────────────────────
+
+def test_train_raises_when_torch_missing():
+    from strategies import cnn_signal as mod
+    with (
+        patch.object(mod, "_TORCH_AVAILABLE", False),
+        patch.object(mod.CNNSignal, "_load_if_available"),
+    ):
+        signal = mod.CNNSignal(model_path="/tmp/x.pt")
+        with pytest.raises(RuntimeError, match="PyTorch"):
+            signal.train(["AAPL"])
+
+
+def test_predict_no_model_falls_back_to_momentum():
+    from strategies import cnn_signal as mod
+    with (
+        patch.object(mod.CNNSignal, "_load_if_available"),
+        patch.object(
+            mod.CNNSignal, "_momentum_fallback", return_value={"AAPL": 0.4},
+        ) as fb,
+    ):
+        signal = mod.CNNSignal(model_path="/tmp/x.pt")
+        out = signal.predict(["AAPL"], period="6mo")
+    fb.assert_called_once()
+    assert out == {"AAPL": 0.4}
+
+
+def test_momentum_fallback_handles_missing_data():
+    from strategies.cnn_signal import CNNSignal
+    with patch("strategies.cnn_signal.CNNSignal._load_if_available"):
+        signal = CNNSignal(model_path="/tmp/x.pt")
+    with patch("strategies.cnn_signal.fetch_ohlcv", return_value=None):
+        out = signal._momentum_fallback(["AAPL"], "6mo")
+    assert out == {"AAPL": 0.0}
+
+
+def test_load_if_available_corrupt_file_does_not_raise(tmp_path):
+    bad = tmp_path / "bad.pt"
+    bad.write_bytes(b"not_a_real_torch_pickle")
+    from strategies.cnn_signal import CNNSignal
+    signal = CNNSignal(model_path=str(bad))
+    assert signal._model is None
+
+
+def test_write_metadata_silences_db_errors():
+    from strategies.cnn_signal import CNNSignal
+    with patch("strategies.cnn_signal.CNNSignal._load_if_available"):
+        signal = CNNSignal(model_path="/tmp/x.pt")
+    with patch("data.db.get_connection", side_effect=RuntimeError("no db")):
+        signal._write_metadata(n_tickers=1, period="2y", train_ic=0.1, test_ic=0.05)
+
+
+# ── _build_image_dataset ──────────────────────────────────────────────────────
+
+def test_build_image_dataset_drops_short_history_and_nan_target():
+    from strategies.cnn_signal import _build_image_dataset
+    closes = {"AAPL": _ohlcv(n=80)["Close"]}
+    fm = _feature_matrix(["AAPL"], n_dates=60)
+    # Force one NaN target
+    fm.iloc[0, fm.columns.get_loc("fwd_ret_5d")] = np.nan
+    X, y, idx = _build_image_dataset(fm, closes, window=16)
+    assert X is not None and y is not None
+    assert X.shape[1:] == (1, 16, 16)
+    assert len(y) == X.shape[0]
+    assert len(idx) == len(y)
+
+
+def test_build_image_dataset_returns_none_when_no_history():
+    from strategies.cnn_signal import _build_image_dataset
+    fm = _feature_matrix(["AAPL"], n_dates=10)
+    closes = {"AAPL": _ohlcv(n=5)["Close"]}  # too short for window=16
+    X, y, idx = _build_image_dataset(fm, closes, window=16)
+    assert X is None and y is None and idx is None
+
+
+# ── Torch-required full surface ───────────────────────────────────────────────
+
+@skip_no_torch
+def test_train_and_predict_end_to_end_with_synthetic_data():
+    from strategies.cnn_signal import CNNSignal
+
+    fm = _feature_matrix(["AAPL", "MSFT"], n_dates=60)
+
+    def fake_fetch(ticker, period):
+        return _ohlcv(n=80, seed=hash(ticker) % 1000)
+
+    with (
+        patch("strategies.cnn_signal.build_feature_matrix", return_value=fm),
+        patch("strategies.cnn_signal.fetch_ohlcv", side_effect=fake_fetch),
+        patch("strategies.cnn_signal.CNNSignal._load_if_available"),
+        patch("strategies.cnn_signal.CNNSignal._write_metadata"),
+        patch("strategies.cnn_signal.torch.save"),
+        patch("strategies.cnn_signal.Path.mkdir"),
+    ):
+        signal = CNNSignal(model_path="/tmp/test_cnn.pt", window=16)
+        result = signal.train(["AAPL", "MSFT"], period="2y", epochs=1, batch_size=16)
+        assert result["n_train_samples"] > 0
+        scores = signal.predict(["AAPL", "MSFT"], period="6mo")
+        assert set(scores) == {"AAPL", "MSFT"}
+        for v in scores.values():
+            assert -1.0 <= v <= 1.0
+
+
+@skip_no_torch
+def test_train_raises_on_empty_feature_matrix():
+    from strategies.cnn_signal import CNNSignal
+    with (
+        patch("strategies.cnn_signal.build_feature_matrix", return_value=pd.DataFrame()),
+        patch("strategies.cnn_signal.CNNSignal._load_if_available"),
+    ):
+        signal = CNNSignal(model_path="/tmp/x.pt")
+        with pytest.raises(ValueError, match="empty"):
+            signal.train(["AAPL"])
+
+
+@skip_no_torch
+def test_predict_handles_missing_history_gracefully():
+    from strategies.cnn_signal import CNNSignal
+    with patch("strategies.cnn_signal.CNNSignal._load_if_available"):
+        signal = CNNSignal(model_path="/tmp/x.pt", window=16)
+    signal._model = MagicMock()
+    with patch("strategies.cnn_signal.fetch_ohlcv", return_value=None):
+        out = signal.predict(["AAPL"], period="6mo")
+    assert out == {"AAPL": 0.0}


### PR DESCRIPTION
Closes #99.

## Summary
- New `analysis/chart_images.py`: `to_gramian_angular_field()` (GASF over a rolling close window) + `ohlc_to_pixels()` (direct OHLC bar rasteriser).
- New `strategies/cnn_signal.py`: `CNNSignal` wrapping a tiny 2-Conv2d network over the GAF image of each ticker's trailing close window. Same `train()` / `predict()` surface as `LinearSignal`, with a momentum fallback when torch isn't installed or the model hasn't been trained.
- torch is **gated** behind `try: import torch` / `_TORCH_AVAILABLE` (mirrors `strategies/dl_signal.py`).
- Marks ML4T Ch 18 ✅ in `ML_BOOK_MAP.md`.

## Test plan
- [x] `tests/test_chart_images.py` — 8 tests: GAF shape/range/symmetry, constant-series degenerate, short-window zero, OHLC raster shape/range, missing-cols zero, constant-prices zero.
- [x] `tests/test_cnn_signal.py` — 10 tests: missing-torch guard, momentum fallback, corrupt-checkpoint resilience, DB error silencing, image-dataset edge cases, end-to-end synthetic train+predict (torch-only).
- [x] `ruff check .` clean
- [x] `bandit -ll` zero issues

https://claude.ai/code/session_01Gu3iR1MKU5D7zCv8HdbuQu