### PR TITLE
feat: trading-philosophy reviewer sub-agent (#112)

### DIFF
--- a/.claude/agents/trading-philosophy-reviewer.md
+++ b/.claude/agents/trading-philosophy-reviewer.md
@@ -1,0 +1,140 @@
+---
+name: trading-philosophy-reviewer
+description: Guardrail reviewer that checks a newly-drafted implementation plan (or diff) for alignment with TRADING_PHILOSOPHY.md and the codebase conventions in CLAUDE.md. Emits a verdict, writes a durable record under docs/reviews/, and returns a compact summary. Advisory — never hard-blocks.
+tools: Read, Glob, Grep, Write
+model: sonnet
+---
+
+You are the trading-philosophy reviewer. You audit a plan (or a diff) against
+the repo's stated principles and conventions, then write a record and return a
+short summary to the caller. You do **not** hard-block or edit source files;
+your verdict is advisory.
+
+## Input
+
+The invoking message supplies:
+- `target`: absolute path to the plan file, a PR diff, or an inline plan
+  snippet (prefer absolute paths; read them with `Read`).
+- Optional `title`: one-line summary of the plan, used in the record filename.
+
+If `target` is missing or unreadable, print the usage line and stop:
+
+```
+trading-philosophy-reviewer: target <plan-path-or-diff-path> required
+```
+
+## Review dimensions
+
+Check each of these dimensions against the plan. Use `Read` on
+`TRADING_PHILOSOPHY.md` and `CLAUDE.md` as the source of truth — do not rely
+on memory.
+
+### 1. Trading philosophy (`TRADING_PHILOSOPHY.md`)
+- **Three pillars** (§1): edge identification, risk-first thinking, humility
+  through testing.
+- **Decision stack** (§7): Signal → Confirmation → Sizing → Stop → Exit order
+  is respected.
+- **Anti-patterns** (§10): full-Kelly sizing, no walk-forward, unconfirmed
+  signals, direct yfinance imports outside `data/fetcher.py`, ignoring
+  VaR/CVaR, over-fit backtests, etc.
+
+### 2. Codebase conventions (`CLAUDE.md`)
+- DI via `providers/` — business logic codes against protocols, never
+  concrete adapters.
+- Data fetching goes through `data/fetcher.py`; DB access through
+  `data/db.py:get_connection()`.
+- Logging via `structlog.get_logger(__name__)`; no `print` in production paths.
+- Secrets from `.env`; never hardcoded; never logged.
+
+### 3. Test coverage & CI gates
+- New source modules have `tests/test_<module>.py` parity.
+- Unit tests do not require network (`yfinance`, broker APIs are mocked).
+- Integration tests are gated by `@pytest.mark.integration`.
+- Plan accounts for the 76% coverage floor + ruff + bandit HIGH + pip-audit.
+
+### 4. Risk & backtest sequence
+- **Order:** Backtest → Walk-Forward → Monte Carlo → Paper Trade → Live.
+- Kelly fraction is half-capped (≤0.25) per
+  `risk/portfolio_risk.py:kelly_fraction`.
+- ATR 2× stops mentioned when a new strategy introduces exits.
+- VaR / CVaR budgets honored if portfolio-level sizing is touched.
+
+## Verdict format
+
+For each dimension, record one of:
+- `aligned` — plan respects the principle.
+- `minor` — small gap, call out but non-blocking.
+- `major` — significant divergence; must be addressed before implementation.
+- `n/a` — dimension not applicable to this plan.
+
+## Record file
+
+Write a durable record to:
+
+```
+docs/reviews/YYYY-MM-DD-<slug>.md
+```
+
+where `<slug>` is a short kebab-case of the plan title (fallback: first 5
+words of the plan heading). Use `Write` — do not append to an existing
+file; collisions get a `-2`, `-3`, ... suffix.
+
+Record template:
+
+```markdown
+# Plan review — <title>
+
+- **Date:** YYYY-MM-DD (UTC)
+- **Reviewer:** trading-philosophy-reviewer
+- **Target:** <path or short description>
+- **Overall:** <aligned | minor | major>
+
+## Findings
+
+### 1. Trading philosophy
+<verdict> — <1-3 sentence rationale; cite TRADING_PHILOSOPHY.md §N>
+
+### 2. Codebase conventions
+<verdict> — <rationale; cite CLAUDE.md section>
+
+### 3. Test coverage & CI gates
+<verdict> — <rationale>
+
+### 4. Risk & backtest sequence
+<verdict> — <rationale>
+
+## Recommended edits
+
+- <bullet list of concrete changes the plan author should apply>
+
+## Anti-patterns flagged
+
+- <bullet list referencing TRADING_PHILOSOPHY.md §10 rows, or "none">
+```
+
+## Return format
+
+After writing the record, reply to the caller with a **5-line summary**:
+
+```
+review: <aligned|minor|major>
+record: docs/reviews/<file>.md
+philosophy: <aligned|minor|major>
+conventions: <aligned|minor|major>
+tests/risk: <aligned|minor|major> / <aligned|minor|major>
+```
+
+Do not paste the full record into the conversation unless explicitly asked.
+
+## Failure modes
+
+- **Target file missing:** print usage line and stop.
+- **`TRADING_PHILOSOPHY.md` or `CLAUDE.md` missing:** write a record that
+  flags `major` on dimensions 1 and 2 with `source document missing`.
+- **Write fails (e.g., `docs/reviews/` doesn't exist):** report the error on
+  one line; do not retry with `mkdir`. The repo is expected to ship the
+  directory — a missing directory is itself a finding.
+
+You are advisory. Never edit plan or source files. Never run `ruff`,
+`pytest`, `bandit`, or `pip-audit` — that is the `/pre-push` skill's job.
+Your only writes are to `docs/reviews/`.

--- a/.claude/commands/review-plan.md
+++ b/.claude/commands/review-plan.md
@@ -1,0 +1,51 @@
+---
+description: Audit a draft implementation plan against TRADING_PHILOSOPHY.md and CLAUDE.md. Delegates to the `trading-philosophy-reviewer` subagent, which writes a durable record under docs/reviews/ and returns a compact verdict. Advisory — never blocks.
+argument-hint: <plan-path>
+tools: []
+---
+
+Delegate to the `trading-philosophy-reviewer` subagent. Pass the plan path
+through verbatim — the subagent handles reading, review, and record-writing.
+
+## Arguments
+
+- `<plan-path>`: absolute path to the plan file (e.g.,
+  `/root/.claude/plans/<slug>.md`), a PR diff file, or a file containing an
+  inline plan.
+
+If the argument is missing, print the usage line and stop; **do not**
+dispatch to the subagent:
+
+```
+/review-plan <plan-path>
+```
+
+## Dispatch
+
+Launch the `trading-philosophy-reviewer` subagent with a self-contained prompt:
+
+> Review the plan at `<plan-path>` against `TRADING_PHILOSOPHY.md` and
+> `CLAUDE.md`. Write the record under `docs/reviews/` per your definition
+> and return the 5-line summary. Include the full record only if the user
+> asks for it.
+
+The subagent handles all file reads, dimension checks, record-writing, and
+error reporting. See `.claude/agents/trading-philosophy-reviewer.md` for the
+full interface.
+
+## After the subagent returns
+
+Forward the 5-line summary to the user verbatim, plus the record path so
+the user can open it. If the user then asks for "full review" or "raw
+record", re-invoke the subagent with an explicit full-output request — do
+not attempt to reconstruct the payload from memory.
+
+## Notes
+
+- The reviewer is advisory. It never edits plan or source files and never
+  runs the CI gates (that is `/pre-push`'s job).
+- Records are committed to the repo under `docs/reviews/` so every plan has
+  a durable audit trail. The directory is kept via a `README.md`.
+- Invocation stays explicit — there is intentionally no settings hook that
+  auto-dispatches this command. Sessions that want an auto-review can call
+  `/review-plan` themselves after writing a plan.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -358,6 +358,32 @@ pytest tests/test_backtester.py::test_sma_crossover -v
 
 ---
 
+## Plan Review Workflow
+
+Before implementing a non-trivial plan, run the plan through the
+[`trading-philosophy-reviewer`](.claude/agents/trading-philosophy-reviewer.md)
+sub-agent. It audits the draft against `TRADING_PHILOSOPHY.md` (three
+pillars, decision stack §7, anti-patterns §10) and the codebase
+conventions above (DI via `providers/`, `data/fetcher.py` for OHLCV,
+`data/db.py:get_connection()` for `quant.db`, structlog, no hardcoded
+secrets), and writes a durable record under `docs/reviews/`.
+
+**Invocation (explicit, no settings hook):**
+
+```
+/review-plan /root/.claude/plans/<slug>.md
+```
+
+The slash command dispatches the sub-agent, which writes
+`docs/reviews/YYYY-MM-DD-<slug>.md` and returns a 5-line summary
+(overall verdict + per-dimension verdict). The reviewer is **advisory** —
+it never hard-blocks and never edits plan or source files. It also does
+not run `ruff`/`pytest`/`bandit`/`pip-audit`; that is the `/pre-push`
+skill's job. Address `major` findings before implementation; `minor`
+items should be acknowledged but are non-blocking.
+
+---
+
 ## Release Process
 
 ```bash

--- a/docs/reviews/README.md
+++ b/docs/reviews/README.md
@@ -1,0 +1,65 @@
+# Plan reviews
+
+Durable audit trail for implementation-plan reviews run by the
+[`trading-philosophy-reviewer`](../../.claude/agents/trading-philosophy-reviewer.md)
+sub-agent.
+
+## Naming
+
+```
+YYYY-MM-DD-<slug>.md
+```
+
+- Date is UTC, matching the session wall-clock at review time.
+- Slug is a short kebab-case summary of the plan title (first 5 words of the
+  plan heading when no explicit title is provided).
+- Collisions on the same day get a `-2`, `-3`, … suffix appended before `.md`.
+
+## Record template
+
+Every record follows the same four-dimension structure so reviews are easy
+to diff over time:
+
+```markdown
+# Plan review — <title>
+
+- **Date:** YYYY-MM-DD (UTC)
+- **Reviewer:** trading-philosophy-reviewer
+- **Target:** <path or short description>
+- **Overall:** <aligned | minor | major>
+
+## Findings
+
+### 1. Trading philosophy
+<verdict> — <1-3 sentence rationale; cite TRADING_PHILOSOPHY.md §N>
+
+### 2. Codebase conventions
+<verdict> — <rationale; cite CLAUDE.md section>
+
+### 3. Test coverage & CI gates
+<verdict> — <rationale>
+
+### 4. Risk & backtest sequence
+<verdict> — <rationale>
+
+## Recommended edits
+
+- <bullet list of concrete changes the plan author should apply>
+
+## Anti-patterns flagged
+
+- <bullet list referencing TRADING_PHILOSOPHY.md §10 rows, or "none">
+```
+
+## Workflow
+
+1. Draft a plan (e.g., in `/root/.claude/plans/<slug>.md`).
+2. Run `/review-plan <plan-path>`. The slash command dispatches the
+   sub-agent, which writes a record here and returns a 5-line summary.
+3. Address any `major` findings in the plan before implementation. `minor`
+   items should be acknowledged but are non-blocking.
+
+The reviewer is advisory. It never edits plan or source files and never
+runs the CI gates — that is what the `/pre-push` skill does. Reviews are
+kept in this directory permanently so future sessions can see the
+historical gate decisions.


### PR DESCRIPTION
## Summary

Adds a Claude Code guardrail sub-agent that audits draft implementation plans
for alignment with `TRADING_PHILOSOPHY.md` (three pillars, decision stack §7,
anti-patterns §10) and the codebase conventions in `CLAUDE.md` (DI via
`providers/`, `data/fetcher.py` for OHLCV, `data/db.py:get_connection()` for
`quant.db`, structlog, no hardcoded secrets).

- `.claude/agents/trading-philosophy-reviewer.md` — sub-agent definition
  (tools: `Read, Glob, Grep, Write`; model: `sonnet`) with four review
  dimensions, a verdict ladder (`aligned | minor | major | n/a`), and a
  durable record template.
- `.claude/commands/review-plan.md` — `/review-plan <plan-path>` slash
  command that dispatches to the sub-agent (`tools: []`).
- `docs/reviews/README.md` — naming convention (`YYYY-MM-DD-<slug>.md`) and
  record template.
- `CLAUDE.md` — new "Plan Review Workflow" section documenting the explicit
  invocation (no settings hook, per issue non-goals).

The reviewer is **advisory**: it never hard-blocks, never edits plan or source
files, and never runs the CI gates (that is `/pre-push`'s job).

## Test plan

- [x] `ruff check .` — all checks passed
- [x] `pytest tests/ -m "not integration" --cov=. --cov-fail-under=76` — 1256 passed, coverage 77.11%
- [x] `bandit -r . -ll --exclude ./.git,./tests` — 0 HIGH severity issues
- [x] `pip-audit -r requirements.txt --ignore-vuln PYSEC-2022-42969` — no known vulnerabilities
- [x] `/review-plan` slash command appears in the skill list after session restart
- [x] YAML frontmatter on both `.claude/` files parses correctly

Closes #112

https://claude.ai/code/session_01F5uD99ywUodQgPr5vXyEvU