### PR TITLE
feat: feed-forward MLP alpha (ML4T Ch 17)

### DIFF
--- a/ML_BOOK_MAP.md
+++ b/ML_BOOK_MAP.md
@@ -124,7 +124,7 @@ graph LR
 | 14 — Text Data / Sentiment Analysis          | Vader, VADER                   |   ✅   | `adapters/sentiment/vader_adapter.py`                           |
 | 15 — Topic Modeling                          | LDA on news                    |   ✅   | `analysis/topic_modeling.py` (fit_lda + infer_topics + top_terms_per_topic + ticker_topic_distribution) |
 | 16 — Word Embeddings                         | word2vec on filings            |   ✅   | `analysis/word_embeddings.py` (train_embeddings + document_embedding + nearest_terms via gensim) |
-| 17 — Deep Learning for Trading               | Keras / PyTorch intro          |   🟡   | `strategies/dl_signal.py` LSTM alpha (torch-gated); full DL workflow partial |
+| 17 — Deep Learning for Trading               | Keras / PyTorch intro          |   ✅   | `strategies/mlp_signal.py` (sklearn MLPRegressor, FFN intro) + `strategies/dl_signal.py` LSTM (torch) |
 | 18 — CNNs                                    | image / chart patterns         |   ✅   | `analysis/chart_images.py` (GAF + OHLC raster) + `strategies/cnn_signal.py` (Conv2d alpha) |
 | 19 — RNNs / LSTM                             | sequence models                |   ✅   | `strategies/dl_signal.py` (_LSTMRegressor + windowed training)  |
 | 20 — Autoencoders                            | conditional risk factors       |   ✅   | `analysis/risk_autoencoder.py` (train_autoencoder + latent_factors + reconstruction_error) |

