### PR TITLE
feat: knowledge-adaption review agent gating ML execution

### DIFF
--- a/.claude/commands/run-agent.md
+++ b/.claude/commands/run-agent.md
@@ -1,5 +1,5 @@
 ---
-description: Invoke a specialist trading agent (regime, risk, sentiment, screener, execution) or the meta-agent with a ticker context, and display the AgentSignal.
+description: Invoke a specialist trading agent (regime, risk, sentiment, screener, execution, knowledge) or the meta-agent with a ticker context, and display the AgentSignal.
 argument-hint: <agent_name> <ticker>
 ---
 
@@ -7,7 +7,7 @@ Invoke one of the trading agents defined in `agents/` with a minimal context and
 
 ## Arguments
 
-- `<agent_name>`: one of `regime`, `risk`, `sentiment`, `screener`, `execution`, `meta` (case-insensitive).
+- `<agent_name>`: one of `regime`, `risk`, `sentiment`, `screener`, `execution`, `knowledge`, `meta` (case-insensitive).
 - `<ticker>`: symbol, validated against `^[A-Z0-9]{1,6}(\.[A-Z]{1,2})?$` — same regex as `agents/meta_agent.py:25`.
 
 Reject unknown agent names with a list of valid options. Reject malformed tickers with the regex.
@@ -21,6 +21,7 @@ Reject unknown agent names with a list of valid options. Reject malformed ticker
 | `sentiment` | `SentimentAgent` | `agents.sentiment_agent` |
 | `screener` | `ScreenerAgent` | `agents.screener_agent` |
 | `execution` | `ExecutionAgent` | `agents.execution_agent` |
+| `knowledge` | `KnowledgeAdaptionAgent` | `agents.knowledge_agent` |
 | `meta` | `MetaAgent` | `agents.meta_agent` |
 
 ## Execution

