### PR TITLE
feat: minimal LSTM-GAN for synthetic return paths (ML4T Ch 21)

### DIFF
--- a/ML_BOOK_MAP.md
+++ b/ML_BOOK_MAP.md
@@ -96,7 +96,7 @@ graph LR
 | 10 — Bet Sizing                              | Kelly, dynamic allocation      |   ✅   | `risk/kelly.py`, `strategies/ml_execution.py`                   |
 | 11 — Dangers of Backtesting                  | deflated Sharpe, PBO           |   ✅   | `analysis/deflated_sharpe.py` (deflated_sharpe + probability_backtest_overfitting) |
 | 12 — Backtesting Through Cross-Validation    | combinatorial-purged CV        |   ✅   | `backtester/combinatorial_cv.py` (combinatorial_purged_cv + paths_dataframe) |
-| 13 — Backtesting on Synthetic Data           | bootstrap, GAN                 |   🟡   | bootstrap in `backtester/monte_carlo.py`; GAN out of scope      |
+| 13 — Backtesting on Synthetic Data           | bootstrap, GAN                 |   ✅   | bootstrap in `backtester/monte_carlo.py`; LSTM-GAN in `analysis/synthetic_paths.py` |
 | 14 — Backtest Statistics                     | Sharpe, Sortino, MAR           |   ✅   | `analysis/risk_metrics.py`, `backtester/engine.py`              |
 | 15 — Understanding Strategy Risk             | efficient frontier, VaR        |   ✅   | `risk/markowitz.py`, `risk/var.py`                              |
 | 16 — ML Asset Allocation                     | Hierarchical Risk Parity       |   ✅   | `risk/hrp.py` (quasi-diag + recursive bisection)                 |
@@ -128,7 +128,7 @@ graph LR
 | 18 — CNNs                                    | image / chart patterns         |   ✅   | `analysis/chart_images.py` (GAF + OHLC raster) + `strategies/cnn_signal.py` (Conv2d alpha) |
 | 19 — RNNs / LSTM                             | sequence models                |   ✅   | `strategies/dl_signal.py` (_LSTMRegressor + windowed training)  |
 | 20 — Autoencoders                            | conditional risk factors       |   ✅   | `analysis/risk_autoencoder.py` (train_autoencoder + latent_factors + reconstruction_error) |
-| 21 — GANs                                    | synthetic time series          |   ⏳   | deferred                                                        |
+| 21 — GANs                                    | synthetic time series          |   ✅   | `analysis/synthetic_paths.py` (LSTM-GAN train_generator + sample_paths) |
 | 22 — Deep Reinforcement Learning             | trading agent                  |   ✅   | `strategies/drl_agent.py` (TradingEnv + PPO DRLAgent); `analysis/rl_sizer.py` handles sizing-only RL |
 
 Legend: ✅ implemented · 🟡 partial · ⏳ planned (issue) · _blank_ deferred.