--- a/strategies/mlp_signal.py
+++ b/strategies/mlp_signal.py
@@ -1,0 +1,253 @@
+"""
+strategies/mlp_signal.py — Feed-forward MLP alpha (Jansen ML4T Ch 17).
+
+Mirror of :mod:`strategies.linear_signal` but with ``MLPRegressor``
+instead of Ridge.  Same train/predict surface so the ensemble blender,
+the ml_signals UI, and the daily_ml_execute cron path can pick it up
+without any other changes.
+
+Backed by ``sklearn.neural_network.MLPRegressor`` (already a dep);
+torch is reserved for the deeper Ch 18 / Ch 19 / Ch 20 / Ch 21 modules
+(``cnn_signal.py``, ``dl_signal.py``, ``risk_autoencoder.py``,
+``synthetic_paths.py``).
+
+ENV vars
+--------
+    MLP_ALPHA_MODEL_PATH    path to model pickle (default: models/mlp_alpha.pkl)
+"""
+from __future__ import annotations
+
+import os
+import pickle
+import time
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+from analysis.factor_ic import _spearman_corr
+from data.features import _FEATURE_COLS, build_feature_matrix
+from utils.logger import get_logger
+
+log = get_logger(__name__)
+
+try:
+    from sklearn.neural_network import MLPRegressor
+    _SKLEARN_AVAILABLE = True
+except ImportError:
+    MLPRegressor = None  # type: ignore[assignment,misc]
+    _SKLEARN_AVAILABLE = False
+
+
+_DEFAULT_MODEL_PATH = os.environ.get("MLP_ALPHA_MODEL_PATH", "models/mlp_alpha.pkl")
+_TARGET_COL = "fwd_ret_5d"
+
+
+class MLPSignal:
+    """Feed-forward MLP cross-sectional alpha model."""
+
+    def __init__(self, model_path: str | None = None) -> None:
+        self._model_path: str = model_path or _DEFAULT_MODEL_PATH
+        self._model = None  # MLPRegressor | None
+        self._feature_cols: list[str] = list(_FEATURE_COLS)
+        self._load_if_available()
+
+    # ── Persistence ───────────────────────────────────────────────────────────
+
+    def _load_if_available(self) -> None:
+        path = Path(self._model_path)
+        if not path.exists():
+            log.info("mlp_signal: no checkpoint found", path=str(path))
+            return
+        try:
+            with open(path, "rb") as f:
+                self._model = pickle.load(f)
+            log.info("mlp_signal: loaded checkpoint", path=str(path))
+        except Exception as exc:
+            log.warning("mlp_signal: failed to load checkpoint", path=str(path), error=str(exc))
+
+    # ── Training ──────────────────────────────────────────────────────────────
+
+    def train(
+        self,
+        tickers: list[str],
+        period: str = "2y",
+        test_size: float = 0.2,
+        hidden_layer_sizes: tuple[int, ...] = (32, 16),
+        alpha: float = 1e-3,
+        max_iter: int = 200,
+        random_state: int = 42,
+    ) -> dict[str, float]:
+        """Fit MLPRegressor on the cross-sectional feature matrix.
+
+        Returns the standard
+        ``{train_ic, test_ic, train_icir, test_icir,
+            n_train_samples, n_test_samples}`` schema.
+        """
+        if not _SKLEARN_AVAILABLE:
+            raise RuntimeError(
+                "scikit-learn is not installed. Run: pip install scikit-learn>=1.3.0"
+            )
+
+        log.info("mlp_signal: building feature matrix", tickers=len(tickers), period=period)
+        fm = build_feature_matrix(tickers, period=period)
+        if fm.empty:
+            raise ValueError("Feature matrix is empty — check tickers and period")
+
+        fm = fm.dropna(subset=[_TARGET_COL])
+        if fm.empty:
+            raise ValueError(f"No rows with non-NaN target '{_TARGET_COL}'")
+
+        all_dates = sorted(fm.index.get_level_values("date").unique())
+        split_idx = int(len(all_dates) * (1 - test_size))
+        train_dates = set(all_dates[:split_idx])
+        test_dates = set(all_dates[split_idx:])
+
+        feature_cols = [c for c in _FEATURE_COLS if c in fm.columns]
+        self._feature_cols = feature_cols
+
+        train_df = fm[fm.index.get_level_values("date").isin(train_dates)]
+        test_df = fm[fm.index.get_level_values("date").isin(test_dates)]
+
+        X_train = train_df[feature_cols].fillna(0.0).values
+        y_train = train_df[_TARGET_COL].values
+        X_test = test_df[feature_cols].fillna(0.0).values
+        y_test = test_df[_TARGET_COL].values
+
+        log.info(
+            "mlp_signal: training MLPRegressor",
+            n_train=len(X_train), n_test=len(X_test),
+            features=len(feature_cols),
+            hidden_layer_sizes=hidden_layer_sizes,
+            alpha=alpha, max_iter=max_iter,
+        )
+
+        model = MLPRegressor(
+            hidden_layer_sizes=tuple(int(h) for h in hidden_layer_sizes),
+            alpha=float(alpha),
+            max_iter=int(max_iter),
+            random_state=int(random_state),
+            early_stopping=False,
+        )
+        model.fit(X_train, y_train)
+        self._model = model
+
+        train_ic = _spearman_corr(model.predict(X_train), y_train)
+        test_ic = _spearman_corr(model.predict(X_test), y_test)
+
+        Path(self._model_path).parent.mkdir(parents=True, exist_ok=True)
+        with open(self._model_path, "wb") as f:
+            pickle.dump(model, f)
+
+        log.info(
+            "mlp_signal: training complete",
+            train_ic=round(train_ic, 4), test_ic=round(test_ic, 4),
+            path=self._model_path,
+        )
+
+        self._write_metadata(
+            n_tickers=len(tickers), period=period,
+            train_ic=train_ic, test_ic=test_ic,
+        )
+
+        return {
+            "train_ic": float(train_ic),
+            "test_ic": float(test_ic),
+            "train_icir": float(train_ic),
+            "test_icir": float(test_ic),
+            "n_train_samples": int(len(X_train)),
+            "n_test_samples": int(len(X_test)),
+        }
+
+    # ── Prediction ────────────────────────────────────────────────────────────
+
+    def predict(self, tickers: list[str], period: str = "6mo") -> dict[str, float]:
+        if self._model is None:
+            return self._momentum_fallback(tickers, period)
+
+        try:
+            fm = build_feature_matrix(tickers, period=period)
+            if fm.empty:
+                return self._momentum_fallback(tickers, period)
+
+            feature_cols = [c for c in self._feature_cols if c in fm.columns]
+            last_date = fm.index.get_level_values("date").max()
+            latest = fm.xs(last_date, level="date")[feature_cols].fillna(0.0)
+            if latest.empty:
+                return self._momentum_fallback(tickers, period)
+
+            raw = self._model.predict(latest.values)
+            std = raw.std()
+            scores = np.zeros_like(raw) if std == 0 else (raw - raw.mean()) / std
+            scores = np.clip(scores, -1.0, 1.0)
+            return {ticker: float(scores[i]) for i, ticker in enumerate(latest.index)}
+        except Exception as exc:
+            log.warning("mlp_signal.predict: error, falling back to momentum", error=str(exc))
+            return self._momentum_fallback(tickers, period)
+
+    # ── Feature importances (|first-layer weights| per feature) ───────────────
+
+    def feature_importances(self) -> pd.DataFrame:
+        """Per-feature importance proxy from the first layer's |weight| sum.
+
+        ``MLPRegressor`` exposes ``coefs_[0]`` of shape
+        ``(n_features, hidden_layer_sizes[0])``; row-wise L1 norms give a
+        cheap interpretable importance signal.
+        """
+        if self._model is None:
+            return pd.DataFrame(columns=["feature", "importance"])
+        try:
+            first_layer = self._model.coefs_[0]
+            importances = np.abs(first_layer).sum(axis=1)
+            df = pd.DataFrame({
+                "feature": self._feature_cols[: len(importances)],
+                "importance": importances,
+            })
+            return df.sort_values("importance", ascending=False).reset_index(drop=True)
+        except Exception as exc:
+            log.warning("mlp_signal.feature_importances: error", error=str(exc))
+            return pd.DataFrame(columns=["feature", "importance"])
+
+    # ── Fallback & metadata ───────────────────────────────────────────────────
+
+    @staticmethod
+    def _momentum_fallback(tickers: list[str], period: str) -> dict[str, float]:
+        from data.fetcher import fetch_ohlcv
+        from strategies.momentum import compute_momentum_score
+
+        scores: dict[str, float] = {}
+        for ticker in tickers:
+            try:
+                df = fetch_ohlcv(ticker, period)
+                if df is not None and not df.empty:
+                    mom = compute_momentum_score(df)
+                    last_val = mom.dropna().iloc[-1] if not mom.dropna().empty else 0.0
+                    scores[ticker] = float(np.clip(last_val, -1.0, 1.0))
+                else:
+                    scores[ticker] = 0.0
+            except Exception:
+                scores[ticker] = 0.0
+        return scores
+
+    def _write_metadata(
+        self,
+        n_tickers: int,
+        period: str,
+        train_ic: float,
+        test_ic: float,
+    ) -> None:
+        try:
+            from data.db import get_connection
+            conn = get_connection()
+            with conn:
+                conn.execute(
+                    """
+                    INSERT INTO model_metadata
+                        (model_name, trained_at, train_ic, test_ic, n_tickers, period)
+                    VALUES (?, ?, ?, ?, ?, ?)
+                    """,
+                    ("mlp_alpha", time.time(), train_ic, test_ic, n_tickers, period),
+                )
+            conn.close()
+        except Exception as exc:
+            log.warning("mlp_signal: could not write metadata", error=str(exc))