--- a/agents/knowledge_agent.py
+++ b/agents/knowledge_agent.py
@@ -1,0 +1,407 @@
+"""
+agents/knowledge_agent.py — Reviews how well the platform's ML knowledge stays
+adapted to live markets (Jansen Ch 12 LGBM + AFML regime conditioning).
+
+The monthly retrain cron (`cron/monthly_ml_retrain.py`) pickles regime-
+conditioned LightGBM models to ``models/lgbm_alpha.pkl`` and
+``models/lgbm_regime_models.pkl``.  If a retrain silently fails or a new
+regime appears without coverage, ``MLSignal.predict()`` quietly falls back to
+momentum and P&L erodes without anyone noticing.
+
+This agent checks three signals on every invocation:
+
+    1. Baseline pickle freshness (mtime age in days).
+    2. Regime-models pickle freshness + current regime coverage.
+    3. IC degradation (``test_ic`` from the most recent training, persisted in
+       the ``model_metadata`` table, compared against a caller-supplied
+       ``live_ic`` when available).
+
+The agent returns an ``AgentSignal`` plus a ``metadata["recommendation"]``
+tag in ``{"fresh", "monitor", "retrain"}`` that the MetaAgent uses to scale
+its output confidence and that ``strategies/ml_execution.py`` uses to scale
+the Kelly fraction.  A stale verdict also triggers a throttled alert via
+``providers.alert`` (24h cooldown) so silent cron failures surface.
+
+ENV vars
+--------
+    LGBM_ALPHA_MODEL_PATH       path to baseline pickle
+                                (default: models/lgbm_alpha.pkl)
+    LGBM_REGIME_MODELS_PATH     path to regime-models pickle
+                                (default: models/lgbm_regime_models.pkl)
+    KNOWLEDGE_STALE_DAYS        age > this → bearish / retrain (default 45)
+    KNOWLEDGE_MONITOR_DAYS      age > this → neutral / monitor (default 35)
+    KNOWLEDGE_ALERT_COOLDOWN    seconds between retrain alerts (default 86400)
+"""
+from __future__ import annotations
+
+import json
+import os
+import pickle
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+from agents.base import AgentSignal
+from utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+# Default thresholds — overridable via env.
+_DEFAULT_STALE_DAYS = 45.0
+_DEFAULT_MONITOR_DAYS = 35.0
+_IC_DROP_BEARISH = 0.5      # live_ic / trained_ic < this → retrain
+_IC_DROP_NEUTRAL = 0.75     # < this → monitor
+_CACHE_TTL_SEC = 60.0
+_DEFAULT_ALERT_COOLDOWN = 24 * 3600.0
+
+# Fed to MetaAgent / ml_execution so they can discount conviction without
+# changing direction.
+_RECOMMENDATION_MULTIPLIER: dict[str, float] = {
+    "fresh": 1.0,
+    "monitor": 0.7,
+    "retrain": 0.4,
+}
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def recommendation_multiplier(recommendation: str) -> float:
+    """Return the confidence / sizing multiplier for a recommendation tag."""
+    return _RECOMMENDATION_MULTIPLIER.get(recommendation, 1.0)
+
+
+def _resolve_path(env_var: str, default_rel: str) -> Path:
+    """Resolve a model pickle path — env override wins, else repo-relative default."""
+    override = os.environ.get(env_var)
+    if override:
+        return Path(override).expanduser().resolve()
+    return (_REPO_ROOT / default_rel).resolve()
+
+
+def _age_days(path: Path, now: float) -> float | None:
+    """Return mtime age in days for an existing file, else ``None``."""
+    try:
+        mtime = path.stat().st_mtime
+    except OSError:
+        return None
+    return round(max(0.0, (now - mtime) / 86400.0), 2)
+
+
+def _read_regime_coverage(path: Path) -> list[str]:
+    """Return the list of regime names present in the regime-models pickle.
+
+    Supports both the canonical ``{"models": {...}, "is_classifier": bool}``
+    payload and the legacy bare-dict format (see
+    ``strategies/ml_signal.py:143–151``).
+    """
+    if not path.exists():
+        return []
+    with open(path, "rb") as f:
+        payload = pickle.load(f)  # noqa: S301  — trusted local file
+    if isinstance(payload, dict):
+        inner = payload.get("models") if "models" in payload else payload
+        if isinstance(inner, dict):
+            return sorted(inner.keys())
+    return []
+
+
+def _read_trained_ic(model_name: str) -> float | None:
+    """Return the most recent ``test_ic`` for ``model_name`` from model_metadata.
+
+    Silently returns ``None`` if the table is missing, empty, or the import
+    graph of ``data.db`` fails for any reason (e.g., during unit tests that
+    haven't bootstrapped the schema).
+    """
+    try:
+        from data.db import get_connection
+    except Exception:
+        return None
+    try:
+        conn = get_connection()
+    except Exception:
+        return None
+    try:
+        row = conn.execute(
+            "SELECT test_ic FROM model_metadata "
+            "WHERE model_name = ? ORDER BY trained_at DESC LIMIT 1",
+            (model_name,),
+        ).fetchone()
+    except Exception:
+        return None
+    finally:
+        try:
+            conn.close()
+        except Exception:
+            pass
+    if row is None:
+        return None
+    try:
+        value = row["test_ic"] if hasattr(row, "keys") else row[0]
+    except Exception:
+        return None
+    return float(value) if value is not None else None
+
+
+def _resolve_regime(context: dict) -> str | None:
+    """Resolve the current regime from context or the cached live classifier."""
+    regime = context.get("regime")
+    if regime:
+        return str(regime)
+    try:
+        from analysis.regime import get_cached_live_regime
+        return str(get_cached_live_regime(use_llm=False).get("regime") or "") or None
+    except Exception as exc:
+        logger.debug("knowledge_agent: live regime lookup failed: %s", exc)
+        return None
+
+
+class _Cache:
+    """Tiny TTL cache keyed on (path, mtime) so the hot path stays cheap."""
+
+    def __init__(self, ttl: float = _CACHE_TTL_SEC) -> None:
+        self._ttl = ttl
+        self._coverage: tuple[tuple[str, float] | None, float, list[str]] = (
+            None, 0.0, [],
+        )
+
+    def coverage(self, path: Path, loader) -> list[str]:
+        """Return cached regime coverage, re-reading if mtime changed or TTL expired."""
+        now = time.time()
+        try:
+            mtime = path.stat().st_mtime
+            key = (str(path), mtime)
+        except OSError:
+            key = None
+        cached_key, cached_at, cached_val = self._coverage
+        if key is not None and key == cached_key and (now - cached_at) < self._ttl:
+            return cached_val
+        try:
+            result = loader(path)
+        except Exception as exc:
+            logger.debug("knowledge_agent: regime pickle load failed: %s", exc)
+            result = []
+        self._coverage = (key, now, result)
+        return result
+
+
+class KnowledgeAdaptionAgent:
+    """Reviews model freshness, regime coverage, and IC drift."""
+
+    name = "knowledge_agent"
+
+    # Injection points for tests.  All default to module-level helpers.
+    _clock = staticmethod(time.time)
+    _coverage_reader = staticmethod(_read_regime_coverage)
+    _metadata_reader = staticmethod(_read_trained_ic)
+
+    def __init__(self) -> None:
+        self._cache = _Cache()
+        self._last_alert_at: float = 0.0
+
+    # ── Main entrypoint ────────────────────────────────────────────────────
+
+    def run(self, context: dict) -> AgentSignal:
+        try:
+            return self._run(context or {})
+        except Exception as exc:
+            logger.warning("KnowledgeAdaptionAgent: unexpected failure: %s", exc)
+            return AgentSignal(
+                agent_name=self.name,
+                signal="neutral",
+                confidence=0.3,
+                reasoning="Knowledge state unavailable",
+                metadata={"recommendation": "monitor"},
+            )
+
+    def _run(self, context: dict) -> AgentSignal:
+        now = self._clock()
+
+        baseline_path = _resolve_path("LGBM_ALPHA_MODEL_PATH", "models/lgbm_alpha.pkl")
+        regime_path = _resolve_path(
+            "LGBM_REGIME_MODELS_PATH", "models/lgbm_regime_models.pkl"
+        )
+
+        baseline_age = _age_days(baseline_path, now)
+        regime_age = _age_days(regime_path, now)
+        regime = _resolve_regime(context)
+        regime_coverage = self._cache.coverage(regime_path, self._coverage_reader)
+
+        trained_ic = self._metadata_reader("lgbm_alpha")
+        live_ic_raw = context.get("live_ic")
+        live_ic = float(live_ic_raw) if live_ic_raw is not None else None
+        ic_ratio = _safe_ratio(live_ic, trained_ic)
+
+        stale_days = _env_float("KNOWLEDGE_STALE_DAYS", _DEFAULT_STALE_DAYS)
+        monitor_days = _env_float("KNOWLEDGE_MONITOR_DAYS", _DEFAULT_MONITOR_DAYS)
+
+        verdict = self._classify(
+            baseline_age=baseline_age,
+            regime_age=regime_age,
+            regime=regime,
+            regime_coverage=regime_coverage,
+            ic_ratio=ic_ratio,
+            stale_days=stale_days,
+            monitor_days=monitor_days,
+        )
+
+        if verdict["recommendation"] == "retrain":
+            self._maybe_alert(verdict["reasoning"], now)
+
+        metadata: dict[str, Any] = {
+            "recommendation": verdict["recommendation"],
+            "baseline_age_days": baseline_age,
+            "regime_age_days": regime_age,
+            "regime": regime,
+            "regime_coverage": regime_coverage,
+            "trained_ic": trained_ic,
+            "live_ic": live_ic,
+            "ic_ratio": ic_ratio,
+            "stale_days": stale_days,
+            "monitor_days": monitor_days,
+        }
+
+        return AgentSignal(
+            agent_name=self.name,
+            signal=verdict["signal"],
+            confidence=verdict["confidence"],
+            reasoning=verdict["reasoning"],
+            metadata=metadata,
+        )
+
+    # ── Classification ────────────────────────────────────────────────────
+
+    @staticmethod
+    def _classify(
+        *,
+        baseline_age: float | None,
+        regime_age: float | None,
+        regime: str | None,
+        regime_coverage: list[str],
+        ic_ratio: float | None,
+        stale_days: float,
+        monitor_days: float,
+    ) -> dict[str, Any]:
+        """First-match condition ladder → (signal, confidence, reasoning, recommendation)."""
+        # 1. Missing baseline pickle — worst case, no model to serve.
+        if baseline_age is None:
+            return _verdict(
+                "bearish", 0.8, "retrain",
+                "baseline model pickle missing",
+            )
+
+        # 2. Hard staleness OR heavy IC degradation.
+        if baseline_age > stale_days:
+            return _verdict(
+                "bearish", 0.7, "retrain",
+                f"baseline stale ({baseline_age:.0f}d > {stale_days:.0f}d)",
+            )
+        if ic_ratio is not None and ic_ratio < _IC_DROP_BEARISH:
+            return _verdict(
+                "bearish", 0.7, "retrain",
+                f"live IC decayed ({ic_ratio:.0%} of trained)",
+            )
+
+        # 3. Regime coverage gap.
+        if regime and regime not in regime_coverage:
+            covered = ",".join(regime_coverage) or "none"
+            return _verdict(
+                "bearish", 0.6, "retrain",
+                f"no dedicated model for regime '{regime}' (covered: {covered})",
+            )
+
+        # 4. Retrain window approaching.
+        if (
+            baseline_age > monitor_days
+            or (regime_age is not None and regime_age > monitor_days)
+            or (ic_ratio is not None and ic_ratio < _IC_DROP_NEUTRAL)
+        ):
+            if ic_ratio is not None and ic_ratio < _IC_DROP_NEUTRAL:
+                why = f"IC decaying ({ic_ratio:.0%} of trained)"
+            else:
+                oldest = max(baseline_age or 0.0, regime_age or 0.0)
+                why = f"retrain window approaching ({oldest:.0f}d)"
+            return _verdict("neutral", 0.5, "monitor", why)
+
+        # 5. Fresh & covered.
+        return _verdict(
+            "bullish", 0.8, "fresh",
+            f"models fresh ({baseline_age:.0f}d) and regime '{regime or '?'}' covered",
+        )
+
+    # ── Alerts (throttled) ─────────────────────────────────────────────────
+
+    def _maybe_alert(self, reason: str, now: float) -> None:
+        cooldown = _env_float("KNOWLEDGE_ALERT_COOLDOWN", _DEFAULT_ALERT_COOLDOWN)
+        if (now - self._last_alert_at) < cooldown:
+            return
+        try:
+            from providers.alert import get_alert_channel
+            channel = get_alert_channel()
+            channel.send(
+                f"ML knowledge stale — retrain recommended: {reason}",
+                level="warning",
+            )
+            self._last_alert_at = now
+        except Exception as exc:
+            logger.debug("knowledge_agent: alert dispatch failed: %s", exc)
+
+
+# ── Module helpers ─────────────────────────────────────────────────────────
+
+def _env_float(name: str, default: float) -> float:
+    raw = os.environ.get(name)
+    if not raw:
+        return default
+    try:
+        return float(raw)
+    except ValueError:
+        return default
+
+
+def _safe_ratio(live: float | None, trained: float | None) -> float | None:
+    """Return ``live / trained`` guarding against None / zero / opposite signs.
+
+    When the trained IC was positive but live IC went negative, we clamp the
+    ratio to 0.0 so the downstream ladder treats it as maximum decay.
+    """
+    if live is None or trained is None:
+        return None
+    if trained == 0:
+        return None
+    if (trained > 0 and live < 0) or (trained < 0 and live > 0):
+        return 0.0
+    ratio = live / trained
+    return round(max(0.0, ratio), 4)
+
+
+def _verdict(
+    signal: str, confidence: float, recommendation: str, reasoning: str,
+) -> dict[str, Any]:
+    return {
+        "signal": signal,
+        "confidence": confidence,
+        "recommendation": recommendation,
+        "reasoning": reasoning,
+    }
+
+
+# ── CLI entrypoint ─────────────────────────────────────────────────────────
+
+def main() -> int:
+    """Print the AgentSignal as JSON and exit non-zero when a retrain is needed."""
+    sig = KnowledgeAdaptionAgent().run({})
+    payload = {
+        "agent": sig.agent_name,
+        "signal": sig.signal,
+        "confidence": sig.confidence,
+        "reasoning": sig.reasoning,
+        "metadata": sig.metadata,
+    }
+    print(json.dumps(payload, indent=2, default=str))
+    rec = (sig.metadata or {}).get("recommendation")
+    return 1 if rec == "retrain" else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/agents/meta_agent.py
+++ b/agents/meta_agent.py
@@ -30,6 +30,10 @@ _DEFAULT_WEIGHTS: dict[str, float] = {
     "sentiment_agent": 0.8,
     "screener_agent": 1.0,
     "execution_agent": 0.5,
+    # KnowledgeAdaptionAgent is a governance gate, not a directional opinion.
+    # Weight 0 keeps it out of the vote; its recommendation scales the
+    # aggregated confidence below (see `knowledge_multiplier`).
+    "knowledge_agent": 0.0,
 }
 
 _SIGNAL_SCORES = {"bullish": 1.0, "neutral": 0.0, "bearish": -1.0}