--- a/analysis/synthetic_paths.py
+++ b/analysis/synthetic_paths.py
@@ -1,0 +1,215 @@
+"""
+analysis/synthetic_paths.py — Minimal GAN for synthetic return time series.
+
+Implements a small adversarial generator inspired by the TimeGAN
+sketch in Jansen, *Machine Learning for Algorithmic Trading*
+(2nd ed.) Chapter 21. The full TimeGAN includes supervised + recovery
+heads in addition to the adversarial loss; this module ships only the
+adversarial pair (LSTM generator + LSTM discriminator) so the moving
+parts stay readable and the training loop fits in a single test.
+
+The intended consumer is :mod:`backtester.monte_carlo` (which already
+exposes a bootstrap-based path generator); ``sample_paths`` here gives
+backtests an alternative source of synthetic stress paths whose
+auto-correlation structure is learned, not block-bootstrapped.
+
+torch is gated through the same try/except pattern used by
+:mod:`strategies.dl_signal`.
+
+Public surface
+--------------
+``GeneratorResult``      — dataclass bundling the trained generator
+``train_generator``      — fit on a 1-D return series
+``sample_paths``         — draw fresh ``(n_paths, horizon)`` paths
+
+Reference
+---------
+    Jansen, *Machine Learning for Algorithmic Trading* (2nd ed.) Ch 21.4.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+import pandas as pd
+
+from utils.logger import get_logger
+
+log = get_logger(__name__)
+
+try:
+    import torch  # type: ignore[import]
+    import torch.nn as nn  # type: ignore[import]
+    _TORCH_AVAILABLE = True
+except ImportError:
+    torch = None  # type: ignore[assignment]
+    nn = None  # type: ignore[assignment]
+    _TORCH_AVAILABLE = False
+
+
+def _require_torch() -> None:
+    if not _TORCH_AVAILABLE:
+        raise RuntimeError(
+            "PyTorch is not installed. Run: pip install 'torch>=2.0.0'"
+        )
+
+
+if _TORCH_AVAILABLE:
+
+    class _LSTMGenerator(nn.Module):  # type: ignore[misc]
+        """Maps Gaussian noise sequences to scalar return paths."""
+
+        def __init__(self, latent_dim: int, hidden: int) -> None:
+            super().__init__()
+            self.lstm = nn.LSTM(latent_dim, hidden, num_layers=1, batch_first=True)
+            self.head = nn.Linear(hidden, 1)
+
+        def forward(self, z):  # type: ignore[override]
+            out, _ = self.lstm(z)
+            return self.head(out).squeeze(-1)  # (batch, horizon)
+
+    class _LSTMDiscriminator(nn.Module):  # type: ignore[misc]
+        """Scores a return path as real (→ 1) or synthetic (→ 0)."""
+
+        def __init__(self, hidden: int) -> None:
+            super().__init__()
+            self.lstm = nn.LSTM(1, hidden, num_layers=1, batch_first=True)
+            self.head = nn.Linear(hidden, 1)
+
+        def forward(self, x):  # type: ignore[override]
+            out, _ = self.lstm(x.unsqueeze(-1))
+            return torch.sigmoid(self.head(out[:, -1, :])).squeeze(-1)
+else:
+    _LSTMGenerator = None  # type: ignore[assignment]
+    _LSTMDiscriminator = None  # type: ignore[assignment]
+
+
+@dataclass(frozen=True)
+class GeneratorResult:
+    """Trained generator artefacts."""
+
+    generator: object
+    latent_dim: int
+    horizon: int
+    train_mean: float
+    train_std: float
+
+
+def _windows(returns: np.ndarray, horizon: int) -> np.ndarray:
+    if len(returns) < horizon:
+        raise ValueError(f"need at least {horizon} returns, got {len(returns)}")
+    n = len(returns) - horizon + 1
+    out = np.stack([returns[i : i + horizon] for i in range(n)], axis=0)
+    return out.astype(np.float32)
+
+
+def train_generator(
+    returns: pd.Series | np.ndarray,
+    horizon: int = 20,
+    latent_dim: int = 8,
+    hidden: int = 16,
+    epochs: int = 50,
+    batch_size: int = 32,
+    lr: float = 1e-3,
+    seed: int = 42,
+) -> GeneratorResult:
+    """Fit a tiny LSTM-GAN on rolling windows of ``returns``.
+
+    Raises
+    ------
+    RuntimeError
+        If torch is not installed.
+    ValueError
+        If ``returns`` is shorter than ``horizon``.
+    """
+    _require_torch()
+    arr = np.asarray(pd.Series(returns).dropna().to_numpy(dtype=float))
+    if arr.size < horizon:
+        raise ValueError(f"train_generator: need ≥{horizon} returns, got {arr.size}")
+
+    mean = float(arr.mean())
+    std = float(arr.std()) or 1.0
+    standardised = (arr - mean) / std
+
+    real_windows = _windows(standardised, horizon)
+
+    torch.manual_seed(int(seed))
+    G = _LSTMGenerator(latent_dim=int(latent_dim), hidden=int(hidden))
+    D = _LSTMDiscriminator(hidden=int(hidden))
+    g_opt = torch.optim.Adam(G.parameters(), lr=lr)
+    d_opt = torch.optim.Adam(D.parameters(), lr=lr)
+    bce = nn.BCELoss()
+
+    real_t = torch.from_numpy(real_windows)
+    n = len(real_t)
+    for _epoch in range(int(epochs)):
+        perm = torch.randperm(n)
+        for start in range(0, n, batch_size):
+            idx = perm[start : start + batch_size]
+            real_batch = real_t[idx]
+            bs = real_batch.shape[0]
+
+            # Discriminator step
+            d_opt.zero_grad()
+            z = torch.randn(bs, horizon, latent_dim)
+            fake = G(z).detach()
+            d_real = D(real_batch)
+            d_fake = D(fake)
+            d_loss = bce(d_real, torch.ones(bs)) + bce(d_fake, torch.zeros(bs))
+            d_loss.backward()
+            d_opt.step()
+
+            # Generator step
+            g_opt.zero_grad()
+            z = torch.randn(bs, horizon, latent_dim)
+            fake = G(z)
+            g_loss = bce(D(fake), torch.ones(bs))
+            g_loss.backward()
+            g_opt.step()
+
+    G.eval()
+    log.info(
+        "synthetic_paths.train complete",
+        n_windows=int(n), horizon=horizon, latent_dim=latent_dim,
+    )
+    return GeneratorResult(
+        generator=G, latent_dim=int(latent_dim), horizon=int(horizon),
+        train_mean=mean, train_std=std,
+    )
+
+
+def sample_paths(
+    result: GeneratorResult,
+    n_paths: int,
+    horizon: int | None = None,
+    seed: int | None = None,
+) -> np.ndarray:
+    """Draw ``n_paths`` synthetic return paths.
+
+    Parameters
+    ----------
+    result :
+        Output of :func:`train_generator`.
+    n_paths :
+        Number of paths to draw.
+    horizon :
+        Length of each path. Defaults to the generator's training
+        horizon; callers may shorten freely (LSTM unrolls to any length).
+    seed :
+        Optional seed for reproducible noise.
+
+    Returns
+    -------
+    np.ndarray
+        ``(n_paths, horizon)`` array of returns on the original
+        (un-standardised) scale.
+    """
+    _require_torch()
+    h = int(horizon if horizon is not None else result.horizon)
+    if seed is not None:
+        torch.manual_seed(int(seed))
+
+    z = torch.randn(int(n_paths), h, result.latent_dim)
+    with torch.no_grad():
+        synth = result.generator(z).cpu().numpy()  # type: ignore[union-attr]
+    return synth * result.train_std + result.train_mean

--- a/tests/test_synthetic_paths.py
+++ b/tests/test_synthetic_paths.py
@@ -1,0 +1,110 @@
+"""Tests for analysis/synthetic_paths.py — minimal LSTM-GAN."""
+from __future__ import annotations
+
+import os
+import sys
+from unittest.mock import patch
+
+import numpy as np
+import pandas as pd
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+try:
+    import torch  # noqa: F401
+    _TORCH = True
+except ImportError:
+    _TORCH = False
+
+skip_no_torch = pytest.mark.skipif(not _TORCH, reason="torch not installed")
+
+
+def _ar1(n: int = 500, phi: float = 0.3, sigma: float = 0.01, seed: int = 0) -> pd.Series:
+    rng = np.random.default_rng(seed)
+    eps = rng.standard_normal(n) * sigma
+    out = np.empty(n)
+    out[0] = eps[0]
+    for t in range(1, n):
+        out[t] = phi * out[t - 1] + eps[t]
+    idx = pd.date_range("2024-01-01", periods=n, freq="B")
+    return pd.Series(out, index=idx, name="ret")
+
+
+# ── Gating ────────────────────────────────────────────────────────────────────
+
+def test_train_generator_raises_without_torch():
+    from analysis import synthetic_paths as mod
+    with patch.object(mod, "_TORCH_AVAILABLE", False):
+        with pytest.raises(RuntimeError, match="PyTorch"):
+            mod.train_generator(_ar1())
+
+
+def test_sample_paths_raises_without_torch():
+    from analysis import synthetic_paths as mod
+    with patch.object(mod, "_TORCH_AVAILABLE", False):
+        with pytest.raises(RuntimeError, match="PyTorch"):
+            mod.sample_paths(None, 5)  # type: ignore[arg-type]
+
+
+def test_train_generator_rejects_too_short_series():
+    from analysis.synthetic_paths import train_generator
+    if not _TORCH:
+        pytest.skip("torch not installed")
+    with pytest.raises(ValueError, match="≥|need"):
+        train_generator(pd.Series([0.01, 0.02, 0.03]), horizon=10)
+
+
+# ── Torch happy paths ────────────────────────────────────────────────────────
+
+@skip_no_torch
+def test_train_returns_correct_artefact_shape():
+    from analysis.synthetic_paths import train_generator
+    series = _ar1(n=200, seed=1)
+    result = train_generator(series, horizon=8, latent_dim=4, hidden=8, epochs=2, batch_size=16)
+    assert result.horizon == 8
+    assert result.latent_dim == 4
+    assert isinstance(result.train_mean, float)
+    assert isinstance(result.train_std, float)
+    assert result.train_std > 0
+
+
+@skip_no_torch
+def test_sample_paths_returns_correct_shape():
+    from analysis.synthetic_paths import sample_paths, train_generator
+    series = _ar1(n=200, seed=2)
+    result = train_generator(series, horizon=8, latent_dim=4, hidden=8, epochs=1, batch_size=16)
+    paths = sample_paths(result, n_paths=12, seed=0)
+    assert paths.shape == (12, 8)
+    assert np.isfinite(paths).all()
+
+
+@skip_no_torch
+def test_sample_paths_reproducible_with_seed():
+    from analysis.synthetic_paths import sample_paths, train_generator
+    series = _ar1(n=200, seed=3)
+    result = train_generator(series, horizon=6, latent_dim=4, hidden=8, epochs=1, batch_size=16)
+    a = sample_paths(result, n_paths=4, seed=42)
+    b = sample_paths(result, n_paths=4, seed=42)
+    np.testing.assert_array_equal(a, b)
+
+
+@skip_no_torch
+def test_sample_paths_supports_shorter_horizon_than_training():
+    from analysis.synthetic_paths import sample_paths, train_generator
+    series = _ar1(n=200, seed=4)
+    result = train_generator(series, horizon=10, latent_dim=4, hidden=8, epochs=1, batch_size=16)
+    paths = sample_paths(result, n_paths=3, horizon=4, seed=1)
+    assert paths.shape == (3, 4)
+
+
+@skip_no_torch
+def test_sample_paths_match_input_scale_order_of_magnitude():
+    """Generator outputs should sit on the same numerical scale as training data."""
+    from analysis.synthetic_paths import sample_paths, train_generator
+    series = _ar1(n=400, sigma=0.02, seed=5)
+    result = train_generator(series, horizon=10, latent_dim=4, hidden=8, epochs=10, batch_size=32)
+    paths = sample_paths(result, n_paths=200, seed=10)
+    # Std-of-stds rather than mean-of-stds — adversarial training is noisy
+    # but the output should still live within an order of magnitude of input.
+    assert 0.1 * series.std() <= paths.std() <= 10 * series.std()


### PR DESCRIPTION
Closes #101.

## Summary
- New `analysis/synthetic_paths.py`: minimal LSTM-GAN — `_LSTMGenerator` + `_LSTMDiscriminator` + adversarial training loop. Stays under ~150 LOC by skipping TimeGAN's supervised + reconstruction heads (per the ticket scope).
- `train_generator()` fits on rolling windows of returns; `sample_paths(result, n_paths, horizon)` draws fresh `(n_paths, horizon)` arrays on the original return scale.
- Complements the existing block-bootstrap path generator in `backtester/monte_carlo.py`.
- torch is **gated** behind `try: import torch` / `_TORCH_AVAILABLE` (mirrors `strategies/dl_signal.py`).
- `ML_BOOK_MAP.md`: Ch 21 ⏳ → ✅, and AFML Ch 13 (Backtesting on Synthetic Data) 🟡 → ✅ since the GAN angle is now covered.

## Test plan
- [x] 8 tests in `tests/test_synthetic_paths.py`: missing-torch guards, too-short-series rejection, artefact shape, sample shape, seed reproducibility, variable-horizon support, and order-of-magnitude scale alignment.
- [x] `ruff check .` clean
- [x] `bandit -ll` zero issues

https://claude.ai/code/session_01Gu3iR1MKU5D7zCv8HdbuQu