--- a/tests/test_mlp_signal.py
+++ b/tests/test_mlp_signal.py
@@ -1,0 +1,228 @@
+"""Tests for strategies/mlp_signal.py — feed-forward MLP alpha."""
+from __future__ import annotations
+
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pandas as pd
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+try:
+    import sklearn  # noqa: F401
+    _SKLEARN = True
+except ImportError:
+    _SKLEARN = False
+
+skip_no_sklearn = pytest.mark.skipif(not _SKLEARN, reason="scikit-learn not installed")
+
+
+def _make_feature_matrix(n_dates: int = 40, tickers: list[str] | None = None) -> pd.DataFrame:
+    if tickers is None:
+        tickers = ["AAPL", "MSFT"]
+    dates = pd.date_range("2023-01-01", periods=n_dates, freq="B")
+    feature_cols = [
+        "ret_1d", "ret_5d", "ret_10d", "ret_21d",
+        "skew_21d", "kurt_21d", "autocorr_1", "realised_vol_21d",
+        "vol_ratio_20d", "vol_zscore_20d",
+        "vpin_50d", "kyle_lambda_21d",
+    ]
+    rng = np.random.default_rng(42)
+    rows, idx = [], []
+    for date in dates:
+        for ticker in tickers:
+            row = dict(zip(feature_cols, rng.standard_normal(len(feature_cols))))
+            row["fwd_ret_5d"] = rng.standard_normal()
+            rows.append(row)
+            idx.append((date, ticker))
+    return pd.DataFrame(rows, index=pd.MultiIndex.from_tuples(idx, names=["date", "ticker"]))
+
+
+def _mock_mlp(n_features: int = 12, hidden: int = 8):
+    mock = MagicMock()
+    mock.coefs_ = [np.random.default_rng(0).standard_normal((n_features, hidden))]
+    mock.predict.side_effect = lambda X: np.random.default_rng(1).standard_normal(len(X))
+    return mock
+
+
+# ── No-model / gating tests ──────────────────────────────────────────────────
+
+def test_feature_importances_empty_without_model():
+    from strategies.mlp_signal import MLPSignal
+    with patch("strategies.mlp_signal.MLPSignal._load_if_available"):
+        model = MLPSignal(model_path="/nonexistent.pkl")
+    df = model.feature_importances()
+    assert df.empty
+    assert list(df.columns) == ["feature", "importance"]
+
+
+def test_predict_falls_back_to_momentum_with_no_model():
+    from strategies.mlp_signal import MLPSignal
+    with (
+        patch("strategies.mlp_signal.MLPSignal._load_if_available"),
+        patch(
+            "strategies.mlp_signal.MLPSignal._momentum_fallback",
+            return_value={"AAPL": 0.42},
+        ) as fb,
+    ):
+        model = MLPSignal(model_path="/nonexistent.pkl")
+        result = model.predict(["AAPL"], period="6mo")
+    fb.assert_called_once()
+    assert result == {"AAPL": 0.42}
+
+
+def test_train_raises_when_sklearn_missing():
+    from strategies.mlp_signal import MLPSignal
+    with (
+        patch("strategies.mlp_signal._SKLEARN_AVAILABLE", False),
+        patch("strategies.mlp_signal.MLPSignal._load_if_available"),
+    ):
+        model = MLPSignal(model_path="/tmp/x.pkl")
+        with pytest.raises(RuntimeError, match="scikit-learn"):
+            model.train(["AAPL"])
+
+
+def test_momentum_fallback_returns_zero_on_missing_data():
+    from strategies.mlp_signal import MLPSignal
+    with patch("strategies.mlp_signal.MLPSignal._load_if_available"):
+        model = MLPSignal(model_path="/tmp/x.pkl")
+    with patch("data.fetcher.fetch_ohlcv", return_value=None):
+        out = model._momentum_fallback(["AAPL"], "6mo")
+    assert out == {"AAPL": 0.0}
+
+
+# ── Mocked-MLP tests (no real sklearn run) ────────────────────────────────────
+
+def test_train_with_mocked_mlp():
+    fm = _make_feature_matrix()
+    mock = _mock_mlp()
+    with (
+        patch("strategies.mlp_signal._SKLEARN_AVAILABLE", True),
+        patch("strategies.mlp_signal.MLPRegressor", return_value=mock),
+        patch("strategies.mlp_signal.build_feature_matrix", return_value=fm),
+        patch("strategies.mlp_signal.MLPSignal._load_if_available"),
+        patch("strategies.mlp_signal.MLPSignal._write_metadata"),
+        patch("builtins.open", MagicMock()),
+        patch("strategies.mlp_signal.pickle.dump"),
+        patch("strategies.mlp_signal.Path.mkdir"),
+    ):
+        from strategies.mlp_signal import MLPSignal
+        model = MLPSignal(model_path="models/test_mlp.pkl")
+        result = model.train(["AAPL", "MSFT"], period="2y")
+    for key in ("train_ic", "test_ic", "train_icir", "test_icir",
+                "n_train_samples", "n_test_samples"):
+        assert key in result
+    assert result["n_train_samples"] > 0
+
+
+def test_predict_scores_in_range_with_mocked_mlp():
+    fm = _make_feature_matrix(tickers=["AAPL", "MSFT", "GOOG"])
+    mock = _mock_mlp()
+    with (
+        patch("strategies.mlp_signal._SKLEARN_AVAILABLE", True),
+        patch("strategies.mlp_signal.MLPRegressor", return_value=mock),
+        patch("strategies.mlp_signal.build_feature_matrix", return_value=fm),
+        patch("strategies.mlp_signal.MLPSignal._load_if_available"),
+        patch("strategies.mlp_signal.MLPSignal._write_metadata"),
+        patch("builtins.open", MagicMock()),
+        patch("strategies.mlp_signal.pickle.dump"),
+        patch("strategies.mlp_signal.Path.mkdir"),
+    ):
+        from strategies.mlp_signal import MLPSignal
+        model = MLPSignal(model_path="models/test_mlp.pkl")
+        model.train(["AAPL", "MSFT", "GOOG"], period="2y")
+        scores = model.predict(["AAPL", "MSFT", "GOOG"], period="6mo")
+    assert set(scores) == {"AAPL", "MSFT", "GOOG"}
+    for v in scores.values():
+        assert -1.0 <= v <= 1.0
+
+
+def test_feature_importances_sorted_descending():
+    mock = _mock_mlp()
+    with patch("strategies.mlp_signal.MLPSignal._load_if_available"):
+        from strategies.mlp_signal import MLPSignal
+        model = MLPSignal(model_path="/tmp/x.pkl")
+        model._model = mock
+    df = model.feature_importances()
+    assert list(df.columns) == ["feature", "importance"]
+    imps = df["importance"].tolist()
+    assert imps == sorted(imps, reverse=True)
+
+
+# ── Persistence ───────────────────────────────────────────────────────────────
+
+def test_load_if_available_corrupt_file_does_not_raise(tmp_path):
+    bad = tmp_path / "bad.pkl"
+    bad.write_bytes(b"not_a_real_pickle")
+    from strategies.mlp_signal import MLPSignal
+    model = MLPSignal(model_path=str(bad))
+    assert model._model is None
+
+
+def test_load_if_available_success_path(tmp_path):
+    import pickle as pk
+    pkl_path = tmp_path / "mlp.pkl"
+    with open(pkl_path, "wb") as f:
+        pk.dump({"coefs_": [np.eye(3)]}, f)
+    from strategies.mlp_signal import MLPSignal
+    model = MLPSignal(model_path=str(pkl_path))
+    assert model._model is not None
+
+
+def test_write_metadata_silences_db_errors():
+    from strategies.mlp_signal import MLPSignal
+    with patch("strategies.mlp_signal.MLPSignal._load_if_available"):
+        model = MLPSignal(model_path="/tmp/x.pkl")
+    with patch("data.db.get_connection", side_effect=RuntimeError("no db")):
+        model._write_metadata(n_tickers=3, period="2y", train_ic=0.1, test_ic=0.05)
+
+
+def test_predict_empty_feature_matrix_falls_back():
+    with (
+        patch("strategies.mlp_signal.MLPSignal._load_if_available"),
+        patch("strategies.mlp_signal.build_feature_matrix", return_value=pd.DataFrame()),
+        patch(
+            "strategies.mlp_signal.MLPSignal._momentum_fallback",
+            return_value={"AAPL": 0.1},
+        ) as fb,
+    ):
+        from strategies.mlp_signal import MLPSignal
+        model = MLPSignal(model_path="/tmp/x.pkl")
+        model._model = MagicMock()
+        out = model.predict(["AAPL"], period="6mo")
+    fb.assert_called_once()
+    assert out == {"AAPL": 0.1}
+
+
+# ── End-to-end with real MLPRegressor ─────────────────────────────────────────
+
+@skip_no_sklearn
+def test_end_to_end_train_and_predict_with_real_mlp():
+    fm = _make_feature_matrix(tickers=["AAPL", "MSFT", "GOOG"])
+    with (
+        patch("strategies.mlp_signal.build_feature_matrix", return_value=fm),
+        patch("strategies.mlp_signal.MLPSignal._load_if_available"),
+        patch("strategies.mlp_signal.MLPSignal._write_metadata"),
+        patch("builtins.open", MagicMock()),
+        patch("strategies.mlp_signal.pickle.dump"),
+        patch("strategies.mlp_signal.Path.mkdir"),
+    ):
+        from strategies.mlp_signal import MLPSignal
+        model = MLPSignal(model_path="models/test_mlp.pkl")
+        result = model.train(
+            ["AAPL", "MSFT", "GOOG"], period="2y",
+            hidden_layer_sizes=(8,), max_iter=20,
+        )
+        scores = model.predict(["AAPL", "MSFT", "GOOG"], period="6mo")
+        df = model.feature_importances()
+
+    assert result["n_train_samples"] > 0 and result["n_test_samples"] > 0
+    assert set(scores) == {"AAPL", "MSFT", "GOOG"}
+    for v in scores.values():
+        assert -1.0 <= v <= 1.0
+    # Real first-layer coefs → real importances column ranked descending
+    assert not df.empty
+    assert df["importance"].tolist() == sorted(df["importance"].tolist(), reverse=True)


### PR DESCRIPTION
Closes #107.

## Summary
- New `strategies/mlp_signal.py`: `MLPSignal` wrapping `sklearn.neural_network.MLPRegressor` over the shared cross-sectional feature matrix.
- Same `train()` / `predict()` / `_momentum_fallback()` / `_write_metadata()` surface as `LinearSignal`; `feature_importances()` returns first-layer `|weight|` sums sorted descending.
- Marks ML4T Ch 17 ✅ in `ML_BOOK_MAP.md` (was 🟡 — LSTM only, no FFN intro).

## Test plan
- [x] 12 tests in `tests/test_mlp_signal.py`: missing-sklearn guard, momentum fallback, mocked-MLP train/predict, feature-importance ordering, corrupt-pickle resilience, DB error silencing, empty-feature-matrix fallback, and one end-to-end with real `MLPRegressor` on a synthetic feature matrix.
- [x] `ruff check .` clean
- [x] `bandit -ll` 0 HIGH (only the same Medium-severity `pickle.load` advisory present in `linear_signal.py`)

https://claude.ai/code/session_01Gu3iR1MKU5D7zCv8HdbuQu