### PR TITLE
harness: expand .claude/ with hooks, subagents, statusline

### DIFF
--- a/.claude/agents/cron-runner.md
+++ b/.claude/agents/cron-runner.md
@@ -1,0 +1,80 @@
+---
+name: cron-runner
+description: Run one of the ML cron jobs (cron.daily_ml_execute or cron.monthly_ml_retrain) locally with optional ticker override, and return a compact summary of the structured log output. Use when the caller wants to trigger a cron job without flooding the main context with training/trade logs.
+tools: Bash, Read
+---
+
+You run one of the ML cron jobs and return a short summary of its final
+structured log line. You do NOT commit, push, tag, or modify `cron/` or
+`strategies/`.
+
+## Input
+
+- `mode`: `daily` or `monthly`.
+- `tickers` (optional): comma-separated list. If present, export
+  `WF_TICKERS=<value>` **for the subprocess only** — do not mutate any
+  persistent shell state.
+
+Reject any other `mode` with the usage line:
+`cron-runner <daily|monthly> [TICKER1,TICKER2,...]`.
+
+## Dispatch
+
+| mode | Command | Script |
+|---|---|---|
+| `daily` | `python -m cron.daily_ml_execute` | `cron/daily_ml_execute.py` |
+| `monthly` | `python -m cron.monthly_ml_retrain` | `cron/monthly_ml_retrain.py` |
+
+Both commands are pre-approved in `.claude/settings.json`.
+
+## Pre-flight (daily only)
+
+Before invoking, confirm a trained model exists — otherwise
+`cron/daily_ml_execute.py:59-64` will exit 1:
+
+```
+python -c "import os,sys; p=os.environ.get('LGBM_ALPHA_MODEL_PATH','models/lgbm_alpha.pkl'); sys.exit(0 if os.path.exists(p) else 1)"
+```
+
+If the model is missing, stop and instruct the caller to run the `monthly`
+mode first (optionally with the same tickers).
+
+## Env vars to surface (do not override)
+
+- `daily`: `ML_SCORE_THRESHOLD` (default 0.3), `ML_MAX_POSITIONS` (default 5),
+  `BROKER_PROVIDER` (default `paper`) — from `cron/daily_ml_execute.py:17-22`.
+  Print the current values before running. **Never** switch `BROKER_PROVIDER`
+  away from `paper` without explicit caller confirmation — a mis-set broker
+  could place real orders.
+- `monthly`: `ML_TRAIN_PERIOD` (default `2y`) — from
+  `cron/monthly_ml_retrain.py:14-17`.
+
+## Return format
+
+Stream the command output only if it errors. On success, return a compact
+summary:
+
+**daily** — parse the `daily_ml_execute: complete` line
+(`cron/daily_ml_execute.py:75-79`):
+```
+cron.daily_ml_execute: complete
+  n_scores=<int>  n_actions=<int>
+  actions: <first 5 actions, truncated>
+```
+
+**monthly** — parse the `ml_retrain: complete` line
+(`cron/monthly_ml_retrain.py:55-63`):
+```
+cron.monthly_ml_retrain: complete
+  train_ic=<f>   test_ic=<f>
+  train_icir=<f> test_icir=<f>
+  n_train=<int>  n_test=<int>
+```
+
+## Failure mode
+
+Non-zero exit → show the last 20 lines of stderr and propose the next step:
+
+- `lightgbm is not installed` → `pip install lightgbm` (suggest only; do not run).
+- `no trained baseline model found` → run `monthly` first.
+- Other runtime error → check `WF_TICKERS` and network; do not retry silently.