@@ -63,11 +67,19 @@ class MetaAgent:
     ) -> None:
         if agents is None:
             from agents.execution_agent import ExecutionAgent
+            from agents.knowledge_agent import KnowledgeAdaptionAgent
             from agents.regime_agent import RegimeAgent
             from agents.risk_agent import RiskAgent
             from agents.screener_agent import ScreenerAgent
             from agents.sentiment_agent import SentimentAgent
-            agents = [RegimeAgent(), RiskAgent(), SentimentAgent(), ScreenerAgent(), ExecutionAgent()]
+            agents = [
+                RegimeAgent(),
+                RiskAgent(),
+                SentimentAgent(),
+                ScreenerAgent(),
+                ExecutionAgent(),
+                KnowledgeAdaptionAgent(),
+            ]
         self._agents: list[AgentProvider] = agents
         self._weights = weights or _load_weights()
 
@@ -123,7 +135,28 @@ class MetaAgent:
             consensus = "neutral"
 
         confidence = min(1.0, abs(weighted_score))
+
+        # Governance gate: if the KnowledgeAdaptionAgent is in the mix, let its
+        # recommendation scale confidence without perturbing direction. Stale
+        # models shouldn't flip signals, just reduce conviction (and, via
+        # strategies/ml_execution.py, position sizing).
+        knowledge_multiplier = 1.0
+        knowledge_reason: str | None = None
+        for sig in signals:
+            if sig.agent_name != "knowledge_agent":
+                continue
+            rec = (sig.metadata or {}).get("recommendation")
+            if rec in ("fresh", "monitor", "retrain"):
+                from agents.knowledge_agent import recommendation_multiplier
+                knowledge_multiplier = recommendation_multiplier(rec)
+                if rec != "fresh":
+                    knowledge_reason = f"knowledge:{rec} ({sig.reasoning})"
+            break
+        confidence = round(min(1.0, confidence * knowledge_multiplier), 4)
+
         reasoning = f"Weighted score={weighted_score:+.3f} → {consensus}"
