### PR TITLE
feat: autoencoder risk factors (ML4T Ch 20)

### DIFF
--- a/ML_BOOK_MAP.md
+++ b/ML_BOOK_MAP.md
@@ -127,7 +127,7 @@ graph LR
 | 17 — Deep Learning for Trading               | Keras / PyTorch intro          |   🟡   | `strategies/dl_signal.py` LSTM alpha (torch-gated); full DL workflow partial |
 | 18 — CNNs                                    | image / chart patterns         |   ✅   | `analysis/chart_images.py` (GAF + OHLC raster) + `strategies/cnn_signal.py` (Conv2d alpha) |
 | 19 — RNNs / LSTM                             | sequence models                |   ✅   | `strategies/dl_signal.py` (_LSTMRegressor + windowed training)  |
-| 20 — Autoencoders                            | conditional risk factors       |   ⏳   | deferred                                                        |
+| 20 — Autoencoders                            | conditional risk factors       |   ✅   | `analysis/risk_autoencoder.py` (train_autoencoder + latent_factors + reconstruction_error) |
 | 21 — GANs                                    | synthetic time series          |   ⏳   | deferred                                                        |
 | 22 — Deep Reinforcement Learning             | trading agent                  |   ✅   | `strategies/drl_agent.py` (TradingEnv + PPO DRLAgent); `analysis/rl_sizer.py` handles sizing-only RL |
 

