### PR TITLE
harness: refine .claude/ — delegate ml-experiment, add /run-experiment

### DIFF
--- a/.claude/commands/run-agent.md
+++ b/.claude/commands/run-agent.md
@@ -1,6 +1,7 @@
 ---
 description: Invoke a specialist trading agent (regime, risk, sentiment, screener, execution, knowledge) or the meta-agent with a ticker context, and display the AgentSignal. Delegates to the `trading-agent-runner` subagent so large JSON payloads stay out of the main context.
 argument-hint: <agent_name> <ticker>
+tools: []
 ---
 
 Delegate to the `trading-agent-runner` subagent with the parsed arguments.

--- a/.claude/commands/run-cron.md
+++ b/.claude/commands/run-cron.md
@@ -1,6 +1,7 @@
 ---
 description: Manually run a cron job (cron.daily_ml_execute or cron.monthly_ml_retrain) locally with optional ticker override, and summarise the structured log output. Delegates to the `cron-runner` subagent so training/trade logs stay out of the main context.
 argument-hint: daily|monthly [TICKER1,TICKER2,...]
+tools: []
 ---
 
 Delegate to the `cron-runner` subagent with the parsed arguments. This keeps

--- a/.claude/commands/run-experiment.md
+++ b/.claude/commands/run-experiment.md
@@ -1,0 +1,54 @@
+---
+description: Run a single phase of an ML experiment (ic, tune, or wf) via the experiment-tracker subagent and return a compact summary. Detailed artifacts remain in data/wf_history.db.
+argument-hint: ic|tune|wf <TICKER> --ticket <REF> [--feature NAME]
+tools: []
+---
+
+Delegate to the `experiment-tracker` subagent with the parsed arguments. This
+keeps verbose Optuna trial logs and per-fold walk-forward tables out of the
+main conversation — the subagent returns only the compact summary block
+documented in its definition.
+
+## Arguments
+
+- `<phase>` (required): one of `ic`, `tune`, `wf`.
+- `<ticker>` (required): symbol matching `^[A-Z0-9]{1,6}(\.[A-Z]{1,2})?$` (same
+  regex as `/run-agent`).
+- `--ticket <REF>` (required): ticket reference (`#123`, `QP-45`, `issue-87`).
+  The subagent enforces this too, but reject early at the command layer for a
+  cleaner error.
+- `--feature NAME` (optional, `ic` phase only): which feature in
+  `data/features.py` to measure.
+
+If any required argument is missing or malformed, print the usage line and
+stop; **do not** dispatch to the subagent:
+
+```
+/run-experiment <ic|tune|wf> <TICKER> --ticket <REF> [--feature NAME]
+```
+
+## Dispatch
+
+Launch the `experiment-tracker` subagent with a self-contained prompt:
+
+> Run the `<phase>` phase on ticker `<TICKER>`, ticket `<REF>`
+> (feature=`<NAME>` if provided). Return the compact summary block documented
+> in your definition. Do not modify feature, strategy, or backtester code.
+
+The subagent handles module dispatch, artifact recording in
+`data/wf_history.db`, and failure reporting. See
+`.claude/agents/experiment-tracker.md` for the full interface.
+
+## After the subagent returns
+
+Forward the summary block to the user verbatim. If the user asks for
+per-trial detail or per-fold tables, point them at `data/wf_history.db`
+(the subagent printed the `run_id`) rather than re-running the phase.
+
+## Notes
+
+- For an end-to-end experiment (feature add → IC → wire → tune → backtest),
+  use the `/ml-experiment` skill instead; it chains the phases and handles
+  the edit steps the subagent deliberately does not perform.
+- `python -c:*` is pre-approved in `.claude/settings.json`, so the subagent
+  runs without permission prompts.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -25,6 +25,10 @@
       "Bash(docker compose ps)"
     ]
   },