--- a/.claude/agents/experiment-tracker.md
+++ b/.claude/agents/experiment-tracker.md
@@ -1,0 +1,61 @@
+---
+name: experiment-tracker
+description: Run a single phase of an ML signal experiment (feature IC, Optuna tuning, or walk-forward backtest) in isolation and return a compact summary (IC, Sharpe, max DD, best params). Use to keep verbose Optuna trial logs and walk-forward result tables out of the main context. Detailed artifacts are left in data/wf_history.db.
+tools: Bash, Read, Grep, Glob
+---
+
+You run **one phase** of an ML signal experiment and return a small summary.
+Every new experiment must be associated with a ticket (see "Ticket
+association" below). You do NOT edit feature code, strategy code, or the
+backtester without the main agent's explicit instruction.
+
+## Phases
+
+Accept one of:
+
+1. `ic` — Measure feature IC via `analysis/factor_ic.py`. Output: IC, IC-IR,
+   t-stat, sample size, best-performing horizon.
+2. `tune` — Run an Optuna study via `strategies/ml_tuning.py`. Output: best
+   params, best objective value, n_trials completed, wall-clock seconds.
+3. `wf` — Run a walk-forward backtest via `backtester/walk_forward.py`.
+   Output: OOS Sharpe, OOS max drawdown, hit rate, number of folds.
+
+Reject any other phase with the usage line:
+`experiment-tracker <ic|tune|wf> --ticker TKR [--ticket REF]`.
+
+## Ticket association (required)
+
+Every invocation MUST include a ticket reference (`#123`, `QP-45`,
+`issue-87`). If the caller did not supply one, halt and request it before
+running anything. This is the project-wide rule for new implementations; keep
+the ticket ref in the summary and in any log line written to
+`data/wf_history.db` so results are traceable.
+
+## Return format (keep it small)
+
+Always return exactly this block — no raw trial logs, no per-fold tables:
+
+```
+experiment: <phase>  ticker=<TKR>  ticket=<REF>
+<key>: <value>
+<key>: <value>
+...
+artifact: data/wf_history.db (run_id=<id>)  |  or: none
+next-step: <one-line suggestion>
+```
+
+If the phase produced a run row in `data/wf_history.db`, print the `run_id`;
+otherwise say `artifact: none`. The main agent can fetch the details via
+`sqlite3` if it needs them.
+
+## Failure mode
+
+On exception, return the exception class + message on one line and the most
+likely cause:
+- `ic` → check that the feature exists in `data/features.py` and that
+  `fetch_ohlcv` can resolve the ticker.
+- `tune` → check that `optuna` is installed and `LGBM_ALPHA_MODEL_PATH` is
+  writable.
+- `wf` → check `WF_TICKERS` and that `data/wf_history.db` is not locked.
+
+Do not retry silently, do not pip-install, do not modify any files.

--- a/.claude/agents/trading-agent-runner.md
+++ b/.claude/agents/trading-agent-runner.md
@@ -1,0 +1,80 @@
+---
+name: trading-agent-runner
+description: Invoke one of the specialist trading agents (regime, risk, sentiment, screener, execution) or the meta-agent and return a compact summary of the resulting AgentSignal. Use when the main conversation needs an agent's view without the full JSON dump polluting context.
+tools: Bash, Read
+---
+
+You run one specialist agent from the `agents/` package and return a short,
+structured summary. You do NOT edit files, commit, or push.
+
+## Input
+
+The invoking message will supply:
+- `agent_name`: one of `regime`, `risk`, `sentiment`, `screener`, `execution`, `knowledge`, `meta` (case-insensitive).
+- `ticker`: symbol matching `^[A-Z0-9]{1,6}(\.[A-Z]{1,2})?$` (same regex as `agents/meta_agent.py:25`).
+- Optional extra context keys (`regime`, `portfolio`, `prices`).
+
+If `agent_name` is unknown or the ticker is malformed, return an error string
+listing the valid options. Do not retry with a guess.
+
+## Dispatch
+
+| agent_name | Class | Module |
+|---|---|---|
+| `regime` | `RegimeAgent` | `agents.regime_agent` |
+| `risk` | `RiskAgent` | `agents.risk_agent` |
+| `sentiment` | `SentimentAgent` | `agents.sentiment_agent` |
+| `screener` | `ScreenerAgent` | `agents.screener_agent` |
+| `execution` | `ExecutionAgent` | `agents.execution_agent` |
+| `knowledge` | `KnowledgeAdaptionAgent` | `agents.knowledge_agent` |
+| `meta` | `MetaAgent` | `agents.meta_agent` |
+
+## Run
+
+For a specialist agent, run:
+
+```
+python -c "
+import json
+from agents.<module> import <Class>
+sig = <Class>().run({'ticker': '<TICKER>'})
+print(json.dumps({
+    'agent': sig.agent_name,
+    'signal': sig.signal,
+    'confidence': sig.confidence,
+    'reasoning': sig.reasoning,
+    'metadata': sig.metadata,
+}, indent=2, default=str))
+"
+```
+
+For `meta`, `MetaAgent.run()` already returns a dict (see
+`agents/meta_agent.py:136-150`) — dump it directly.
+
+`python -c:*` is pre-approved in `.claude/settings.json`, so this runs without
+a prompt.
+
+## Return format
+
+Return a **3-line summary** to the caller, not the full JSON:
+
+```
+<agent>: <signal> (confidence=<0.00>)
+reason: <first 120 chars of reasoning>
+metadata: <comma-separated key=value pairs, truncated at 160 chars>
+```
+
+If the caller explicitly asks for the raw JSON, include it below the summary
+fenced as ```json. Otherwise keep the full payload in your own working notes
+only — the point of this subagent is to keep the main context clean.
+
+## Failure mode
+
+If the Python call raises, report the exception class + message on one line
+and suggest the most likely fix:
+- `sentiment` → check `LLM_PROVIDER` env var (`agents/sentiment_agent.py`).
+- `risk`/`regime` → check that `data/fetcher.py` has cached OHLCV for the ticker.
+- `knowledge` → check that `models/lgbm_alpha.pkl` exists and that `model_metadata` rows are populated (see `agents/knowledge_agent.py`).
+- Any agent → check that the module imports without error via `python -c "import agents.<module>"`.
+
+Do not retry silently, do not pip-install missing packages, do not modify any files.

--- a/.claude/commands/run-agent.md
+++ b/.claude/commands/run-agent.md
@@ -1,65 +1,48 @@
 ---
-description: Invoke a specialist trading agent (regime, risk, sentiment, screener, execution, knowledge) or the meta-agent with a ticker context, and display the AgentSignal.
+description: Invoke a specialist trading agent (regime, risk, sentiment, screener, execution, knowledge) or the meta-agent with a ticker context, and display the AgentSignal. Delegates to the `trading-agent-runner` subagent so large JSON payloads stay out of the main context.
 argument-hint: <agent_name> <ticker>
 ---
 
-Invoke one of the trading agents defined in `agents/` with a minimal context and print the resulting `AgentSignal` (see `agents/base.py:15-48`).
+Delegate to the `trading-agent-runner` subagent with the parsed arguments.
+This keeps verbose agent output (full reasoning, metadata dumps) out of the
+main conversation — the subagent returns only a 3-line summary unless the
+user explicitly asks for raw JSON.
 
 ## Arguments
 
-- `<agent_name>`: one of `regime`, `risk`, `sentiment`, `screener`, `execution`, `knowledge`, `meta` (case-insensitive).
-- `<ticker>`: symbol, validated against `^[A-Z0-9]{1,6}(\.[A-Z]{1,2})?$` — same regex as `agents/meta_agent.py:25`.
+- `<agent_name>`: one of `regime`, `risk`, `sentiment`, `screener`,
+  `execution`, `knowledge`, `meta` (case-insensitive).
+- `<ticker>`: symbol matching `^[A-Z0-9]{1,6}(\.[A-Z]{1,2})?$` — same regex as
+  `agents/meta_agent.py:25`.
 
-Reject unknown agent names with a list of valid options. Reject malformed tickers with the regex.
+If either argument is missing or malformed, print the usage line and stop;
+**do not** dispatch to the subagent:
+
+```
+/run-agent <regime|risk|sentiment|screener|execution|knowledge|meta> <TICKER>
+```
 
 ## Dispatch
 
-| agent_name | Class | Module |
-|---|---|---|
-| `regime` | `RegimeAgent` | `agents.regime_agent` |
-| `risk` | `RiskAgent` | `agents.risk_agent` |
-| `sentiment` | `SentimentAgent` | `agents.sentiment_agent` |
-| `screener` | `ScreenerAgent` | `agents.screener_agent` |
-| `execution` | `ExecutionAgent` | `agents.execution_agent` |
-| `knowledge` | `KnowledgeAdaptionAgent` | `agents.knowledge_agent` |
-| `meta` | `MetaAgent` | `agents.meta_agent` |
+Launch the `trading-agent-runner` subagent with a self-contained prompt:
 
-## Execution
+> Run the `<agent_name>` agent on ticker `<TICKER>`. Return the compact
+> 3-line summary documented in your definition. Include raw JSON only if the
+> user explicitly asked for it.
 
-Run a one-shot Python invocation. For specialists:
+The subagent handles module dispatch, execution, and failure reporting. See
+`.claude/agents/trading-agent-runner.md` for the full interface.
 
-```
-python -c "
-import json
-from agents.<module> import <Class>
-agent = <Class>()
-sig = agent.run({'ticker': '<TICKER>'})
-print(json.dumps({
-    'agent': sig.agent_name,
-    'signal': sig.signal,
-    'confidence': sig.confidence,
-    'reasoning': sig.reasoning,
-    'metadata': sig.metadata,
-}, indent=2, default=str))
-"
-```
+## After the subagent returns
 
-For `meta`, `MetaAgent.run()` already returns a dict (see `agents/meta_agent.py:136-150`) — dump it directly:
-
-```
-python -c "
-import json
-from agents.meta_agent import MetaAgent
-result = MetaAgent().run({'ticker': '<TICKER>'})
-print(json.dumps(result, indent=2, default=str))
-"
-```
-
-## Output
-
-Show the JSON result as a formatted block. Do not edit files. If the agent raises, show the exception class and message; suggest checking the agent's dependencies (e.g., sentiment needs an LLM provider configured via `LLM_PROVIDER`).
+Forward the 3-line summary to the user verbatim. If the user then asks for
+"full output" or "raw JSON", re-invoke the subagent with the explicit
+raw-JSON request — do not attempt to reconstruct the payload.
 
 ## Notes
 
-- `MetaAgent` reads `AGENT_WEIGHTS` and `AGENT_LLM_ARBITER` from the environment (`agents/meta_agent.py:9-11`). Do not override them from this command.
-- `python -c:*` is pre-approved in `.claude/settings.json`, so this runs without a permission prompt.
+- `MetaAgent` reads `AGENT_WEIGHTS` and `AGENT_LLM_ARBITER` from the
+  environment (`agents/meta_agent.py:9-11`). Do not override them from this
+  command.
+- `python -c:*` is pre-approved in `.claude/settings.json`, so the subagent
+  runs without permission prompts.

--- a/.claude/commands/run-cron.md
+++ b/.claude/commands/run-cron.md
@@ -1,59 +1,44 @@
 ---
-description: Manually run a cron job (cron.daily_ml_execute or cron.monthly_ml_retrain) locally with optional ticker override, and summarise the structured log output.
+description: Manually run a cron job (cron.daily_ml_execute or cron.monthly_ml_retrain) locally with optional ticker override, and summarise the structured log output. Delegates to the `cron-runner` subagent so training/trade logs stay out of the main context.
 argument-hint: daily|monthly [TICKER1,TICKER2,...]
 ---
 
-Manually trigger one of the ML cron jobs. Mirrors the manual-invocation lines documented in `cron/daily_ml_execute.py:9-11` and `cron/monthly_ml_retrain.py:7-11`.
+Delegate to the `cron-runner` subagent with the parsed arguments. This keeps
+verbose training/trade logs out of the main conversation — the subagent
+returns only the parsed summary of the final structured log line.
 
 ## Arguments
 
 - First arg (required): `daily` or `monthly`.
-- Second arg (optional): comma-separated ticker list. If present, export `WF_TICKERS=<arg>` **for the subprocess only** — do not mutate the user's shell.
+- Second arg (optional): comma-separated ticker list (forwarded as
+  `WF_TICKERS` for the subprocess only; never mutates the user's shell).
 
-Reject any other first arg with a usage line: `/run-cron daily|monthly [TICKER1,TICKER2,...]`.
+Reject anything else with:
+
+```
+/run-cron daily|monthly [TICKER1,TICKER2,...]
+```
 
 ## Dispatch
 
-| First arg | Command | Script |
-|---|---|---|
-| `daily` | `python -m cron.daily_ml_execute` | `cron/daily_ml_execute.py` |
-| `monthly` | `python -m cron.monthly_ml_retrain` | `cron/monthly_ml_retrain.py` |
+Launch the `cron-runner` subagent with a self-contained prompt:
 
-Both are pre-approved in `.claude/settings.json`.
+> Run `<mode>` (tickers=<value or "default">). Perform the documented
+> pre-flight checks, surface any env vars that differ from defaults, and
+> return the compact summary block.
 
-## Pre-flight for `daily`
+The subagent enforces the "never switch `BROKER_PROVIDER` away from paper
+without confirmation" guardrail and handles failure reporting. See
+`.claude/agents/cron-runner.md` for the full interface.
 
-Before invoking, check that a trained model exists — otherwise `cron/daily_ml_execute.py:59-64` will exit 1:
+## After the subagent returns
 
-```
-python -c "import os; p=os.environ.get('LGBM_ALPHA_MODEL_PATH','models/lgbm_alpha.pkl'); import sys; sys.exit(0 if os.path.exists(p) else 1)"
-```
+Forward the summary block to the user. If the subagent reports a missing
+model, suggest running `/run-cron monthly` first with the same tickers.
 
-If the model is missing, stop and tell the user to run `/run-cron monthly` first (optionally with the same tickers).
+## Guardrails (enforced by the subagent)
 
-## Env vars to surface
-
-`daily` also reads `ML_SCORE_THRESHOLD` (default 0.3), `ML_MAX_POSITIONS` (default 5), `BROKER_PROVIDER` (default `paper`) — all from `cron/daily_ml_execute.py:17-22`. Before running, print the current values and ask the user whether to override. Default to the existing env; never silently switch to a live broker.
-
-`monthly` reads `ML_TRAIN_PERIOD` (default `2y`) from `cron/monthly_ml_retrain.py:14-17`. Surface the same way.
-
-## Run
-
-Stream output to the user. On success, parse the final structured log line and summarise:
-
-- **daily**: extract `n_actions`, `n_scores`, and the `actions` list from the `daily_ml_execute: complete` log (fields match `cron/daily_ml_execute.py:75-79`). Show a one-screen summary.
-- **monthly**: extract `train_ic`, `test_ic`, `train_icir`, `test_icir`, `n_train`, `n_test` from the `ml_retrain: complete` log (fields match `cron/monthly_ml_retrain.py:55-63`). Show them in a small table.
-
-## On failure
-
-If exit code is non-zero, show the last 20 lines of stderr and propose the next step:
-
-- `lightgbm is not installed` → `pip install lightgbm`.
-- `no trained baseline model found` → run `/run-cron monthly` first.
-- `runtime error` during retraining → check `WF_TICKERS` and network; do not retry silently.
-
-## Guardrails
-
-- Do not switch `BROKER_PROVIDER` away from `paper` without explicit user confirmation — a mis-set broker could place real orders.
-- Do not modify anything under `cron/` or `strategies/` from this command.
-- Do not commit, push, or tag anything.
+- Does not switch `BROKER_PROVIDER` away from `paper` without explicit
+  confirmation — a mis-set broker could place real orders.
+- Does not modify anything under `cron/` or `strategies/`.
+- Does not commit, push, or tag anything.

--- a/.claude/hooks/guard-bash.sh
+++ b/.claude/hooks/guard-bash.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""
+PreToolUse(Bash) guard — blocks destructive shell patterns.
+
+Reads the tool input as JSON on stdin; exits 2 to deny and stderr is fed
+back to Claude.
+
+Heredoc bodies are stripped before pattern-matching so that a commit message
+(or PR body) that *mentions* a forbidden flag does not trigger the guard.
+"""
+from __future__ import annotations
+
+import json
+import re
+import sys
+
+
+def strip_heredocs(cmd: str) -> str:
+    """Remove heredoc bodies: `<<EOF ... EOF`, `<<'EOF' ... EOF`, etc."""
+    pattern = re.compile(
+        r"(?P<prefix><<-?\s*['\"]?(?P<tag>[A-Za-z_][A-Za-z0-9_]*)['\"]?)"
+        r".*?^\s*(?P=tag)\s*$",
+        re.DOTALL | re.MULTILINE,
+    )
+    return pattern.sub(lambda m: m.group("prefix"), cmd)
+
+
+RULES: list[tuple[str, str]] = [
+    (r"(?:^|\s)--no-verify(?:\s|$)",
+     "skipping commit hooks (--no-verify) is not allowed (CLAUDE.md: 'Never skip CI')"),
+    (r"(?:^|\s)--no-gpg-sign(?:\s|$)",
+     "skipping commit signing is not allowed"),
+    (r"-c\s+commit\.gpgsign=false",
+     "disabling commit signing via -c is not allowed"),
+    # Plain --force: destructive (can overwrite a remote ref that moved).
+    # --force-with-lease: allowed — refuses if the remote advanced, which is
+    # the standard safe way to update a feature branch after a rebase.
+    (r"\bgit\s+push\b[^|;&\n]*--force(?!-with-lease)\b",
+     "force-push (--force) is destructive; use --force-with-lease instead"),
+    (r"\bgit\s+push\b[^|;&\n]*\s-f(?:\s|$)",
+     "force-push (-f) is destructive; use --force-with-lease instead"),
+    (r"\bgit\s+push\s+(?:origin\s+)?(?:main|master)(?:\s|$)",
+     "direct push to main/master is not allowed; push to a feature branch and open a PR"),
+    (r"\bgit\s+reset\s+--hard\b",
+     "git reset --hard discards uncommitted work; investigate first"),
+    (r"\bgit\s+branch\s+-D\b",
+     "force-deleting a branch can lose work; ask the user to confirm"),
+    (r"\bgit\s+branch\s+--delete\s+--force\b",
+     "force-deleting a branch can lose work; ask the user to confirm"),
+    (r"\bgit\s+(?:checkout|switch)\s+(?:main|master)(?:\s|$)",
+     "do not switch to main/master mid-task; stay on the feature branch"),
+    (r"\bgit\s+clean\s+-[fFdDxX]{1,3}\b",
+     "git clean removes untracked files irreversibly"),
+    (r"\brm\s+-rf?\s+/(?:\s|$|\*)",
+     "rm -rf on the root filesystem is forbidden"),
+    (r"\brm\s+-rf?\s+~(?:\s|$|/)",
+     "rm -rf on the home directory is forbidden"),
+    (r"\brm\s+-rf?\s+\$HOME\b",
+     "rm -rf on $HOME is forbidden"),
+    (r"\bgit\s+config\s+--global\b",
+     "global git config edits are not allowed (CLAUDE.md: 'NEVER update the git config')"),
+]
+
+
+def main() -> int:
+    try:
+        data = json.load(sys.stdin)
+    except Exception:
+        return 0  # malformed input — defer to Claude's own handling
+    cmd = (data.get("tool_input") or {}).get("command") or ""
+    if not cmd:
+        return 0
+    scrubbed = strip_heredocs(cmd)
+    for pat, reason in RULES:
+        if re.search(pat, scrubbed):
+            first = cmd.splitlines()[0][:200] if cmd else ""
+            print(f"BLOCKED by guard-bash: {reason}", file=sys.stderr)
+            print(f"Command: {first}", file=sys.stderr)
+            print("If this is intentional, ask the user to run it manually.", file=sys.stderr)
+            return 2
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# SessionStart hook — emits a one-shot context block for the session.
+# Output goes into Claude's context, so keep it compact and never echo secrets.
+set -u
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$REPO_ROOT" || exit 0
+
+emit() { printf '%s\n' "$*"; }
+
+emit "## quant-platform session context"
+emit ""
+
+# --- Toolchain ---------------------------------------------------------------
+PY_VER="$(python3 --version 2>/dev/null || echo 'python3 missing')"
+emit "- python: ${PY_VER}"
+
+VENV_STATE="inactive"
+[ -n "${VIRTUAL_ENV:-}" ] && VENV_STATE="active (${VIRTUAL_ENV##*/})"
+[ -d ".venv" ] && [ -z "${VIRTUAL_ENV:-}" ] && VENV_STATE="present (.venv, not activated)"
+emit "- venv: ${VENV_STATE}"
+
+TOOLS=()
+for t in ruff pytest bandit pip-audit; do
+  if command -v "$t" >/dev/null 2>&1; then
+    TOOLS+=("${t}=ok")
+  else
+    TOOLS+=("${t}=MISSING")
+  fi
+done
+emit "- tooling: ${TOOLS[*]}"
+
+# --- Env / secrets (presence only, never values) -----------------------------
+ENV_STATE="absent"
+[ -f ".env" ] && ENV_STATE="present"
+emit "- .env: ${ENV_STATE}"
+
+# --- Databases ---------------------------------------------------------------
+DBS=()
+for db in quant.db journal_trades.db data/wf_history.db; do
+  if [ -f "$db" ]; then
+    DBS+=("${db}=ok")
+  else
+    DBS+=("${db}=missing")
+  fi
+done
+emit "- databases: ${DBS[*]}"
+
+# --- Git state ---------------------------------------------------------------
+if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  BRANCH="$(git rev-parse --abbrev-ref HEAD 2>/dev/null)"
+  HEAD_SHORT="$(git rev-parse --short HEAD 2>/dev/null)"
+  HEAD_SUBJ="$(git log -1 --pretty=%s 2>/dev/null)"
+  emit "- branch: ${BRANCH}"
+  emit "- head: ${HEAD_SHORT} ${HEAD_SUBJ}"
+
+  AHEAD_BEHIND="$(git rev-list --left-right --count "origin/main...HEAD" 2>/dev/null || echo '? ?')"
+  BEHIND="${AHEAD_BEHIND%%	*}"
+  AHEAD="${AHEAD_BEHIND##*	}"
+  emit "- vs origin/main: ${AHEAD} ahead, ${BEHIND} behind"
+
+  DIRTY="$(git status --porcelain 2>/dev/null | wc -l | tr -d ' ')"
+  emit "- uncommitted changes: ${DIRTY} file(s)"
+fi
+
+emit ""
+emit "Reminder: CI gate is 76% coverage + ruff + bandit HIGH + pip-audit. Run the \`pre-push\` skill before pushing."

--- a/.claude/hooks/stop-reminder.sh
+++ b/.claude/hooks/stop-reminder.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Stop hook — advisory nudges printed when Claude finishes a turn.
+#   1. If the branch has uncommitted .py changes → remind to run the pre-push skill.
+#   2. If new implementation work is present (code files added/modified) → remind
+#      to associate the change with a ticket before committing.
+# Exit 0 always; never block.
+set -u
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$REPO_ROOT" || exit 0
+
+# Quiet when not in a git repo.
+git rev-parse --is-inside-work-tree >/dev/null 2>&1 || exit 0
+
+PY_CHANGED="$(git status --porcelain -- '*.py' 2>/dev/null | wc -l | tr -d ' ')"
+CODE_CHANGED="$(git status --porcelain -- '*.py' '*.md' '*.yml' '*.yaml' '*.sh' 2>/dev/null | wc -l | tr -d ' ')"
+
+[ "$CODE_CHANGED" = "0" ] && exit 0
+
+printf '\n[stop-reminder]\n'
+
+if [ "$PY_CHANGED" != "0" ]; then
+  printf -- '- %s uncommitted .py file(s). Run the `pre-push` skill to mirror CI gates before pushing.\n' "$PY_CHANGED"
+fi
+
+# Ticket-association nudge — fires when any tracked-code file was changed.
+# Rule: every new implementation must reference a ticket/issue (e.g. #123, QP-45)
+# in the branch name, commit message, or PR description.
+BRANCH="$(git rev-parse --abbrev-ref HEAD 2>/dev/null)"
+HAS_TICKET_IN_BRANCH=0
+if printf '%s' "$BRANCH" | grep -Eq '(#[0-9]+|[A-Z]{2,}-[0-9]+|issue[-_/][0-9]+)'; then
+  HAS_TICKET_IN_BRANCH=1
+fi
+
+if [ "$HAS_TICKET_IN_BRANCH" = "0" ]; then
+  printf -- '- Rule: associate new implementations with a ticket. Branch `%s` has no ticket ref — include one (e.g. `#123` or `QP-45`) in the commit message or PR body before pushing.\n' "$BRANCH"
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,14 +1,65 @@
 {
   "permissions": {
     "allow": [
-      "Bash(ruff check:*)",
-      "Bash(ruff check . --fix)",
-      "Bash(pytest tests/:*)",
-      "Bash(bandit -r . -ll --exclude ./.git,./tests:*)",
-      "Bash(pip-audit -r requirements.txt:*)",
-      "Bash(python -m cron.daily_ml_execute)",
-      "Bash(python -m cron.monthly_ml_retrain)",
-      "Bash(python -c:*)"
+      "Bash(git status:*)",
+      "Bash(git diff:*)",
+      "Bash(git log:*)",
+      "Bash(git show:*)",
+      "Bash(git branch:*)",
+      "Bash(git rev-parse:*)",
+      "Bash(git stash list:*)",
+      "Bash(ls:*)",
+      "Bash(find:*)",
+      "Bash(wc:*)",
+      "Bash(tree:*)",
+      "Bash(ruff:*)",
+      "Bash(pytest:*)",
+      "Bash(bandit:*)",
+      "Bash(pip-audit:*)",
+      "Bash(python -m pytest:*)",
+      "Bash(python -m cron.daily_ml_execute:*)",
+      "Bash(python -m cron.monthly_ml_retrain:*)",
+      "Bash(python -m cron.monthly_wf:*)",
+      "Bash(python -c:*)",
+      "Bash(docker compose config)",
+      "Bash(docker compose ps)"
     ]
+  },
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/guard-bash.sh"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/stop-reminder.sh"
+          }
+        ]
+      }
+    ]
+  },
+  "statusLine": {
+    "type": "command",
+    "command": ".claude/statusline.sh"
   }
 }