--- a/analysis/risk_autoencoder.py
+++ b/analysis/risk_autoencoder.py
@@ -1,0 +1,167 @@
+"""
+analysis/risk_autoencoder.py — Autoencoder-based latent risk factors.
+
+Implements the conditional-autoencoder pipeline from Jansen,
+*Machine Learning for Algorithmic Trading* (2nd ed.) Chapter 20: fit a
+small fully-connected autoencoder over a panel of returns, treat the
+bottleneck activations as latent risk factors (an ML-native sibling of
+PCA), and expose reconstruction error as a stress signal.
+
+torch is gated through the same try/except pattern used by
+:mod:`strategies.dl_signal`.
+
+Public surface
+--------------
+``AEResult``               — dataclass bundling the trained model
+``train_autoencoder``      — fit on a returns DataFrame
+``latent_factors``         — per-row latent activations (DataFrame)
+``reconstruction_error``   — per-row L2 distance, indexed like input
+
+Reference
+---------
+    Jansen, *Machine Learning for Algorithmic Trading* (2nd ed.) Ch 20.5.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+import pandas as pd
+
+from utils.logger import get_logger
+
+log = get_logger(__name__)
+
+try:
+    import torch  # type: ignore[import]
+    import torch.nn as nn  # type: ignore[import]
+    _TORCH_AVAILABLE = True
+except ImportError:
+    torch = None  # type: ignore[assignment]
+    nn = None  # type: ignore[assignment]
+    _TORCH_AVAILABLE = False
+
+
+def _require_torch() -> None:
+    if not _TORCH_AVAILABLE:
+        raise RuntimeError(
+            "PyTorch is not installed. Run: pip install 'torch>=2.0.0'"
+        )
+
+
+if _TORCH_AVAILABLE:
+
+    class _Autoencoder(nn.Module):  # type: ignore[misc]
+        """Fully-connected encoder/decoder with a single hidden layer per side."""
+
+        def __init__(self, n_features: int, latent_dim: int, hidden: int) -> None:
+            super().__init__()
+            self.encoder = nn.Sequential(
+                nn.Linear(n_features, hidden),
+                nn.ReLU(),
+                nn.Linear(hidden, latent_dim),
+            )
+            self.decoder = nn.Sequential(
+                nn.Linear(latent_dim, hidden),
+                nn.ReLU(),
+                nn.Linear(hidden, n_features),
+            )
+
+        def forward(self, x):  # type: ignore[override]
+            z = self.encoder(x)
+            return self.decoder(z), z
+else:
+    _Autoencoder = None  # type: ignore[assignment]
+
+
+@dataclass(frozen=True)
+class AEResult:
+    """Trained autoencoder artefacts."""
+
+    model: object
+    latent_dim: int
+    feature_names: tuple[str, ...]
+
+
+def _to_tensor(panel: pd.DataFrame) -> "torch.Tensor":  # type: ignore[name-defined]
+    return torch.from_numpy(panel.fillna(0.0).to_numpy(dtype=np.float32))
+
+
+def train_autoencoder(
+    returns: pd.DataFrame,
+    latent_dim: int = 4,
+    hidden: int = 16,
+    epochs: int = 100,
+    lr: float = 1e-3,
+    seed: int = 42,
+) -> AEResult:
+    """Fit an autoencoder on ``returns`` (rows = dates, cols = tickers).
+
+    Raises
+    ------
+    RuntimeError
+        If torch is not installed.
+    ValueError
+        If ``returns`` is empty or has fewer columns than ``latent_dim``.
+    """
+    _require_torch()
+    if returns.empty:
+        raise ValueError("train_autoencoder: empty returns panel")
+    n_features = returns.shape[1]
+    if n_features < latent_dim:
+        raise ValueError(
+            f"train_autoencoder: latent_dim ({latent_dim}) exceeds n_features ({n_features})"
+        )
+
+    torch.manual_seed(int(seed))
+    model = _Autoencoder(n_features=n_features, latent_dim=int(latent_dim), hidden=int(hidden))
+    opt = torch.optim.Adam(model.parameters(), lr=lr)
+    loss_fn = nn.MSELoss()
+
+    X = _to_tensor(returns)
+    model.train()
+    for _epoch in range(int(epochs)):
+        opt.zero_grad()
+        recon, _ = model(X)
+        loss = loss_fn(recon, X)
+        loss.backward()
+        opt.step()
+    model.eval()
+
+    log.info(
+        "risk_autoencoder.train complete",
+        n_dates=len(returns), n_features=n_features,
+        latent_dim=latent_dim, final_loss=float(loss.item()),
+    )
+    return AEResult(
+        model=model,
+        latent_dim=int(latent_dim),
+        feature_names=tuple(str(c) for c in returns.columns),
+    )
+
+
+def latent_factors(result: AEResult, returns: pd.DataFrame) -> pd.DataFrame:
+    """Per-row encoder activations as a ``(n_rows, latent_dim)`` DataFrame."""
+    _require_torch()
+    aligned = returns.reindex(columns=list(result.feature_names))
+    X = _to_tensor(aligned)
+    with torch.no_grad():
+        _, z = result.model(X)  # type: ignore[union-attr]
+    columns = [f"f{i+1}" for i in range(result.latent_dim)]
+    return pd.DataFrame(z.cpu().numpy(), index=aligned.index, columns=columns)
+
+
+def reconstruction_error(result: AEResult, returns: pd.DataFrame) -> pd.Series:
+    """Per-row L2 reconstruction distance.
+
+    Useful as a regime-shift / outlier signal: rows whose error spikes
+    above a recent rolling baseline indicate the panel has moved into a
+    regime the autoencoder hasn't seen.
+    """
+    _require_torch()
+    aligned = returns.reindex(columns=list(result.feature_names))
+    X = _to_tensor(aligned)
+    with torch.no_grad():
+        recon, _ = result.model(X)  # type: ignore[union-attr]
+    err = torch.norm(recon - X, dim=1).cpu().numpy()
+    return pd.Series(err, index=aligned.index, name="ae_recon_err")

--- a/tests/test_risk_autoencoder.py
+++ b/tests/test_risk_autoencoder.py
@@ -1,0 +1,138 @@
+"""Tests for analysis/risk_autoencoder.py — autoencoder risk factors."""
+from __future__ import annotations
+
+import os
+import sys
+from unittest.mock import patch
+
+import numpy as np
+import pandas as pd
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+try:
+    import torch  # noqa: F401
+    _TORCH = True
+except ImportError:
+    _TORCH = False
+
+skip_no_torch = pytest.mark.skipif(not _TORCH, reason="torch not installed")
+
+
+def _low_rank_panel(
+    n_dates: int = 200,
+    n_assets: int = 6,
+    rank: int = 2,
+    seed: int = 0,
+) -> pd.DataFrame:
+    """Synthetic returns whose true latent rank is ``rank`` (plus noise)."""
+    rng = np.random.default_rng(seed)
+    factors = rng.standard_normal((n_dates, rank)) * 0.02
+    loadings = rng.standard_normal((rank, n_assets)) * 0.5
+    noise = rng.standard_normal((n_dates, n_assets)) * 0.001
+    panel = factors @ loadings + noise
+    idx = pd.date_range("2024-01-01", periods=n_dates, freq="B")
+    cols = [f"T{i}" for i in range(n_assets)]
+    return pd.DataFrame(panel, index=idx, columns=cols)
+
+
+# ── Gating ────────────────────────────────────────────────────────────────────
+
+def test_train_autoencoder_raises_without_torch():
+    from analysis import risk_autoencoder as mod
+    with patch.object(mod, "_TORCH_AVAILABLE", False):
+        with pytest.raises(RuntimeError, match="PyTorch"):
+            mod.train_autoencoder(_low_rank_panel())
+
+
+def test_latent_factors_raises_without_torch():
+    from analysis import risk_autoencoder as mod
+    with patch.object(mod, "_TORCH_AVAILABLE", False):
+        with pytest.raises(RuntimeError, match="PyTorch"):
+            mod.latent_factors(None, _low_rank_panel())  # type: ignore[arg-type]
+
+
+def test_reconstruction_error_raises_without_torch():
+    from analysis import risk_autoencoder as mod
+    with patch.object(mod, "_TORCH_AVAILABLE", False):
+        with pytest.raises(RuntimeError, match="PyTorch"):
+            mod.reconstruction_error(None, _low_rank_panel())  # type: ignore[arg-type]
+
+
+def test_train_autoencoder_rejects_empty_panel():
+    from analysis.risk_autoencoder import train_autoencoder
+    if not _TORCH:
+        pytest.skip("torch not installed")
+    with pytest.raises(ValueError, match="empty"):
+        train_autoencoder(pd.DataFrame())
+
+
+def test_train_autoencoder_rejects_too_large_latent_dim():
+    from analysis.risk_autoencoder import train_autoencoder
+    if not _TORCH:
+        pytest.skip("torch not installed")
+    panel = _low_rank_panel(n_assets=3)
+    with pytest.raises(ValueError, match="latent_dim"):
+        train_autoencoder(panel, latent_dim=10)
+
+
+# ── Torch happy paths ────────────────────────────────────────────────────────
+
+@skip_no_torch
+def test_train_returns_correct_artefact_shape():
+    from analysis.risk_autoencoder import latent_factors, train_autoencoder
+    panel = _low_rank_panel(n_dates=120, n_assets=6, rank=2)
+    result = train_autoencoder(panel, latent_dim=2, hidden=8, epochs=20)
+    assert result.latent_dim == 2
+    assert result.feature_names == tuple(panel.columns)
+
+    z = latent_factors(result, panel)
+    assert z.shape == (len(panel), 2)
+    assert list(z.columns) == ["f1", "f2"]
+
+
+@skip_no_torch
+def test_reconstruction_error_decreases_after_training():
+    """A trained autoencoder must reconstruct better than a random init."""
+    from analysis import risk_autoencoder as mod
+
+    panel = _low_rank_panel(n_dates=200, n_assets=6, rank=2, seed=7)
+    init = mod.train_autoencoder(panel, latent_dim=2, hidden=8, epochs=1, seed=7)
+    init_err = mod.reconstruction_error(init, panel).mean()
+
+    trained = mod.train_autoencoder(panel, latent_dim=2, hidden=8, epochs=200, seed=7)
+    trained_err = mod.reconstruction_error(trained, panel).mean()
+
+    assert trained_err < init_err
+
+
+@skip_no_torch
+def test_reconstruction_error_index_matches_input():
+    from analysis import risk_autoencoder as mod
+    panel = _low_rank_panel(n_dates=50, n_assets=4, rank=2)
+    result = mod.train_autoencoder(panel, latent_dim=2, hidden=8, epochs=10)
+    err = mod.reconstruction_error(result, panel)
+    assert err.shape == (len(panel),)
+    assert (err.index == panel.index).all()
+
+
+@skip_no_torch
+def test_latent_factors_align_with_input_index():
+    from analysis import risk_autoencoder as mod
+    panel = _low_rank_panel(n_dates=40, n_assets=4, rank=2)
+    result = mod.train_autoencoder(panel, latent_dim=2, hidden=8, epochs=10)
+    z = mod.latent_factors(result, panel)
+    assert (z.index == panel.index).all()
+
+
+@skip_no_torch
+def test_train_autoencoder_handles_nan_inputs_via_fill():
+    """NaNs in the panel should not crash; they're zero-filled internally."""
+    from analysis.risk_autoencoder import train_autoencoder
+    panel = _low_rank_panel(n_dates=60, n_assets=4, rank=2)
+    panel.iloc[0, 0] = np.nan
+    panel.iloc[5, 2] = np.nan
+    # Should not raise
+    result = train_autoencoder(panel, latent_dim=2, hidden=8, epochs=5)
+    assert result.latent_dim == 2


### PR DESCRIPTION
Closes #100.

## Summary
- New `analysis/risk_autoencoder.py`: small fully-connected encoder/decoder trained on a returns panel via torch.
- `train_autoencoder()` returns an `AEResult`; `latent_factors()` exposes per-row bottleneck activations as a DataFrame; `reconstruction_error()` returns per-row L2 distance for regime-shift detection.
- torch is **gated** behind `try: import torch` / `_TORCH_AVAILABLE` (mirrors `strategies/dl_signal.py`).
- Marks ML4T Ch 20 ✅ in `ML_BOOK_MAP.md`.

## Test plan
- [x] 10 tests in `tests/test_risk_autoencoder.py`: missing-torch guards on all three public functions, empty/oversized-latent rejection, artefact shape, reconstruction error decreases after training, index alignment, NaN-input fill-through.
- [x] `ruff check .` clean
- [x] `bandit -ll` zero issues

https://claude.ai/code/session_01Gu3iR1MKU5D7zCv8HdbuQu