+        if knowledge_reason is not None:
+            reasoning = f"{reasoning} | {knowledge_reason}"
 
         # Optional LLM arbitration for close calls
         if os.environ.get("AGENT_LLM_ARBITER", "0") == "1" and abs(weighted_score) < 0.3:
@@ -137,6 +170,7 @@ class MetaAgent:
             "signal": consensus,
             "confidence": round(confidence, 4),
             "weighted_score": round(weighted_score, 4),
+            "knowledge_multiplier": round(knowledge_multiplier, 4),
             "specialist_signals": [
                 {
                     "agent": s.agent_name,

--- a/strategies/ml_execution.py
+++ b/strategies/ml_execution.py
@@ -55,6 +55,39 @@ def _current_regime() -> str:
         return "trending_bull"
 
 
+def _knowledge_gate(regime: str) -> tuple[float, str, bool]:
+    """Ask the KnowledgeAdaptionAgent whether the pickled models are fit to trade.
+
+    Returns ``(multiplier, recommendation, skip_all)``.  ``skip_all`` is True
+    when the baseline pickle is missing entirely — without a model we should
+    not place trades even if a caller passed in synthetic scores.
+    """
+    try:
+        from agents.knowledge_agent import KnowledgeAdaptionAgent, recommendation_multiplier
+    except Exception as exc:
+        log.debug("ml_execution: knowledge agent import failed", error=str(exc))
+        return 1.0, "fresh", False
+
+    try:
+        sig = KnowledgeAdaptionAgent().run({"regime": regime})
+    except Exception as exc:
+        log.debug("ml_execution: knowledge agent run failed", error=str(exc))
+        return 1.0, "fresh", False
+
+    meta = sig.metadata or {}
+    rec = str(meta.get("recommendation") or "fresh")
+    mult = recommendation_multiplier(rec)
+    skip_all = bool(rec == "retrain" and meta.get("baseline_age_days") is None)
+    if rec != "fresh":
+        log.warning(
+            "ml_execution: knowledge gate",
+            recommendation=rec,
+            multiplier=mult,
+            reason=sig.reasoning,
+        )
+    return mult, rec, skip_all
+
+
 def _size_order(
     equity: float,
     price: float,
@@ -161,6 +194,14 @@ def execute_ml_signals(
     kelly_base = _kelly_baseline()
     regime = _current_regime()
     regime_mult = kelly_regime_multiplier(regime)
+    knowledge_mult, knowledge_rec, skip_all = _knowledge_gate(regime)
+    if skip_all:
+        log.warning(
+            "ml_execution: skipping all buys — baseline model missing",
+            recommendation=knowledge_rec,
+        )
+        return actions
+    kelly_base *= knowledge_mult
 
     # Enter new long positions sized by Kelly × regime × |score|.
     for ticker, score in long_candidates:

--- a/tests/test_knowledge_agent.py
+++ b/tests/test_knowledge_agent.py
@@ -1,0 +1,285 @@
+"""Tests for agents/knowledge_agent.py (KnowledgeAdaptionAgent)."""
+from __future__ import annotations
+
+import os
+import pickle
+import subprocess
+import sys
+import time
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agents.base import AgentSignal
+from agents.knowledge_agent import (
+    KnowledgeAdaptionAgent,
+    _safe_ratio,
+    recommendation_multiplier,
+)
+
+# ── Fixtures ─────────────────────────────────────────────────────────────────
+
+def _write_pickle(path: Path, payload, age_seconds: float = 0.0) -> Path:
+    """Write a pickle file and backdate its mtime by ``age_seconds``."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "wb") as f:
+        pickle.dump(payload, f)
+    if age_seconds:
+        now = time.time()
+        os.utime(path, (now - age_seconds, now - age_seconds))
+    return path
+
+
+@pytest.fixture
+def model_paths(tmp_path, monkeypatch):
+    """Return (baseline_path, regime_path) with env vars pointing at tmp_path."""
+    baseline = tmp_path / "lgbm_alpha.pkl"
+    regime = tmp_path / "lgbm_regime_models.pkl"
+    monkeypatch.setenv("LGBM_ALPHA_MODEL_PATH", str(baseline))
+    monkeypatch.setenv("LGBM_REGIME_MODELS_PATH", str(regime))
+    return baseline, regime
+
+
+@pytest.fixture
+def isolate_metadata(monkeypatch):
+    """Force _read_trained_ic to return None unless a test overrides it."""
+    monkeypatch.setattr(
+        "agents.knowledge_agent._read_trained_ic",
+        lambda model_name: None,
+    )
+    monkeypatch.setattr(
+        KnowledgeAdaptionAgent, "_metadata_reader",
+        staticmethod(lambda model_name: None),
+    )
+
+
+# ── _safe_ratio ──────────────────────────────────────────────────────────────
+
+def test_safe_ratio_handles_zero_and_sign_flip():
+    assert _safe_ratio(None, 0.05) is None
+    assert _safe_ratio(0.05, None) is None
+    assert _safe_ratio(0.05, 0.0) is None
+    # Sign flip → maximum decay (0.0)
+    assert _safe_ratio(-0.02, 0.05) == 0.0
+    assert _safe_ratio(0.02, -0.05) == 0.0
+    # Normal ratio
+    assert _safe_ratio(0.02, 0.04) == 0.5
+
+
+def test_recommendation_multiplier_exposes_table():
+    assert recommendation_multiplier("fresh") == 1.0
+    assert recommendation_multiplier("monitor") == 0.7
+    assert recommendation_multiplier("retrain") == 0.4
+    # Unknown falls back to safe 1.0
+    assert recommendation_multiplier("garbage") == 1.0
+
+
+# ── Core verdict ladder ──────────────────────────────────────────────────────
+
+def test_missing_pickles_bearish_retrain(model_paths, isolate_metadata):
+    # No files exist yet
+    sig = KnowledgeAdaptionAgent().run({"regime": "trending_bull"})
+    assert isinstance(sig, AgentSignal)
+    assert sig.signal == "bearish"
+    assert sig.metadata["recommendation"] == "retrain"
+    assert sig.metadata["baseline_age_days"] is None
+    assert "missing" in sig.reasoning.lower()
+
+
+def test_fresh_and_covered_bullish(model_paths, isolate_metadata):
+    baseline, regime = model_paths
+    _write_pickle(baseline, {"model": object()}, age_seconds=60)  # seconds old
+    _write_pickle(
+        regime, {"models": {"trending_bull": 1, "trending_bear": 1,
+                             "mean_reverting": 1, "high_vol": 1}}, age_seconds=60,
+    )
+    sig = KnowledgeAdaptionAgent().run({"regime": "trending_bull"})
+    assert sig.signal == "bullish"
+    assert sig.metadata["recommendation"] == "fresh"
+    assert sig.metadata["regime_coverage"] == sorted(
+        ["trending_bull", "trending_bear", "mean_reverting", "high_vol"]
+    )
+
+
+def test_stale_baseline_bearish_retrain(model_paths, isolate_metadata):
+    baseline, regime = model_paths
+    days = 60 * 86400
+    _write_pickle(baseline, {"model": object()}, age_seconds=days)
+    _write_pickle(
+        regime, {"models": {"trending_bull": 1, "trending_bear": 1,
+                             "mean_reverting": 1, "high_vol": 1}},
+        age_seconds=days,
+    )
+    sig = KnowledgeAdaptionAgent().run({"regime": "trending_bull"})
+    assert sig.signal == "bearish"
+    assert sig.metadata["recommendation"] == "retrain"
+    assert sig.metadata["baseline_age_days"] >= 45
+
+
+def test_monitor_window_neutral(model_paths, isolate_metadata):
+    baseline, regime = model_paths
+    # 40 days is inside [35, 45] → monitor
+    age = 40 * 86400
+    _write_pickle(baseline, {"model": object()}, age_seconds=age)
+    _write_pickle(
+        regime, {"models": {"trending_bull": 1, "trending_bear": 1,
+                             "mean_reverting": 1, "high_vol": 1}},
+        age_seconds=age,
+    )
+    sig = KnowledgeAdaptionAgent().run({"regime": "trending_bull"})
+    assert sig.signal == "neutral"
+    assert sig.metadata["recommendation"] == "monitor"
+
+
+def test_regime_not_covered_bearish(model_paths, isolate_metadata):
+    baseline, regime = model_paths
+    _write_pickle(baseline, {"model": object()}, age_seconds=60)
+    _write_pickle(
+        regime, {"models": {"trending_bull": 1, "trending_bear": 1}},
+        age_seconds=60,
+    )
+    sig = KnowledgeAdaptionAgent().run({"regime": "high_vol"})
+    assert sig.signal == "bearish"
+    assert sig.metadata["recommendation"] == "retrain"
+    assert "high_vol" in sig.reasoning
+
+
+def test_ic_degradation_bearish(model_paths, monkeypatch):
+    baseline, regime = model_paths
+    _write_pickle(baseline, {"model": object()}, age_seconds=60)
+    _write_pickle(
+        regime, {"models": {"trending_bull": 1, "trending_bear": 1,
+                             "mean_reverting": 1, "high_vol": 1}}, age_seconds=60,
+    )
+    monkeypatch.setattr(
+        KnowledgeAdaptionAgent, "_metadata_reader",
+        staticmethod(lambda model_name: 0.05),  # trained IC = 0.05
+    )
+    # live IC = 0.01 → ratio 0.2 → bearish / retrain
+    sig = KnowledgeAdaptionAgent().run(
+        {"regime": "trending_bull", "live_ic": 0.01}
+    )
+    assert sig.signal == "bearish"
+    assert sig.metadata["recommendation"] == "retrain"
+    assert sig.metadata["ic_ratio"] == pytest.approx(0.2)
+
+
+def test_ic_degradation_monitor(model_paths, monkeypatch):
+    baseline, regime = model_paths
+    _write_pickle(baseline, {"model": object()}, age_seconds=60)
+    _write_pickle(
+        regime, {"models": {"trending_bull": 1, "trending_bear": 1,
+                             "mean_reverting": 1, "high_vol": 1}}, age_seconds=60,
+    )
+    monkeypatch.setattr(
+        KnowledgeAdaptionAgent, "_metadata_reader",
+        staticmethod(lambda model_name: 0.05),
+    )
+    # live 0.033 → ratio 0.66 → monitor
+    sig = KnowledgeAdaptionAgent().run(
+        {"regime": "trending_bull", "live_ic": 0.033}
+    )
+    assert sig.signal == "neutral"
+    assert sig.metadata["recommendation"] == "monitor"
+
+
+def test_legacy_pickle_format_accepted(model_paths, isolate_metadata):
+    baseline, regime = model_paths
+    _write_pickle(baseline, {"model": object()}, age_seconds=60)
+    # Legacy: bare dict of {regime: model}
+    _write_pickle(
+        regime, {"trending_bull": 1, "trending_bear": 1},
+        age_seconds=60,
+    )
+    sig = KnowledgeAdaptionAgent().run({"regime": "trending_bull"})
+    assert sig.metadata["regime_coverage"] == ["trending_bear", "trending_bull"]
+
+
+def test_context_regime_overrides_live_lookup(model_paths, isolate_metadata):
+    baseline, regime = model_paths
+    _write_pickle(baseline, {"model": object()}, age_seconds=60)
+    _write_pickle(regime, {"models": {"trending_bull": 1}}, age_seconds=60)
+    # get_cached_live_regime must NOT be called when context provides regime.
+    with patch("analysis.regime.get_cached_live_regime") as fake:
+        KnowledgeAdaptionAgent().run({"regime": "trending_bull"})
+    fake.assert_not_called()
+
+
+def test_unexpected_exception_returns_neutral(monkeypatch):
+    def boom(*a, **kw):
+        raise RuntimeError("kapow")
+    monkeypatch.setattr("agents.knowledge_agent._resolve_path", boom)
+    sig = KnowledgeAdaptionAgent().run({"regime": "trending_bull"})
+    assert sig.signal == "neutral"
+    assert sig.confidence == 0.3
+    assert sig.reasoning == "Knowledge state unavailable"
+    assert sig.metadata["recommendation"] == "monitor"
+
+
+# ── Caching of pickle reads ──────────────────────────────────────────────────
+
+def test_regime_coverage_cached_within_ttl(model_paths, isolate_metadata):
+    baseline, regime = model_paths
+    _write_pickle(baseline, {"model": object()}, age_seconds=60)
+    _write_pickle(regime, {"models": {"trending_bull": 1}}, age_seconds=60)
+
+    counter = MagicMock(return_value=["trending_bull"])
+    agent = KnowledgeAdaptionAgent()
+    # Inject a counting loader via the cache.
+    agent._cache._coverage = (None, 0.0, [])
+    agent._cache.coverage(regime, counter)
+    agent._cache.coverage(regime, counter)
+    # Second call within TTL and with unchanged mtime should not re-invoke loader.
+    assert counter.call_count == 1
+
+
+# ── Alert throttling ─────────────────────────────────────────────────────────
+
+def test_retrain_alert_fires_once_within_cooldown(model_paths, isolate_metadata, monkeypatch):
+    # No pickles → retrain verdict on every call.
+    channel = MagicMock()
+    channel.send = MagicMock(return_value=True)
+    monkeypatch.setattr(
+        "providers.alert.get_alert_channel", lambda *a, **kw: channel,
+    )
+    monkeypatch.setenv("KNOWLEDGE_ALERT_COOLDOWN", "3600")
+
+    agent = KnowledgeAdaptionAgent()
+    agent.run({"regime": "trending_bull"})
+    agent.run({"regime": "trending_bull"})
+    assert channel.send.call_count == 1
+
+
+def test_retrain_alert_refires_after_cooldown(model_paths, isolate_metadata, monkeypatch):
+    channel = MagicMock()
+    channel.send = MagicMock(return_value=True)
+    monkeypatch.setattr(
+        "providers.alert.get_alert_channel", lambda *a, **kw: channel,
+    )
+    monkeypatch.setenv("KNOWLEDGE_ALERT_COOLDOWN", "100")
+
+    clock = [1_000_000.0]
+    agent = KnowledgeAdaptionAgent()
+    agent._clock = staticmethod(lambda: clock[0])  # type: ignore[method-assign]
+
+    agent.run({"regime": "trending_bull"})
+    clock[0] += 200.0  # past cooldown
+    agent.run({"regime": "trending_bull"})
+    assert channel.send.call_count == 2
+
+
+# ── CLI ──────────────────────────────────────────────────────────────────────
+
+def test_cli_exits_nonzero_on_retrain(tmp_path, monkeypatch):
+    env = dict(os.environ)
+    env["LGBM_ALPHA_MODEL_PATH"] = str(tmp_path / "missing.pkl")
+    env["LGBM_REGIME_MODELS_PATH"] = str(tmp_path / "missing_regime.pkl")
+    # Ensure the subprocess reaches this repo (not the user's cwd).
+    result = subprocess.run(
+        [sys.executable, "-m", "agents.knowledge_agent"],
+        capture_output=True, text=True, env=env,
+        cwd=Path(__file__).resolve().parent.parent,
+    )
+    assert result.returncode == 1
+    assert "retrain" in result.stdout

--- a/tests/test_meta_agent.py
+++ b/tests/test_meta_agent.py
@@ -136,3 +136,65 @@ def test_meta_agent_weighted_score_and_reasoning_present():
     assert "reasoning" in result
     assert isinstance(result["reasoning"], str)
     assert len(result["reasoning"]) > 0
+
+
+# ── KnowledgeAdaptionAgent gate ────────────────────────────────────────────
+
+def _make_knowledge_agent(recommendation: str):
+    from unittest.mock import MagicMock
+
+    agent = MagicMock()
+    agent.name = "knowledge_agent"
+    agent.run.return_value = AgentSignal(
+        agent_name="knowledge_agent",
+        signal="neutral",
+        confidence=0.5,
+        reasoning=f"models {recommendation}",
+        metadata={"recommendation": recommendation},
+    )
+    return agent
+
+
+def test_meta_agent_knowledge_multiplier_fresh_is_one():
+    from agents.meta_agent import MetaAgent
+
+    agents = [
+        _make_mock_agent("regime_agent", "bullish", 0.8),
+        _make_knowledge_agent("fresh"),
+    ]
+    result = MetaAgent(agents=agents).run({"ticker": "AAPL"})
+    assert result["signal"] == "bullish"
+    assert result["knowledge_multiplier"] == 1.0
+
+
+def test_meta_agent_knowledge_retrain_scales_confidence():
+    from agents.meta_agent import MetaAgent
+
+    agents = [
+        _make_mock_agent("regime_agent", "bullish", 0.8),
+        _make_knowledge_agent("retrain"),
+    ]
+    result = MetaAgent(agents=agents).run({"ticker": "AAPL"})
+    # Direction is preserved, confidence is discounted by the 0.4 multiplier.
+    assert result["signal"] == "bullish"
+    assert result["knowledge_multiplier"] == 0.4
+    # No regression: a fresh-knowledge run would produce a strictly higher
+    # confidence than this retrain run.
+    fresh_agents = [
+        _make_mock_agent("regime_agent", "bullish", 0.8),
+        _make_knowledge_agent("fresh"),
+    ]
+    fresh_result = MetaAgent(agents=fresh_agents).run({"ticker": "AAPL"})
+    assert fresh_result["confidence"] > result["confidence"]
+
+
+def test_meta_agent_knowledge_monitor_reason_appended():
+    from agents.meta_agent import MetaAgent
+
+    agents = [
+        _make_mock_agent("regime_agent", "bullish", 0.8),
+        _make_knowledge_agent("monitor"),
+    ]
+    result = MetaAgent(agents=agents).run({"ticker": "AAPL"})
+    assert "knowledge:monitor" in result["reasoning"]
+    assert result["knowledge_multiplier"] == 0.7

--- a/tests/test_ml_execution.py
+++ b/tests/test_ml_execution.py
@@ -59,10 +59,17 @@ def _held(ticker: str, qty: float = 10.0) -> dict:
 
 @pytest.fixture(autouse=True)
 def _patch_regime_and_prices():
-    """Keep regime lookup deterministic and avoid yfinance in every test."""
+    """Keep regime lookup deterministic and avoid yfinance in every test.
+
+    The knowledge gate is stubbed to "fresh" so existing sizing tests are not
+    perturbed by missing model pickles in the test checkout.  New tests below
+    override ``_knowledge_gate`` explicitly where needed.
+    """
     with patch("strategies.ml_execution._current_regime", return_value="trending_bull"), \
          patch("strategies.ml_execution.fetch_ohlcv",
-               return_value=pd.DataFrame({"Close": [150.0]})):
+               return_value=pd.DataFrame({"Close": [150.0]})), \
+         patch("strategies.ml_execution._knowledge_gate",
+               return_value=(1.0, "fresh", False)):
         yield
 
 
@@ -210,3 +217,64 @@ def test_positions_fetch_failure_falls_back_to_empty():
 
     assert "AAPL" in _buys_for(broker)
     assert any(a.startswith("BUY AAPL") for a in actions)
+
+
+# ── Knowledge-adaption gate ───────────────────────────────────────────────
+
+def test_knowledge_gate_skips_all_when_baseline_missing():
+    """retrain + baseline missing → no buys even for strong positive scores."""
+    broker = FakeBroker(positions=[], equity=100_000.0)
+    scores = {"AAPL": 0.9, "MSFT": 0.8}
+
+    with patch("strategies.ml_execution._knowledge_gate",
+               return_value=(0.4, "retrain", True)):
+        actions = execute_ml_signals(scores, threshold=0.3, max_positions=5, broker=broker)
+
+    assert actions == []
+    assert _buys_for(broker) == []
+
+
+def test_knowledge_gate_reduces_kelly_on_monitor():
+    """monitor recommendation (0.7×) produces smaller qty than fresh (1.0×)."""
+    fresh = FakeBroker(positions=[], equity=1_000_000.0)
+    monitor = FakeBroker(positions=[], equity=1_000_000.0)
+
+    with patch("strategies.ml_execution._knowledge_gate",
+               return_value=(1.0, "fresh", False)):
+        execute_ml_signals({"AAPL": 0.9}, threshold=0.3, max_positions=5, broker=fresh)
+    with patch("strategies.ml_execution._knowledge_gate",
+               return_value=(0.7, "monitor", False)):
+        execute_ml_signals({"AAPL": 0.9}, threshold=0.3, max_positions=5, broker=monitor)
+
+    assert monitor.orders[0]["qty"] < fresh.orders[0]["qty"]
+
+
+def test_knowledge_gate_reduces_kelly_on_retrain_without_skip():
+    """retrain + pickles present (skip_all=False) still shrinks sizing."""
+    fresh = FakeBroker(positions=[], equity=1_000_000.0)
+    retrain = FakeBroker(positions=[], equity=1_000_000.0)
+
+    with patch("strategies.ml_execution._knowledge_gate",
+               return_value=(1.0, "fresh", False)):
+        execute_ml_signals({"AAPL": 0.9}, threshold=0.3, max_positions=5, broker=fresh)
+    with patch("strategies.ml_execution._knowledge_gate",
+               return_value=(0.4, "retrain", False)):
+        execute_ml_signals({"AAPL": 0.9}, threshold=0.3, max_positions=5, broker=retrain)
+
+    assert 0 < retrain.orders[0]["qty"] < fresh.orders[0]["qty"]
+
+
+def test_knowledge_gate_still_exits_bearish_positions_when_skip():
+    """skip_all blocks buys but existing bearish positions should still be exited."""
+    broker = FakeBroker(positions=[_held("AAPL", qty=10.0)], equity=100_000.0)
+
+    with patch("strategies.ml_execution._knowledge_gate",
+               return_value=(0.4, "retrain", True)):
+        actions = execute_ml_signals(
+            {"AAPL": -0.7, "MSFT": 0.9}, threshold=0.3, max_positions=5, broker=broker
+        )
+
+    # AAPL should be sold (risk-reducing), MSFT must not be bought.
+    assert "AAPL" in _sells_for(broker)
+    assert _buys_for(broker) == []
+    assert any(a.startswith("SELL AAPL") for a in actions)


### PR DESCRIPTION
Adds a KnowledgeAdaptionAgent that audits the freshness of regime-
conditioned LightGBM models and the coverage of the live regime on
every invocation. It returns an AgentSignal plus a recommendation tag
(fresh/monitor/retrain) that is consumed by two sites:

* MetaAgent: registered with weight 0.0 so the verdict scales the
  aggregated confidence without perturbing direction (stale knowledge
  reduces conviction, not polarity).
* strategies/ml_execution.py: the same multiplier scales the Kelly
  fraction; a missing baseline pickle skips all new buys (existing
  bearish positions are still exited).

The agent also fires a throttled alert (24h cooldown) via
providers.alert when the verdict flips to retrain so silent cron
failures surface instead of eroding P&L.

CLI entrypoint: python -m agents.knowledge_agent exits non-zero on a
retrain recommendation for easy pre-trade gating.