--- a/.claude/statusline.sh
+++ b/.claude/statusline.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Claude Code status line for quant-platform.
+# Output on stdout is rendered as the status line. Keep it one line, ASCII-safe.
+set -u
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT" || exit 0
+
+# --- Branch + ahead/behind ---------------------------------------------------
+BRANCH="?"
+AHEAD="?"
+BEHIND="?"
+if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  BRANCH="$(git rev-parse --abbrev-ref HEAD 2>/dev/null)"
+  if COUNTS="$(git rev-list --left-right --count origin/main...HEAD 2>/dev/null)"; then
+    BEHIND="${COUNTS%%	*}"
+    AHEAD="${COUNTS##*	}"
+  fi
+fi
+
+# --- Python version (stripped) ----------------------------------------------
+PY="$(python3 --version 2>/dev/null | awk '{print $2}')"
+[ -z "$PY" ] && PY="?"
+
+# --- Coverage from latest coverage.xml (cached read) -------------------------
+COV="-"
+if [ -f "coverage.xml" ]; then
+  COV="$(python3 - <<'PY' 2>/dev/null
+import re, sys
+try:
+    with open("coverage.xml", "r", encoding="utf-8") as f:
+        head = f.read(4096)
+    m = re.search(r'line-rate="([0-9.]+)"', head)
+    if m:
+        pct = round(float(m.group(1)) * 100)
+        print(f"{pct}%")
+    else:
+        print("-")
+except Exception:
+    print("-")
+PY
+)"
+fi
+
+# --- Uncommitted file count --------------------------------------------------
+DIRTY=""
+if [ "$BRANCH" != "?" ]; then
+  N="$(git status --porcelain 2>/dev/null | wc -l | tr -d ' ')"
+  [ "$N" != "0" ] && DIRTY=" *${N}"
+fi
+
+printf '%s | py%s | cov:%s | %sup/%sdown%s' \
+  "$BRANCH" "$PY" "$COV" "$AHEAD" "$BEHIND" "$DIRTY"


