### PR TITLE
security: pickle path confinement + regime at_risk flag (#124)

### DIFF
--- a/agents/knowledge_agent.py
+++ b/agents/knowledge_agent.py
@@ -22,6 +22,22 @@ its output confidence and that ``strategies/ml_execution.py`` uses to scale
 the Kelly fraction.  A stale verdict also triggers a throttled alert via
 ``providers.alert`` (24h cooldown) so silent cron failures surface.
 
+Threat model (pickle path confinement)
+--------------------------------------
+``pickle.load`` executes arbitrary ``__reduce__`` code during deserialisation.
+If an attacker can control ``LGBM_ALPHA_MODEL_PATH`` /
+``LGBM_REGIME_MODELS_PATH`` they can redirect the agent (and
+``strategies/ml_signal.py``) to a crafted pickle anywhere on disk and gain
+code execution in the trading process.
+
+Environment variables are therefore treated as **operator-trusted** — they
+should only be set by the human who deploys the platform, never by
+user-supplied request data or runtime config fetched from an untrusted
+source. As defence-in-depth, every pickle load is confined to
+``_ALLOWED_ROOTS`` (repo root + system temp dir for tests) via
+``_safe_pickle_path`` / ``_confine_pickle_path``. Paths escaping those
+roots are refused before ``pickle.load`` runs.
+
 ENV vars
 --------
     LGBM_ALPHA_MODEL_PATH       path to baseline pickle
@@ -38,6 +54,7 @@ import json
 import os
 import pickle
 import sys
+import tempfile
 import time
 from pathlib import Path
 from typing import Any
@@ -65,18 +82,48 @@ _RECOMMENDATION_MULTIPLIER: dict[str, float] = {
 
 _REPO_ROOT = Path(__file__).resolve().parent.parent
 
+# Pickle loads are confined to these roots. The repo root covers production
+# (``models/*.pkl``); the system temp dir is needed so unit tests can stage
+# fixture pickles under ``tmp_path``. Anything outside these roots is refused
+# before ``pickle.load`` runs (see ``_confine_pickle_path``).
+_ALLOWED_ROOTS: tuple[Path, ...] = (
+    _REPO_ROOT.resolve(),
+    Path(tempfile.gettempdir()).resolve(),
+)
+
 
 def recommendation_multiplier(recommendation: str) -> float:
     """Return the confidence / sizing multiplier for a recommendation tag."""
     return _RECOMMENDATION_MULTIPLIER.get(recommendation, 1.0)
 
 
-def _resolve_path(env_var: str, default_rel: str) -> Path:
-    """Resolve a model pickle path — env override wins, else repo-relative default."""
+def _confine_pickle_path(raw_path: str | Path) -> Path:
+    """Resolve ``raw_path`` and require it under ``_ALLOWED_ROOTS``.
+
+    Raises ``ValueError`` when the resolved path escapes every allowed root.
+    Callers that load via ``pickle`` should invoke this immediately before
+    opening the file so traversal tricks (``..``, symlinks) are neutralised.
+    """
+    resolved = Path(raw_path).expanduser().resolve()
+    for root in _ALLOWED_ROOTS:
+        if resolved == root or resolved.is_relative_to(root):
+            return resolved
+    raise ValueError(
+        f"pickle path {resolved} is outside allowed roots "
+        f"{[str(r) for r in _ALLOWED_ROOTS]}; refusing to load"
+    )
+
+
+def _safe_pickle_path(env_var: str, default_rel: str) -> Path:
+    """Resolve a model pickle path — env override wins, else repo-relative
+    default — and confine it to ``_ALLOWED_ROOTS``.
+
+    Raises ``ValueError`` on escape so the caller fails closed instead of
+    silently loading from an attacker-controlled location.
+    """
     override = os.environ.get(env_var)
-    if override:
-        return Path(override).expanduser().resolve()
-    return (_REPO_ROOT / default_rel).resolve()
+    src = override if override else str(_REPO_ROOT / default_rel)
+    return _confine_pickle_path(src)
 
 
 def _age_days(path: Path, now: float) -> float | None:
@@ -94,11 +141,20 @@ def _read_regime_coverage(path: Path) -> list[str]:
     Supports both the canonical ``{"models": {...}, "is_classifier": bool}``
     payload and the legacy bare-dict format (see
     ``strategies/ml_signal.py:143–151``).
+
+    The path is re-confined to ``_ALLOWED_ROOTS`` at the load site as
+    defence-in-depth; callers should still pass a path produced by
+    ``_safe_pickle_path``.
     """
-    if not path.exists():
+    try:
+        safe_path = _confine_pickle_path(path)
+    except ValueError as exc:
+        logger.error("knowledge_agent: refusing regime-models pickle: %s", exc)
         return []
-    with open(path, "rb") as f:
-        payload = pickle.load(f)  # noqa: S301  — trusted local file
+    if not safe_path.exists():
+        return []
+    with open(safe_path, "rb") as f:
+        payload = pickle.load(f)  # noqa: S301  — confined to _ALLOWED_ROOTS above
     if isinstance(payload, dict):
         inner = payload.get("models") if "models" in payload else payload
         if isinstance(inner, dict):
@@ -154,6 +210,31 @@ def _resolve_regime(context: dict) -> str | None:
     except Exception as exc:
         logger.debug("knowledge_agent: live regime lookup failed: %s", exc)
         return None
+
+
+def _resolve_at_risk(context: dict) -> bool:
+    """Resolve the regime-boundary ``at_risk`` flag.
+
+    Precedence:
+      1. ``context['at_risk']`` — explicit caller override.
+      2. If the caller also supplied ``context['regime']`` they are running
+         offline / in tests, so we skip the live lookup and default to False
+         (boundary detection requires live SPY/VIX).
+      3. Otherwise, read the cached live regime classifier's flag.
+
+    Fail-open to ``False`` on any error so the agent does not accidentally
+    demote when the live feed is unavailable.
+    """
+    if "at_risk" in context:
+        return bool(context.get("at_risk"))
+    if "regime" in context:
+        return False
+    try:
+        from analysis.regime import get_cached_live_regime
+        return bool(get_cached_live_regime(use_llm=False).get("at_risk", False))
+    except Exception as exc:
+        logger.debug("knowledge_agent: live at_risk lookup failed: %s", exc)
+        return False
 
 
 class _Cache:
@@ -217,15 +298,28 @@ class KnowledgeAdaptionAgent:
     def _run(self, context: dict) -> AgentSignal:
         now = self._clock()
 
-        baseline_path = _resolve_path("LGBM_ALPHA_MODEL_PATH", "models/lgbm_alpha.pkl")
-        regime_path = _resolve_path(
-            "LGBM_REGIME_MODELS_PATH", "models/lgbm_regime_models.pkl"
-        )
+        try:
+            baseline_path = _safe_pickle_path(
+                "LGBM_ALPHA_MODEL_PATH", "models/lgbm_alpha.pkl"
+            )
+            regime_path = _safe_pickle_path(
+                "LGBM_REGIME_MODELS_PATH", "models/lgbm_regime_models.pkl"
+            )
+        except ValueError as exc:
+            logger.error("knowledge_agent: unsafe pickle path: %s", exc)
+            return AgentSignal(
+                agent_name=self.name,
+                signal="bearish",
+                confidence=0.8,
+                reasoning=f"refusing to load pickle from untrusted path: {exc}",
+                metadata={"recommendation": "retrain"},
+            )
 
         baseline_age = _age_days(baseline_path, now)
         regime_age = _age_days(regime_path, now)
         regime = _resolve_regime(context)
         regime_coverage = self._cache.coverage(regime_path, self._coverage_reader)
+        at_risk = _resolve_at_risk(context)
 
         trained_ic = self._metadata_reader("lgbm_alpha")
         live_ic_raw = context.get("live_ic")
@@ -243,6 +337,7 @@ class KnowledgeAdaptionAgent:
             ic_ratio=ic_ratio,
             stale_days=stale_days,
             monitor_days=monitor_days,
+            at_risk=at_risk,
         )
 
         if verdict["recommendation"] == "retrain":
@@ -259,6 +354,7 @@ class KnowledgeAdaptionAgent:
             "ic_ratio": ic_ratio,
             "stale_days": stale_days,
             "monitor_days": monitor_days,
+            "at_risk": at_risk,
         }
 
         return AgentSignal(
@@ -281,6 +377,7 @@ class KnowledgeAdaptionAgent:
         ic_ratio: float | None,
         stale_days: float,
         monitor_days: float,
+        at_risk: bool = False,
     ) -> dict[str, Any]:
         """First-match condition ladder → (signal, confidence, reasoning, recommendation)."""
         # 1. Missing baseline pickle — worst case, no model to serve.
@@ -323,7 +420,15 @@ class KnowledgeAdaptionAgent:
                 why = f"retrain window approaching ({oldest:.0f}d)"
             return _verdict("neutral", 0.5, "monitor", why)
 
-        # 5. Fresh & covered.
+        # 5. Near a regime boundary — demote fresh to monitor so consumers
+        #    downweight the signal proactively.
+        if at_risk:
+            return _verdict(
+                "neutral", 0.5, "monitor",
+                "regime near boundary — elevated coverage risk",
+            )
+
+        # 6. Fresh & covered.
         return _verdict(
             "bullish", 0.8, "fresh",
             f"models fresh ({baseline_age:.0f}d) and regime '{regime or '?'}' covered",

--- a/analysis/regime.py
+++ b/analysis/regime.py
@@ -34,6 +34,30 @@ REGIME_STATES: list[str] = [
     "high_vol",
 ]
 
+# ── Regime-boundary tolerances ─────────────────────────────────────────────────
+# When SPY is near its 200d SMA *or* VIX is near the mean-reverting boundary
+# of 20, the quantitative classifier is one data point away from flipping.
+# Downstream consumers (KnowledgeAdaptionAgent) treat these zones as `at_risk`
+# so they can proactively demote model confidence.
+_SPY_SMA_TOL_PCT: float = 0.02   # ±2% of SMA200
+_VIX_TOL_PCT: float = 0.10       # ±10% of the 20-VIX boundary → [18, 22]
+_VIX_BOUNDARY: float = 20.0
+
+
+def is_regime_at_risk(spy_price: float, spy_sma200: float, vix: float) -> bool:
+    """Return ``True`` when the regime classifier is near a boundary.
+
+    Boundaries: SPY within ``±_SPY_SMA_TOL_PCT`` of its 200d SMA, OR VIX
+    within ``±_VIX_TOL_PCT`` of ``_VIX_BOUNDARY``. Near either boundary the
+    next session can flip the regime; consumers should treat the current
+    regime as provisional.
+    """
+    if spy_sma200 == 0:
+        return False
+    sma_dev = abs(spy_price - spy_sma200) / abs(spy_sma200)
+    vix_dev = abs(vix - _VIX_BOUNDARY) / _VIX_BOUNDARY
+    return sma_dev <= _SPY_SMA_TOL_PCT or vix_dev <= _VIX_TOL_PCT
+
 # ── Regime metadata ────────────────────────────────────────────────────────────
 
 REGIME_METADATA: dict[str, dict] = {
@@ -180,6 +204,7 @@ def get_live_regime() -> dict:
         "vix": vix_level,
         "description": meta["description"],
         "recommended_strategies": list(meta["recommended_strategies"]),
+        "at_risk": is_regime_at_risk(spy_price, sma200, vix_level),
     }
 
 

--- a/strategies/ml_signal.py
+++ b/strategies/ml_signal.py
@@ -8,6 +8,16 @@ for long/short or momentum-overlay strategies.
 Falls back to a momentum-composite score when lightgbm is not installed or
 no trained model checkpoint is present.
 
+Threat model (pickle path confinement)
+--------------------------------------
+The paths read from ``LGBM_ALPHA_MODEL_PATH`` / ``LGBM_REGIME_MODELS_PATH``
+feed ``pickle.load``, which executes arbitrary code during deserialisation.
+Environment variables are therefore treated as **operator-trusted** — they
+should only be set by the human who deploys the platform. As
+defence-in-depth every load site runs the candidate path through
+``agents.knowledge_agent._confine_pickle_path`` and refuses any path that
+escapes the repo root or system temp dir.
+
 ENV vars
 --------
     LGBM_ALPHA_MODEL_PATH       path to baseline model pickle
@@ -28,6 +38,7 @@ from pathlib import Path
 import numpy as np
 import pandas as pd
 
+from agents.knowledge_agent import _confine_pickle_path
 from analysis.regime import get_live_regime
 from data.features import _FEATURE_COLS, build_feature_matrix
 from data.fetcher import fetch_ohlcv
@@ -104,7 +115,14 @@ class MLSignal:
 
     def _load_if_available(self) -> None:
         """Load a persisted baseline model checkpoint if it exists."""
-        path = Path(self._model_path)
+        try:
+            path = _confine_pickle_path(self._model_path)
+        except ValueError as exc:
+            log.error(
+                "ml_signal: refusing unsafe baseline path",
+                path=str(self._model_path), error=str(exc),
+            )
+            return
         if not path.exists():
             log.info("ml_signal: no baseline checkpoint found, will use fallback", path=str(path))
             return
@@ -132,7 +150,14 @@ class MLSignal:
 
     def _load_regime_models_if_available(self) -> None:
         """Load persisted regime-conditioned model checkpoints if they exist."""
-        path = Path(self._regime_model_path)
+        try:
+            path = _confine_pickle_path(self._regime_model_path)
+        except ValueError as exc:
+            log.error(
+                "ml_signal: refusing unsafe regime-models path",
+                path=str(self._regime_model_path), error=str(exc),
+            )
+            return
         if not path.exists():
             return
         try:

--- a/tests/test_knowledge_agent.py
+++ b/tests/test_knowledge_agent.py
@@ -209,7 +209,7 @@ def test_context_regime_overrides_live_lookup(model_paths, isolate_metadata):
 def test_unexpected_exception_returns_neutral(monkeypatch):
     def boom(*a, **kw):
         raise RuntimeError("kapow")
-    monkeypatch.setattr("agents.knowledge_agent._resolve_path", boom)
+    monkeypatch.setattr("agents.knowledge_agent._safe_pickle_path", boom)
     sig = KnowledgeAdaptionAgent().run({"regime": "trending_bull"})
     assert sig.signal == "neutral"
     assert sig.confidence == 0.3
@@ -283,3 +283,119 @@ def test_cli_exits_nonzero_on_retrain(tmp_path, monkeypatch):
     )
     assert result.returncode == 1
     assert "retrain" in result.stdout
+
+
+# ── Pickle path confinement (#124) ────────────────────────────────────────────
+
+from agents.knowledge_agent import (  # noqa: E402  (after CLI tests is fine)
+    _confine_pickle_path,
+    _safe_pickle_path,
+)
+
+
+class TestConfinePicklePath:
+    def test_accepts_repo_relative_path(self):
+        # models/lgbm_alpha.pkl under the repo root
+        repo_root = Path(__file__).resolve().parent.parent
+        candidate = repo_root / "models" / "lgbm_alpha.pkl"
+        resolved = _confine_pickle_path(candidate)
+        assert resolved == candidate.resolve()
+
+    def test_accepts_tempdir_path(self, tmp_path):
+        # tmp_path lives under the system temp dir, explicitly allowed for tests
+        candidate = tmp_path / "fixture.pkl"
+        candidate.write_bytes(b"")
+        resolved = _confine_pickle_path(candidate)
+        assert resolved == candidate.resolve()
+
+    def test_rejects_etc_passwd(self):
+        with pytest.raises(ValueError, match="outside allowed roots"):
+            _confine_pickle_path("/etc/passwd")
+
+    def test_rejects_traversal_out_of_repo(self):
+        # A repo-rooted path that traverses up past the repo escapes to a
+        # parent directory that is neither repo-root nor tmpdir.
+        repo_root = Path(__file__).resolve().parent.parent
+        traversal = repo_root / ".." / ".." / ".." / "etc" / "passwd"
+        with pytest.raises(ValueError, match="outside allowed roots"):
+            _confine_pickle_path(traversal)
+
+
+class TestSafePicklePath:
+    def test_env_override_under_tempdir_is_allowed(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("LGBM_ALPHA_MODEL_PATH", str(tmp_path / "x.pkl"))
+        resolved = _safe_pickle_path("LGBM_ALPHA_MODEL_PATH", "models/lgbm_alpha.pkl")
+        assert resolved.parent == tmp_path.resolve()
+
+    def test_env_override_outside_allowed_roots_raises(self, monkeypatch):
+        monkeypatch.setenv("LGBM_ALPHA_MODEL_PATH", "/etc/passwd")
+        with pytest.raises(ValueError, match="outside allowed roots"):
+            _safe_pickle_path("LGBM_ALPHA_MODEL_PATH", "models/lgbm_alpha.pkl")
+
+    def test_default_repo_relative_is_allowed(self, monkeypatch):
+        monkeypatch.delenv("LGBM_ALPHA_MODEL_PATH", raising=False)
+        resolved = _safe_pickle_path("LGBM_ALPHA_MODEL_PATH", "models/lgbm_alpha.pkl")
+        repo_root = Path(__file__).resolve().parent.parent
+        assert resolved == (repo_root / "models" / "lgbm_alpha.pkl").resolve()
+
+
+def test_unsafe_env_path_fails_closed(monkeypatch, isolate_metadata):
+    # When LGBM_ALPHA_MODEL_PATH points outside the allowed roots, the agent
+    # must refuse to load and return a retrain verdict rather than silently
+    # loading a potentially-hostile pickle.
+    monkeypatch.setenv("LGBM_ALPHA_MODEL_PATH", "/etc/passwd")
+    monkeypatch.setenv("LGBM_REGIME_MODELS_PATH", "/etc/shadow")
+    sig = KnowledgeAdaptionAgent().run({"regime": "trending_bull"})
+    assert sig.signal == "bearish"
+    assert sig.metadata["recommendation"] == "retrain"
+    assert "untrusted path" in sig.reasoning
+
+
+# ── at_risk demotion (#124) ───────────────────────────────────────────────────
+
+def test_at_risk_demotes_fresh_to_monitor(model_paths, isolate_metadata):
+    baseline, regime = model_paths
+    _write_pickle(baseline, {"model": object()}, age_seconds=60)
+    _write_pickle(
+        regime, {"models": {"trending_bull": 1, "trending_bear": 1,
+                             "mean_reverting": 1, "high_vol": 1}}, age_seconds=60,
+    )
+    # Would normally verdict "fresh"; at_risk=True demotes to monitor.
+    sig = KnowledgeAdaptionAgent().run(
+        {"regime": "trending_bull", "at_risk": True}
+    )
+    assert sig.signal == "neutral"
+    assert sig.metadata["recommendation"] == "monitor"
+    assert sig.metadata["at_risk"] is True
+    assert "boundary" in sig.reasoning
+
+
+def test_at_risk_false_keeps_fresh(model_paths, isolate_metadata):
+    baseline, regime = model_paths
+    _write_pickle(baseline, {"model": object()}, age_seconds=60)
+    _write_pickle(
+        regime, {"models": {"trending_bull": 1, "trending_bear": 1,
+                             "mean_reverting": 1, "high_vol": 1}}, age_seconds=60,
+    )
+    sig = KnowledgeAdaptionAgent().run(
+        {"regime": "trending_bull", "at_risk": False}
+    )
+    assert sig.signal == "bullish"
+    assert sig.metadata["recommendation"] == "fresh"
+    assert sig.metadata["at_risk"] is False
+
+
+def test_at_risk_does_not_override_retrain(model_paths, isolate_metadata):
+    # With a stale baseline the verdict should stay retrain even if at_risk=True
+    baseline, regime = model_paths
+    days = 60 * 86400
+    _write_pickle(baseline, {"model": object()}, age_seconds=days)
+    _write_pickle(
+        regime, {"models": {"trending_bull": 1, "trending_bear": 1,
+                             "mean_reverting": 1, "high_vol": 1}}, age_seconds=days,
+    )
+    sig = KnowledgeAdaptionAgent().run(
+        {"regime": "trending_bull", "at_risk": True}
+    )
+    assert sig.signal == "bearish"
+    assert sig.metadata["recommendation"] == "retrain"

--- a/tests/test_regime.py
+++ b/tests/test_regime.py
@@ -5,6 +5,7 @@ import pandas as pd
 from analysis.regime import (
     REGIME_METADATA,
     detect_regime,
+    is_regime_at_risk,
     kelly_regime_multiplier,
 )
 
@@ -102,6 +103,36 @@ class TestKellyRegimeMultiplier:
 
 
 # ── REGIME_METADATA ───────────────────────────────────────────────────────────
+
+class TestIsRegimeAtRisk:
+    def test_spy_at_sma_is_at_risk(self):
+        # SPY exactly equal to SMA200 → within tolerance → at_risk=True
+        assert is_regime_at_risk(spy_price=100.0, spy_sma200=100.0, vix=15.0) is True
+
+    def test_spy_within_2pct_of_sma_is_at_risk(self):
+        # +1% of SMA is within ±2% tolerance
+        assert is_regime_at_risk(spy_price=101.0, spy_sma200=100.0, vix=15.0) is True
+
+    def test_spy_far_from_sma_low_vix_not_at_risk(self):
+        # +10% SMA deviation and VIX far from 20 → safe
+        assert is_regime_at_risk(spy_price=110.0, spy_sma200=100.0, vix=15.0) is False
+
+    def test_vix_within_10pct_of_20_is_at_risk(self):
+        # VIX=19 is within ±10% of 20 → [18, 22] → at_risk=True even if SPY is far from SMA
+        assert is_regime_at_risk(spy_price=110.0, spy_sma200=100.0, vix=19.0) is True
+
+    def test_vix_at_22_is_at_risk(self):
+        # Upper boundary of [18, 22] — still at risk
+        assert is_regime_at_risk(spy_price=110.0, spy_sma200=100.0, vix=22.0) is True
+
+    def test_vix_at_25_not_at_risk(self):
+        # VIX=25 is outside ±10% of 20 and SPY is far from SMA
+        assert is_regime_at_risk(spy_price=110.0, spy_sma200=100.0, vix=25.0) is False
+
+    def test_zero_sma_returns_false(self):
+        # Guard against division by zero; fail-open
+        assert is_regime_at_risk(spy_price=100.0, spy_sma200=0.0, vix=15.0) is False
+
 
 class TestRegimeMetadata:
     def test_all_four_regimes_present(self):


### PR DESCRIPTION
## Summary

Two hardening items from the #114 review:

**1. Pickle path confinement.** `LGBM_ALPHA_MODEL_PATH` /
`LGBM_REGIME_MODELS_PATH` feed `pickle.load`, which executes arbitrary code
during deserialisation. Both `agents/knowledge_agent.py` and
`strategies/ml_signal.py` now run every candidate path through
`_safe_pickle_path` / `_confine_pickle_path`, which resolve the path and
require it to live under `_ALLOWED_ROOTS` (repo root + system temp dir).
Paths outside those roots fail closed:
- `KnowledgeAdaptionAgent` returns a `retrain` verdict with reasoning
  "refusing to load pickle from untrusted path".
- `MLSignal._load_if_available` / `_load_regime_models_if_available` log
  an error and skip the load — the model stays empty.

The threat model is documented in the module docstring of both files
(env vars are operator-trusted; confinement is defence-in-depth).

**2. Regime `at_risk` flag.** `analysis/regime.py` now exposes
`is_regime_at_risk(spy_price, spy_sma200, vix)` (True when SPY within ±2%
of SMA200 *or* VIX within ±10% of 20) and includes the flag in
`get_live_regime()` / `get_cached_live_regime()` return dicts. The
knowledge agent consults the flag and demotes a would-be `fresh` verdict
to `monitor` with reasoning "regime near boundary — elevated coverage
risk". Stale/retrain/coverage-gap verdicts are unaffected.

Constants `_SPY_SMA_TOL_PCT`, `_VIX_TOL_PCT`, `_VIX_BOUNDARY` are exposed
at module level.

## Test plan

- [x] `ruff check .` — all checks passed
- [x] `pytest tests/ -m "not integration" --cov=. --cov-fail-under=76` — 1274 passed, coverage 76.98%
- [x] `bandit -r . -ll --exclude ./.git,./tests` — 0 HIGH severity issues
- [x] `pip-audit -r requirements.txt --ignore-vuln PYSEC-2022-42969` — no known vulnerabilities
- [x] New `TestConfinePicklePath` + `TestSafePicklePath` classes cover accept-repo, accept-tmpdir, reject-`/etc/passwd`, reject-traversal-out-of-repo
- [x] New `TestIsRegimeAtRisk` covers SPY-near-SMA, SPY-far-low-VIX, VIX-near-20, zero-SMA guard
- [x] New `test_at_risk_demotes_fresh_to_monitor` + friends cover the agent demotion path
- [x] New `test_unsafe_env_path_fails_closed` asserts `/etc/passwd` → `retrain` verdict

Closes #124

https://claude.ai/code/session_01F5uD99ywUodQgPr5vXyEvU