+  "env": {
+    "PYTHONDONTWRITEBYTECODE": "1",
+    "PYTHONUNBUFFERED": "1"
+  },
   "hooks": {
     "SessionStart": [
       {

--- a/.claude/skills/ml-experiment/SKILL.md
+++ b/.claude/skills/ml-experiment/SKILL.md
@@ -5,32 +5,44 @@ description: Guide the user end-to-end through a new ML signal or feature experi
 
 # ml-experiment — scaffold a new ML signal experiment
 
-The platform already has a full ML pipeline. This skill does **not** re-implement any of it — it chains the existing modules and emits a concise experiment report. Always reuse; never duplicate.
+The platform already has a full ML pipeline. This skill does **not** re-implement any of it — it chains the existing modules via the `experiment-tracker` subagent and emits a concise experiment report. Always reuse; never duplicate.
 
 ## Pipeline modules (reuse these, do not rewrite)
 
 | Stage | Module | Key API |
 |---|---|---|
 | Features | `data/features.py` | add a function here; the feature list is assembled inside the module |
-| IC / ICIR | `analysis/factor_ic.py` | `compute_ic(df, feature, horizon)` |
+| IC / ICIR | `analysis/factor_ic.py` | measured via the `experiment-tracker` subagent (`ic` phase) |
 | Baseline model | `strategies/ml_signal.py` | `MLSignal().train(tickers, period)`, `MLSignal().predict(tickers, period)` — LightGBM + regime-conditioning |
 | Ensemble | `strategies/ensemble_signal.py` | use when stacking multiple signals |
-| Tuning | `strategies/ml_tuning.py` | `run_optuna(...)`, `load_best_params(model_name)` — persisted params are picked up automatically by `cron/monthly_ml_retrain.py` |
-| Walk-forward backtest | `backtester/walk_forward.py` | `run_walk_forward(...)` |
+| Tuning | `strategies/ml_tuning.py` | measured via the `experiment-tracker` subagent (`tune` phase); persisted winners are picked up automatically by `cron/monthly_ml_retrain.py` |
+| Walk-forward backtest | `backtester/walk_forward.py` | run via the `experiment-tracker` subagent (`wf` phase) |
 | Tests | `tests/test_ml_signal.py`, `tests/test_features.py` | mock `fetch_ohlcv`; no network |
+
+## Delegation — keep compute off the main context
+
+Long-running phases (IC, Optuna tuning, walk-forward) MUST run inside the
+`experiment-tracker` subagent (see `.claude/agents/experiment-tracker.md`), not
+as inline `python -c` calls from the main context. The subagent returns a
+compact summary block; raw trial logs and per-fold tables stay in
+`data/wf_history.db`. Never paste those back into the main conversation.
+
+Collect the user's ticket ref (`#123`, `QP-45`, `issue-87`) up front in step 1
+and forward it to every subagent dispatch — the subagent rejects invocations
+without one.
 
 ## Steps
 
 Walk the user through these, one at a time. At each step, print what you changed and what command you ran.
 
-1. **Clarify scope.** Ask: what feature or signal idea, and on which ticker universe? Default universe is `$WF_TICKERS` or `SPY,QQQ,AAPL,MSFT,TSLA` (matches `cron/daily_ml_execute.py:35`).
+1. **Clarify scope and ticket.** Ask: what feature or signal idea, on which ticker universe, and what ticket ref? Default universe is `$WF_TICKERS` or `SPY,QQQ,AAPL,MSFT,TSLA` (matches `cron/daily_ml_execute.py:35`). Stop if no ticket is provided.
 2. **Add the feature.** Edit `data/features.py` to add the feature function; register it in the existing feature list. Add or extend a unit test in `tests/test_features.py` that mocks OHLCV — do not hit network.
 3. **Run the feature test.** `pytest tests/test_features.py -v`.
-4. **Measure IC.** Compute `compute_ic` on the configured universe across sensible horizons (1d / 5d / 20d). Convention from `IMPLEMENTATION_SUMMARY.md`: if `|IC| < 0.02` and ICIR is small, reject the feature and stop. Report the IC table.
+4. **Measure IC (delegated).** Dispatch the `experiment-tracker` subagent with phase=`ic`, the ticker, the ticket ref, and `--feature <name>`. Forward the returned summary block verbatim. Convention from `IMPLEMENTATION_SUMMARY.md`: if `|IC| < 0.02` and ICIR is small, reject the feature and stop.
 5. **Wire into a signal.** If a pure feature, add to `MLSignal`. If combining signals, extend `ensemble_signal.py`. Do **not** modify `cron/monthly_ml_retrain.py` or `cron/daily_ml_execute.py` — they consume whatever `MLSignal` and `load_best_params` return.
-6. **Tune.** Call `strategies.ml_tuning.run_optuna(...)` for N trials (ask; default 30) with purged CV. Persist winners so `monthly_ml_retrain` picks them up on the next schedule.
-7. **Walk-forward backtest.** `run_walk_forward` on the configured universe; report Sharpe, Sortino, max drawdown, turnover.
-8. **Report.** Emit a one-screen experiment report:
+6. **Tune (delegated).** Dispatch the `experiment-tracker` subagent with phase=`tune`, the ticker, the ticket ref (ask for trial count; default 30). The subagent persists winners via `strategies/ml_tuning.py` so `monthly_ml_retrain` picks them up on the next schedule. Forward the summary block.
+7. **Walk-forward backtest (delegated).** Dispatch the `experiment-tracker` subagent with phase=`wf`, the ticker, the ticket ref. Forward the summary block (OOS Sharpe, OOS max drawdown, hit rate, folds).
+8. **Report.** Combine the three returned summary blocks into a one-screen experiment report:
 
    ```
    Experiment: <feature/signal name>

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,6 +98,8 @@ pytest tests/ -m "integration"
 
 **CI enforces `--cov-fail-under=76`.** Keep coverage above this threshold when adding code.
 
+For a single-command CI-mirror run (ruff + pytest 76% + bandit HIGH + pip-audit) from inside Claude Code, invoke the `/pre-push` skill.
+
 ### Linting
 
 ```bash


### PR DESCRIPTION
- Refactor ml-experiment skill to delegate IC/tune/wf phases to the
  experiment-tracker subagent instead of inline python -c, keeping
  trial logs and per-fold tables out of the main context.
- Add /run-experiment slash command parallel to /run-cron and /run-agent,
  covering the single-phase entry point the subagent was missing.
- Declare tools: [] on delegating commands so future edits don't
  accidentally grant direct Bash access bypassing the subagent layer.
- Add PYTHONDONTWRITEBYTECODE=1 and PYTHONUNBUFFERED=1 to settings.json
  env so harness-run python stops littering __pycache__ (which would
  trip stop-reminder.sh) and emits progress in order.
- Cross-ref /pre-push skill from CLAUDE.md Running Tests section.

Refs #126.

https://claude.ai/code/session_01G8YVywLdGLbTsmizCBkXQ6