### PR DESCRIPTION
## Summary

Closes #113. Brings the Claude Code harness up to a production baseline. No product code, CI workflow, or existing skill is touched.

- **Permissions** — glob-pattern allowlist for read-only ops (git, ls, find, wc, ruff, pytest, bandit, pip-audit, docker read). Destructive ops still prompt.
- **`SessionStart` hook** — one-shot env/git context (python, venv, tooling, `.env` presence, DB flags, branch, head, ahead/behind, dirty count).
- **`PreToolUse(Bash)` guard** — denies `--no-verify`, plain `--force` / `-f` push, direct push to `main`/`master`, `git reset --hard`, `rm -rf /` or `~`, global git-config edits, force branch delete, `git clean -f`. Strips heredoc bodies so commit/PR messages that *mention* these patterns are not false-flagged. Allows `--force-with-lease` (safe rebase push).
- **`Stop` reminder** — nudges `/pre-push` on uncommitted `.py` changes; enforces project rule that new implementations must reference a ticket in the branch name, commit message, or PR body.
- **Subagents** under `.claude/agents/`:
  - `trading-agent-runner` — wraps `agents/*` dispatch (including the new `knowledge` agent merged in #114), returns a 3-line summary instead of raw `AgentSignal` JSON.
  - `cron-runner` — runs `cron.daily_ml_execute` / `cron.monthly_ml_retrain`; enforces the paper-broker guardrail; returns a parsed summary line.
  - `experiment-tracker` — runs one `ic`/`tune`/`wf` phase in isolation; requires a ticket ref; writes artifacts to `data/wf_history.db`.
- **Status line** — `branch | py<ver> | cov:<pct from coverage.xml> | Nup/Ndown *dirty`.
- **Slash commands** (`/run-agent`, `/run-cron`) updated to delegate to the new subagents so verbose output stays out of the main context.

Explicitly out of scope (with rationale in `#113`): `.mcp.json` (`providers/` already abstracts externals) and `.pre-commit-config.yaml` (the `pre-push` skill + Stop reminder cover the gate without a second toolchain).

## Test plan

- [x] `.claude/hooks/session-start.sh` — emits context block on a fresh session.
- [x] `.claude/hooks/guard-bash.sh` — blocks `git push -f`, `git commit --no-verify`, `rm -rf /`; allows `git status` and a commit message body that mentions `--no-verify`; allows `--force-with-lease`.
- [x] `.claude/hooks/stop-reminder.sh` — fires on uncommitted `.py` files and when the branch name has no ticket ref.
- [x] `.claude/statusline.sh` — renders branch/py/cov/ahead-behind/dirty on this branch.
- [x] Rebased onto latest `main` (`fc4cc57` incl. knowledge-agent merge) and pushed via `--force-with-lease`.
- [ ] CI green (`lint`, `security`, `test`, `build`).

https://claude.ai/code/session_01NnANq86tjy5DUyuEJC6RP9