### PR TITLE
feat: pre-trade circuit breaker in daily_ml_execute (#120)

### DIFF
--- a/cron/README.md
+++ b/cron/README.md
@@ -131,14 +131,41 @@ Run at 16:05 ET (post-close) on weekdays:
 
 ## Environment variables
 
-| Variable              | Default                    | Description                                           |
-|-----------------------|----------------------------|-------------------------------------------------------|
-| WF_TICKERS            | SPY,QQQ,AAPL,MSFT,TSLA    | Comma-separated tickers to score                       |
-| ML_SCORE_THRESHOLD    | 0.3                        | Minimum |score| required to act                         |
-| ML_MAX_POSITIONS      | 5                          | Maximum simultaneous long positions                    |
-| BROKER_PROVIDER       | paper                      | paper / alpaca / ibkr / schwab (routed via providers/) |
-| LGBM_ALPHA_MODEL_PATH | models/lgbm_alpha.pkl      | Path to the trained model checkpoint                   |
+| Variable                | Default                    | Description                                           |
+|-------------------------|----------------------------|-------------------------------------------------------|
+| WF_TICKERS              | SPY,QQQ,AAPL,MSFT,TSLA    | Comma-separated tickers to score                       |
+| ML_SCORE_THRESHOLD      | 0.3                        | Minimum \|score\| required to act                      |
+| ML_MAX_POSITIONS        | 5                          | Maximum simultaneous long positions                    |
+| BROKER_PROVIDER         | paper                      | paper / alpaca / ibkr / schwab (routed via providers/) |
+| LGBM_ALPHA_MODEL_PATH   | models/lgbm_alpha.pkl      | Path to the trained model checkpoint                   |
+| KNOWLEDGE_GATE_ENFORCE  | (unset)                    | When `1`, same as passing `--enforce-knowledge-gate`   |
 
 Position sizes are computed as `equity × Kelly × regime_mult × |score|`, where
 Kelly uses the priors `ML_KELLY_WIN_RATE` (0.55), `ML_KELLY_AVG_WIN` (0.03),
 `ML_KELLY_AVG_LOSS` (0.02). Regime multiplier halves size in `high_vol`.
+
+## Pre-trade circuit breaker
+
+Optional flag that refuses to place orders when `KnowledgeAdaptionAgent`
+returns a `retrain` verdict — intended for production so stale models do
+not silently bleed P&L:
+
+```bash
+python -m cron.daily_ml_execute --enforce-knowledge-gate
+# or equivalently
+KNOWLEDGE_GATE_ENFORCE=1 python -m cron.daily_ml_execute
+```
+
+The CLI flag wins over the env var when both are set (use
+`--no-enforce-knowledge-gate` to explicitly disable). Verdicts:
+
+| Verdict    | Behaviour                                                |
+|------------|----------------------------------------------------------|
+| `fresh`    | Proceeds normally.                                       |
+| `monitor`  | Proceeds normally; agent logs the reason.                |
+| `retrain`  | **Exits with code 2** before any order is placed.        |
+
+Exit codes emitted by the job: `0` success, `1` fatal error (missing
+lightgbm, no trained model, unexpected exception), `2` knowledge gate
+tripped. The agent's own 24h alert cooldown dedupes alerts so the cron
+does not spam on every run.

--- a/cron/daily_ml_execute.py
+++ b/cron/daily_ml_execute.py
@@ -13,6 +13,20 @@ Schedule (16:05 ET on weekdays):
     5 16 * * 1-5 cd /path/to/quant-platform && \\
         .venv/bin/python -m cron.daily_ml_execute
 
+Optional circuit breaker — fail closed when ML knowledge is stale:
+    python -m cron.daily_ml_execute --enforce-knowledge-gate
+    KNOWLEDGE_GATE_ENFORCE=1 python -m cron.daily_ml_execute
+
+    When the gate is on and ``KnowledgeAdaptionAgent`` returns a
+    ``retrain`` verdict, the cron exits with code ``2`` before any order is
+    placed. ``fresh`` / ``monitor`` verdicts proceed unchanged. The CLI flag
+    wins over the env var when both are set.
+
+Exit codes:
+    0 — success (trades placed or no-op).
+    1 — fatal error (lightgbm missing, no trained model, unexpected exception).
+    2 — circuit breaker tripped on retrain verdict.
+
 ENV vars
 --------
     WF_TICKERS             Comma-separated tickers (default: SPY,QQQ,AAPL,MSFT,TSLA)
@@ -20,9 +34,11 @@ ENV vars
     ML_MAX_POSITIONS       Maximum simultaneous longs (default: 5)
     BROKER_PROVIDER        paper | alpaca | ibkr | schwab (default: paper)
     LGBM_ALPHA_MODEL_PATH  Path to the trained model checkpoint
+    KNOWLEDGE_GATE_ENFORCE 1 → same as passing --enforce-knowledge-gate
 """
 from __future__ import annotations
 
+import argparse
 import os
 import sys
 
@@ -34,8 +50,73 @@ log = get_logger("cron.daily_ml_execute")
 
 DEFAULT_TICKERS = "SPY,QQQ,AAPL,MSFT,TSLA"
 
+EXIT_OK = 0
+EXIT_FATAL = 1
+EXIT_KNOWLEDGE_GATE = 2
 
-def main() -> None:
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="cron.daily_ml_execute",
+        description="Daily ML signal execution cron job.",
+    )
+    parser.add_argument(
+        "--enforce-knowledge-gate",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help=(
+            "Refuse to place any order when KnowledgeAdaptionAgent returns a "
+            "retrain verdict (exit code 2). When unset the job falls back to "
+            "the KNOWLEDGE_GATE_ENFORCE env var; the flag wins on conflict."
+        ),
+    )
+    return parser
+
+
+def _resolve_gate_enforcement(flag: bool | None) -> bool:
+    """CLI flag wins when explicitly set; otherwise consult env var."""
+    if flag is not None:
+        return flag
+    return os.environ.get("KNOWLEDGE_GATE_ENFORCE", "").strip().lower() in (
+        "1", "true", "yes", "on",
+    )
+
+
+def _check_knowledge_gate() -> int | None:
+    """Run KnowledgeAdaptionAgent and return an exit code when it blocks.
+
+    Returns ``None`` when the verdict is fresh/monitor (proceed). Returns
+    ``EXIT_KNOWLEDGE_GATE`` (2) when the verdict is ``retrain``.
+    """
+    try:
+        from agents.knowledge_agent import KnowledgeAdaptionAgent
+    except ImportError as exc:
+        log.error("daily_ml_execute: knowledge agent unavailable", error=str(exc))
+        return EXIT_KNOWLEDGE_GATE
+
+    sig = KnowledgeAdaptionAgent().run({})
+    recommendation = (sig.metadata or {}).get("recommendation", "fresh")
+    log.info(
+        "daily_ml_execute: knowledge-gate verdict",
+        recommendation=recommendation,
+        reasoning=sig.reasoning,
+    )
+    if recommendation == "retrain":
+        log.error(
+            "daily_ml_execute: knowledge gate tripped — refusing to trade",
+            recommendation=recommendation,
+            reasoning=sig.reasoning,
+        )
+        return EXIT_KNOWLEDGE_GATE
+    return None
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = _build_arg_parser()
+    args = parser.parse_args(argv)
+
+    enforce_gate = _resolve_gate_enforcement(args.enforce_knowledge_gate)
+
     tickers_str = os.environ.get("WF_TICKERS", DEFAULT_TICKERS)
     tickers = [t.strip() for t in tickers_str.split(",") if t.strip()]
     threshold = float(os.environ.get("ML_SCORE_THRESHOLD", "0.3"))
@@ -48,11 +129,17 @@ def main() -> None:
         threshold=threshold,
         max_positions=max_positions,
         broker=broker_name,
+        enforce_knowledge_gate=enforce_gate,
     )
 
     if not _LGBM_AVAILABLE:
         log.error("daily_ml_execute: lightgbm is not installed — aborting")
-        sys.exit(1)
+        sys.exit(EXIT_FATAL)
+
+    if enforce_gate:
+        gate_exit = _check_knowledge_gate()
+        if gate_exit is not None:
+            sys.exit(gate_exit)
 
     try:
         model = MLSignal()
@@ -61,7 +148,7 @@ def main() -> None:
                 "daily_ml_execute: no trained baseline model found — "
                 "run cron.monthly_ml_retrain first"
             )
-            sys.exit(1)
+            sys.exit(EXIT_FATAL)
 
         scores = model.predict(tickers, period="6mo")
         log.info("daily_ml_execute: scored", n_scores=len(scores))
@@ -80,7 +167,7 @@ def main() -> None:
 
     except Exception as exc:
         log.error("daily_ml_execute: unexpected failure", error=str(exc))
-        sys.exit(1)
+        sys.exit(EXIT_FATAL)
 
 
 if __name__ == "__main__":

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -39,6 +39,15 @@ supervisorctl restart all      # restart everything
 supervisorctl tail -f quant-streamlit   # follow logs
 ```
 
+### Gated Daily ML Execution (opt-in)
+
+`supervisord.conf` ships a commented-out `[program:ml-execute-gated]` block
+that runs `cron/daily_ml_execute.py --enforce-knowledge-gate`. Uncomment
+it to refuse orders when `KnowledgeAdaptionAgent` returns a `retrain`
+verdict (exit code `2`); `fresh` / `monitor` proceed normally. Use this
+in production so stale models never trade live — see `cron/README.md`
+for full semantics and exit codes.
+
 ### Nginx Reverse Proxy (optional)
 ```nginx
 server {

--- a/deploy/supervisord.conf
+++ b/deploy/supervisord.conf
@@ -35,6 +35,20 @@ stdout_logfile_maxbytes=10MB
 stderr_logfile=/var/log/quant-platform/alerts_err.log
 environment=PYTHONUNBUFFERED=1
 
+; Optional gated daily ML execution — uncomment to enable in production.
+; Fails closed on retrain verdict (exit 2) so stale models never trade live.
+; See cron/daily_ml_execute.py and cron/README.md for details.
+; [program:ml-execute-gated]
+; command=/home/%(ENV_USER)s/projects/quant-platform/.venv/bin/python -m cron.daily_ml_execute --enforce-knowledge-gate
+; directory=/home/%(ENV_USER)s/projects/quant-platform
+; user=%(ENV_USER)s
+; autostart=false
+; autorestart=false
+; stdout_logfile=/var/log/quant-platform/ml_execute.log
+; stdout_logfile_maxbytes=10MB
+; stderr_logfile=/var/log/quant-platform/ml_execute_err.log
+; environment=PYTHONUNBUFFERED=1
+
 [unix_http_server]
 file=/var/run/supervisor.sock
 

--- a/tests/test_daily_ml_execute.py
+++ b/tests/test_daily_ml_execute.py
@@ -27,7 +27,7 @@ def test_main_happy_path(mock_cls, mock_exec):
     mock_exec.return_value = ["BUY AAPL x10", "SELL GOOG x5"]
 
     from cron.daily_ml_execute import main
-    main()
+    main(argv=[])
 
     mock_cls.return_value.predict.assert_called_once()
     mock_exec.assert_called_once()
@@ -50,7 +50,7 @@ def test_main_respects_env_overrides(mock_cls, mock_exec):
     }
     with patch.dict(os.environ, env):
         from cron.daily_ml_execute import main
-        main()
+        main(argv=[])
 
     predict_args = mock_cls.return_value.predict.call_args
     assert predict_args[0][0] == ["AAPL", "TSLA"]
@@ -63,7 +63,7 @@ def test_main_respects_env_overrides(mock_cls, mock_exec):
 def test_main_exits_when_lgbm_unavailable():
     from cron.daily_ml_execute import main
     with pytest.raises(SystemExit) as exc_info:
-        main()
+        main(argv=[])
     assert exc_info.value.code == 1
 
 
@@ -76,7 +76,7 @@ def test_main_exits_when_no_trained_model(mock_cls):
 
     from cron.daily_ml_execute import main
     with pytest.raises(SystemExit) as exc_info:
-        main()
+        main(argv=[])
     assert exc_info.value.code == 1
 
 
@@ -89,7 +89,7 @@ def test_main_exits_on_unexpected_exception(mock_cls, mock_exec):
 
     from cron.daily_ml_execute import main
     with pytest.raises(SystemExit) as exc_info:
-        main()
+        main(argv=[])
     assert exc_info.value.code == 1
 
 
@@ -101,7 +101,107 @@ def test_main_strips_whitespace_from_tickers(mock_cls, mock_exec):
 
     with patch.dict(os.environ, {"WF_TICKERS": " AAPL , MSFT , TSLA "}):
         from cron.daily_ml_execute import main
-        main()
+        main(argv=[])
 
     tickers = mock_cls.return_value.predict.call_args[0][0]
     assert tickers == ["AAPL", "MSFT", "TSLA"]
+
+
+# ── Knowledge-gate circuit breaker (#120) ─────────────────────────────────────
+
+def _agent_returning(recommendation: str):
+    """Return a callable that mimics `KnowledgeAdaptionAgent()` with a fixed verdict."""
+    sig = MagicMock()
+    sig.metadata = {"recommendation": recommendation}
+    sig.reasoning = f"mock verdict: {recommendation}"
+
+    agent = MagicMock()
+    agent.run.return_value = sig
+    factory = MagicMock(return_value=agent)
+    return factory
+
+
+@patch("cron.daily_ml_execute.execute_ml_signals")
+@patch("cron.daily_ml_execute.MLSignal")
+@patch("cron.daily_ml_execute._LGBM_AVAILABLE", True)
+def test_gate_off_retrain_verdict_still_trades(mock_cls, mock_exec):
+    # Gate disabled: the cron must proceed regardless of knowledge verdict.
+    mock_cls.return_value = _mock_model()
+    mock_exec.return_value = []
+
+    with patch("agents.knowledge_agent.KnowledgeAdaptionAgent",
+               _agent_returning("retrain")):
+        from cron.daily_ml_execute import main
+        main(argv=[])  # no flag, no env
+
+    mock_cls.return_value.predict.assert_called_once()
+    mock_exec.assert_called_once()
+
+
+@patch("cron.daily_ml_execute.execute_ml_signals")
+@patch("cron.daily_ml_execute.MLSignal")
+@patch("cron.daily_ml_execute._LGBM_AVAILABLE", True)
+def test_gate_on_retrain_verdict_exits_2(mock_cls, mock_exec):
+    mock_cls.return_value = _mock_model()
+
+    with patch("agents.knowledge_agent.KnowledgeAdaptionAgent",
+               _agent_returning("retrain")):
+        from cron.daily_ml_execute import main
+        with pytest.raises(SystemExit) as exc_info:
+            main(argv=["--enforce-knowledge-gate"])
+
+    assert exc_info.value.code == 2
+    # When the gate trips we must NOT have reached the model or executor.
+    mock_cls.return_value.predict.assert_not_called()
+    mock_exec.assert_not_called()
+
+
+@patch("cron.daily_ml_execute.execute_ml_signals")
+@patch("cron.daily_ml_execute.MLSignal")
+@patch("cron.daily_ml_execute._LGBM_AVAILABLE", True)
+def test_gate_on_monitor_verdict_proceeds(mock_cls, mock_exec):
+    mock_cls.return_value = _mock_model()
+    mock_exec.return_value = []
+
+    with patch("agents.knowledge_agent.KnowledgeAdaptionAgent",
+               _agent_returning("monitor")):
+        from cron.daily_ml_execute import main
+        main(argv=["--enforce-knowledge-gate"])
+
+    mock_cls.return_value.predict.assert_called_once()
+    mock_exec.assert_called_once()
+
+
+@patch("cron.daily_ml_execute.execute_ml_signals")
+@patch("cron.daily_ml_execute.MLSignal")
+@patch("cron.daily_ml_execute._LGBM_AVAILABLE", True)
+def test_env_var_enforces_gate(mock_cls, mock_exec):
+    # KNOWLEDGE_GATE_ENFORCE=1 is equivalent to --enforce-knowledge-gate.
+    mock_cls.return_value = _mock_model()
+
+    with patch("agents.knowledge_agent.KnowledgeAdaptionAgent",
+               _agent_returning("retrain")), \
+         patch.dict(os.environ, {"KNOWLEDGE_GATE_ENFORCE": "1"}):
+        from cron.daily_ml_execute import main
+        with pytest.raises(SystemExit) as exc_info:
+            main(argv=[])
+
+    assert exc_info.value.code == 2
+
+
+@patch("cron.daily_ml_execute.execute_ml_signals")
+@patch("cron.daily_ml_execute.MLSignal")
+@patch("cron.daily_ml_execute._LGBM_AVAILABLE", True)
+def test_cli_flag_wins_over_env(mock_cls, mock_exec):
+    # Env says enforce; CLI explicitly disables via --no-enforce-knowledge-gate.
+    mock_cls.return_value = _mock_model()
+    mock_exec.return_value = []
+
+    with patch("agents.knowledge_agent.KnowledgeAdaptionAgent",
+               _agent_returning("retrain")), \
+         patch.dict(os.environ, {"KNOWLEDGE_GATE_ENFORCE": "1"}):
+        from cron.daily_ml_execute import main
+        main(argv=["--no-enforce-knowledge-gate"])
+
+    mock_cls.return_value.predict.assert_called_once()
+    mock_exec.assert_called_once()


### PR DESCRIPTION
## Summary

Adds an opt-in `--enforce-knowledge-gate` flag (also readable as
`KNOWLEDGE_GATE_ENFORCE=1`) that refuses to place any order when
`KnowledgeAdaptionAgent` returns a `retrain` verdict — fails closed so
stale models never silently bleed P&L in production.

- **Exit codes**: `0` success, `1` fatal error (missing lightgbm, no
  trained model, unexpected exception), **`2` knowledge gate tripped**
  (distinct from fatal so orchestrators can tell them apart).
- **Flag vs env precedence**: CLI wins over env. Uses
  `argparse.BooleanOptionalAction` so `--no-enforce-knowledge-gate`
  explicitly disables even when `KNOWLEDGE_GATE_ENFORCE=1`.
- **Verdict handling**: `fresh` / `monitor` proceed unchanged; `retrain`
  logs an ERROR and exits before `model.predict` or `execute_ml_signals`
  is called.
- **Alert dedup**: the agent's existing 24h cooldown stamp means the
  cron does not spam on every run.
- `main()` now accepts `argv: list[str] | None` for test injection;
  existing tests updated to pass `argv=[]`.

### Docs & deployment

- `cron/README.md` — new "Pre-trade circuit breaker" section with
  verdict table and exit codes.
- `deploy/README.md` — points at the new supervisord block.
- `deploy/supervisord.conf` — commented-out `[program:ml-execute-gated]`
  that runs the cron with the flag enabled (off by default; one-line
  config change in production).

## Test plan

- [x] `ruff check .` — all checks passed
- [x] `pytest tests/ -m "not integration" --cov=. --cov-fail-under=76` — 1279 passed, coverage 77.03%
- [x] `bandit -r . -ll --exclude ./.git,./tests` — 0 HIGH severity issues
- [x] `pip-audit -r requirements.txt --ignore-vuln PYSEC-2022-42969` — no known vulnerabilities
- [x] New `test_gate_off_retrain_verdict_still_trades` — legacy behaviour
- [x] New `test_gate_on_retrain_verdict_exits_2` — circuit breaker trips
- [x] New `test_gate_on_monitor_verdict_proceeds` — monitor does not block
- [x] New `test_env_var_enforces_gate` — env-var path
- [x] New `test_cli_flag_wins_over_env` — precedence

Closes #120

https://claude.ai/code/session_01F5uD99ywUodQgPr5vXyEvU