### PR TITLE
feat: retrain ROI tracking — test_ic_delta + plateau demotion (#122)

### DIFF
--- a/agents/knowledge_agent.py
+++ b/agents/knowledge_agent.py
@@ -212,6 +212,27 @@ def _resolve_regime(context: dict) -> str | None:
         return None
 
 
+def _resolve_plateau(context: dict, model_name: str = "lgbm_alpha") -> bool:
+    """Resolve the ``plateau_detected`` flag.
+
+    Precedence:
+      1. ``context['plateau_detected']`` — explicit caller override (tests).
+      2. Otherwise, read the last ``n`` ``test_ic_delta`` rows via
+         ``analysis.retrain_roi.is_ic_plateau``.
+
+    Fails open to ``False`` so a DB hiccup never spuriously demotes the
+    agent's verdict.
+    """
+    if "plateau_detected" in context:
+        return bool(context.get("plateau_detected"))
+    try:
+        from analysis.retrain_roi import is_ic_plateau
+        return bool(is_ic_plateau(model_name, n=3))
+    except Exception as exc:
+        logger.debug("knowledge_agent: plateau lookup failed: %s", exc)
+        return False
+
+
 def _resolve_at_risk(context: dict) -> bool:
     """Resolve the regime-boundary ``at_risk`` flag.
 
@@ -320,6 +341,7 @@ class KnowledgeAdaptionAgent:
         regime = _resolve_regime(context)
         regime_coverage = self._cache.coverage(regime_path, self._coverage_reader)
         at_risk = _resolve_at_risk(context)
+        plateau_detected = _resolve_plateau(context)
 
         trained_ic = self._metadata_reader("lgbm_alpha")
         live_ic_raw = context.get("live_ic")
@@ -338,6 +360,7 @@ class KnowledgeAdaptionAgent:
             stale_days=stale_days,
             monitor_days=monitor_days,
             at_risk=at_risk,
+            plateau_detected=plateau_detected,
         )
 
         if verdict["recommendation"] == "retrain":
@@ -355,6 +378,7 @@ class KnowledgeAdaptionAgent:
             "stale_days": stale_days,
             "monitor_days": monitor_days,
             "at_risk": at_risk,
+            "plateau_detected": plateau_detected,
         }
 
         return AgentSignal(
@@ -378,6 +402,7 @@ class KnowledgeAdaptionAgent:
         stale_days: float,
         monitor_days: float,
         at_risk: bool = False,
+        plateau_detected: bool = False,
     ) -> dict[str, Any]:
         """First-match condition ladder → (signal, confidence, reasoning, recommendation)."""
         # 1. Missing baseline pickle — worst case, no model to serve.
@@ -428,7 +453,16 @@ class KnowledgeAdaptionAgent:
                 "regime near boundary — elevated coverage risk",
             )
 
-        # 6. Fresh & covered.
+        # 6. IC plateau — retraining is not paying off, feature drift suspected.
+        #    Demote fresh to monitor so the operator investigates instead of
+        #    blindly trusting the next retrain to recover the edge.
+        if plateau_detected:
+            return _verdict(
+                "neutral", 0.5, "monitor",
+                "IC plateau over 3 retrains — feature drift suspected",
+            )
+
+        # 7. Fresh & covered.
         return _verdict(
             "bullish", 0.8, "fresh",
             f"models fresh ({baseline_age:.0f}d) and regime '{regime or '?'}' covered",

--- a/analysis/retrain_roi.py
+++ b/analysis/retrain_roi.py
@@ -1,0 +1,101 @@
+"""
+analysis/retrain_roi.py — Retrain return-on-investment tracker.
+
+Reads the per-model ``test_ic_delta`` history from the ``model_metadata``
+table and exposes two helpers:
+
+- ``retrain_roi(model_name, n=6)``     — last N deltas + linear-regression
+                                          slope.
+- ``is_ic_plateau(model_name, n=3)``   — True when the slope over the
+                                          last N retrains is non-positive
+                                          (i.e., retraining is not
+                                          improving IC any more).
+
+The ``KnowledgeAdaptionAgent`` consults ``is_ic_plateau`` to demote a
+would-be ``fresh`` verdict to ``monitor`` when retraining is no longer
+paying off — staleness is not the bottleneck, the feature set or
+hyperparameters probably are (#122).
+"""
+from __future__ import annotations
+
+import pandas as pd
+
+from utils.logger import get_logger
+
+log = get_logger(__name__)
+
+
+def retrain_roi(model_name: str, n: int = 6) -> tuple[pd.Series, float]:
+    """Return the last ``n`` ``test_ic_delta`` values for ``model_name``
+    (chronological order) together with the slope of a simple linear fit.
+
+    The slope is computed over an integer index 0..len-1 so it is roughly
+    "delta-per-retrain". When fewer than 2 non-null deltas are available
+    the slope is ``0.0``. Any DB error returns an empty series and a zero
+    slope so callers never have to defensively catch.
+    """
+    try:
+        from data.db import get_connection
+
+        conn = get_connection()
+    except Exception as exc:
+        log.debug("retrain_roi: could not open DB: %s", exc)
+        return pd.Series(dtype=float), 0.0
+
+    try:
+        rows = conn.execute(
+            "SELECT trained_at, test_ic_delta FROM model_metadata "
+            "WHERE model_name = ? AND test_ic_delta IS NOT NULL "
+            "ORDER BY trained_at DESC LIMIT ?",
+            (model_name, int(n)),
+        ).fetchall()
+    except Exception as exc:
+        log.debug("retrain_roi: query failed: %s", exc)
+        rows = []
+    finally:
+        try:
+            conn.close()
+        except Exception:
+            pass
+
+    if not rows:
+        return pd.Series(dtype=float), 0.0
+
+    # rows came out DESC for LIMIT; reverse to chronological
+    ordered = list(reversed(rows))
+    series = pd.Series(
+        [float(r["test_ic_delta"] if hasattr(r, "keys") else r[1]) for r in ordered],
+        index=[
+            float(r["trained_at"] if hasattr(r, "keys") else r[0]) for r in ordered
+        ],
+        dtype=float,
+        name="test_ic_delta",
+    )
+
+    if len(series) < 2:
+        return series, 0.0
+
+    # Integer index for the slope so the scale is deltas-per-retrain.
+    x = pd.Series(range(len(series)), dtype=float)
+    y = series.reset_index(drop=True)
+    x_mean = x.mean()
+    y_mean = y.mean()
+    denom = ((x - x_mean) ** 2).sum()
+    if denom == 0:
+        return series, 0.0
+    slope = float(((x - x_mean) * (y - y_mean)).sum() / denom)
+    return series, slope
+
+
+def is_ic_plateau(model_name: str, n: int = 3) -> bool:
+    """Return True when the last ``n`` retrains show a non-positive slope.
+
+    Non-positive rather than "negative" — a flat series (slope == 0) is
+    already evidence that retraining is not earning its keep. Requires at
+    least ``n`` non-null deltas to fire; otherwise returns False so the
+    detector is silent until we have enough history.
+    """
+    series, slope = retrain_roi(model_name, n=n)
+    if len(series) < n:
+        return False
+    return slope <= 0.0

--- a/data/db.py
+++ b/data/db.py
@@ -122,6 +122,14 @@ def init_db() -> None:
                 PRIMARY KEY (model_name, trained_at)
             )
         """)
+        # Idempotent add of the test_ic_delta column for retrain-ROI tracking
+        # (#122). Nullable + populated only on retrain #2 onward so legacy
+        # rows are preserved.
+        existing_cols = {
+            row[1] for row in conn.execute("PRAGMA table_info(model_metadata)")
+        }
+        if "test_ic_delta" not in existing_cols:
+            conn.execute("ALTER TABLE model_metadata ADD COLUMN test_ic_delta REAL")
 
         # ----- Tuned hyperparameters (one row per model, upsert on tune) -----
         conn.execute("""

--- a/strategies/ml_signal.py
+++ b/strategies/ml_signal.py
@@ -603,18 +603,39 @@ class MLSignal:
         train_ic: float,
         test_ic: float,
     ) -> None:
-        """Persist training metadata to quant.db model_metadata table."""
+        """Persist training metadata to quant.db model_metadata table.
+
+        On retrain #2 onward also computes ``test_ic_delta`` as
+        ``this_test_ic - previous_test_ic`` for the same ``model_name`` so
+        downstream consumers (``analysis/retrain_roi.py``,
+        ``KnowledgeAdaptionAgent``) can detect IC plateaus.
+        """
         try:
             from data.db import get_connection
             conn = get_connection()
             with conn:
+                prev_row = conn.execute(
+                    "SELECT test_ic FROM model_metadata "
+                    "WHERE model_name = ? ORDER BY trained_at DESC LIMIT 1",
+                    ("lgbm_alpha",),
+                ).fetchone()
+                prev_ic = None
+                if prev_row is not None:
+                    raw = prev_row["test_ic"] if hasattr(prev_row, "keys") else prev_row[0]
+                    if raw is not None:
+                        prev_ic = float(raw)
+                delta = None if prev_ic is None else float(test_ic) - prev_ic
                 conn.execute(
                     """
                     INSERT INTO model_metadata
-                        (model_name, trained_at, train_ic, test_ic, n_tickers, period)
-                    VALUES (?, ?, ?, ?, ?, ?)
+                        (model_name, trained_at, train_ic, test_ic,
+                         n_tickers, period, test_ic_delta)
+                    VALUES (?, ?, ?, ?, ?, ?, ?)
                     """,
-                    ("lgbm_alpha", time.time(), train_ic, test_ic, n_tickers, period),
+                    (
+                        "lgbm_alpha", time.time(), train_ic, test_ic,
+                        n_tickers, period, delta,
+                    ),
                 )
             conn.close()
         except Exception as exc:

--- a/tests/test_knowledge_agent.py
+++ b/tests/test_knowledge_agent.py
@@ -399,3 +399,52 @@ def test_at_risk_does_not_override_retrain(model_paths, isolate_metadata):
     )
     assert sig.signal == "bearish"
     assert sig.metadata["recommendation"] == "retrain"
+
+
+# ── IC plateau demotion (#122) ────────────────────────────────────────────────
+
+def test_plateau_demotes_fresh_to_monitor(model_paths, isolate_metadata):
+    baseline, regime = model_paths
+    _write_pickle(baseline, {"model": object()}, age_seconds=60)
+    _write_pickle(
+        regime, {"models": {"trending_bull": 1, "trending_bear": 1,
+                             "mean_reverting": 1, "high_vol": 1}}, age_seconds=60,
+    )
+    # Would normally be fresh; plateau demotes to monitor.
+    sig = KnowledgeAdaptionAgent().run(
+        {"regime": "trending_bull", "plateau_detected": True}
+    )
+    assert sig.signal == "neutral"
+    assert sig.metadata["recommendation"] == "monitor"
+    assert sig.metadata["plateau_detected"] is True
+    assert "plateau" in sig.reasoning.lower()
+
+
+def test_plateau_false_keeps_fresh(model_paths, isolate_metadata):
+    baseline, regime = model_paths
+    _write_pickle(baseline, {"model": object()}, age_seconds=60)
+    _write_pickle(
+        regime, {"models": {"trending_bull": 1, "trending_bear": 1,
+                             "mean_reverting": 1, "high_vol": 1}}, age_seconds=60,
+    )
+    sig = KnowledgeAdaptionAgent().run(
+        {"regime": "trending_bull", "plateau_detected": False}
+    )
+    assert sig.signal == "bullish"
+    assert sig.metadata["recommendation"] == "fresh"
+    assert sig.metadata["plateau_detected"] is False
+
+
+def test_plateau_does_not_override_retrain(model_paths, isolate_metadata):
+    # Stale baseline trumps plateau — still a hard retrain
+    baseline, regime = model_paths
+    days = 60 * 86400
+    _write_pickle(baseline, {"model": object()}, age_seconds=days)
+    _write_pickle(
+        regime, {"models": {"trending_bull": 1, "trending_bear": 1,
+                             "mean_reverting": 1, "high_vol": 1}}, age_seconds=days,
+    )
+    sig = KnowledgeAdaptionAgent().run(
+        {"regime": "trending_bull", "plateau_detected": True}
+    )
+    assert sig.metadata["recommendation"] == "retrain"

--- a/tests/test_retrain_roi.py
+++ b/tests/test_retrain_roi.py
@@ -1,0 +1,125 @@
+"""Tests for analysis/retrain_roi.py."""
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def tmp_db(tmp_path, monkeypatch):
+    """Redirect data.db to a throw-away SQLite file for isolation."""
+    db_path = tmp_path / "quant.db"
+    monkeypatch.setattr("data.db._DB_PATH", Path(db_path))
+
+    conn = sqlite3.connect(str(db_path))
+    conn.execute(
+        """
+        CREATE TABLE model_metadata (
+            model_name     TEXT NOT NULL,
+            trained_at     REAL NOT NULL,
+            train_ic       REAL,
+            test_ic        REAL,
+            n_tickers      INTEGER,
+            period         TEXT,
+            test_ic_delta  REAL,
+            PRIMARY KEY (model_name, trained_at)
+        )
+        """
+    )
+    conn.commit()
+    conn.close()
+    return db_path
+
+
+def _insert_deltas(db_path: Path, model_name: str, deltas: list[float | None]) -> None:
+    """Insert rows with monotonically increasing trained_at timestamps."""
+    conn = sqlite3.connect(str(db_path))
+    with conn:
+        for i, d in enumerate(deltas):
+            conn.execute(
+                "INSERT INTO model_metadata "
+                "(model_name, trained_at, test_ic, test_ic_delta) VALUES (?, ?, ?, ?)",
+                (model_name, 1_000.0 + float(i), 0.05, d),
+            )
+    conn.close()
+
+
+def test_retrain_roi_empty_returns_empty_series(tmp_db):
+    from analysis.retrain_roi import retrain_roi
+
+    series, slope = retrain_roi("lgbm_alpha", n=6)
+    assert series.empty
+    assert slope == 0.0
+
+
+def test_retrain_roi_returns_last_n_chronological(tmp_db):
+    from analysis.retrain_roi import retrain_roi
+
+    _insert_deltas(tmp_db, "lgbm_alpha", [-0.02, -0.01, 0.0, 0.01, 0.02])
+    series, _ = retrain_roi("lgbm_alpha", n=3)
+    # Latest 3 in chronological order: 0.0, 0.01, 0.02
+    assert list(series.values) == pytest.approx([0.0, 0.01, 0.02])
+
+
+def test_retrain_roi_improving_positive_slope(tmp_db):
+    from analysis.retrain_roi import retrain_roi
+
+    _insert_deltas(tmp_db, "lgbm_alpha", [0.01, 0.02, 0.03])
+    _, slope = retrain_roi("lgbm_alpha", n=3)
+    assert slope > 0
+
+
+def test_retrain_roi_flat_zero_slope(tmp_db):
+    from analysis.retrain_roi import retrain_roi
+
+    _insert_deltas(tmp_db, "lgbm_alpha", [0.01, 0.01, 0.01])
+    _, slope = retrain_roi("lgbm_alpha", n=3)
+    assert slope == pytest.approx(0.0)
+
+
+def test_retrain_roi_degrading_negative_slope(tmp_db):
+    from analysis.retrain_roi import retrain_roi
+
+    _insert_deltas(tmp_db, "lgbm_alpha", [0.03, 0.01, -0.02])
+    _, slope = retrain_roi("lgbm_alpha", n=3)
+    assert slope < 0
+
+
+def test_retrain_roi_ignores_null_deltas(tmp_db):
+    from analysis.retrain_roi import retrain_roi
+
+    # Legacy rows with NULL delta should be filtered out by the query
+    _insert_deltas(tmp_db, "lgbm_alpha", [None, None, 0.01, 0.02, 0.03])
+    series, _ = retrain_roi("lgbm_alpha", n=10)
+    assert len(series) == 3
+
+
+def test_is_ic_plateau_flat_series_fires(tmp_db):
+    from analysis.retrain_roi import is_ic_plateau
+
+    _insert_deltas(tmp_db, "lgbm_alpha", [0.01, 0.01, 0.01])
+    assert is_ic_plateau("lgbm_alpha", n=3) is True
+
+
+def test_is_ic_plateau_degrading_series_fires(tmp_db):
+    from analysis.retrain_roi import is_ic_plateau
+
+    _insert_deltas(tmp_db, "lgbm_alpha", [0.03, 0.02, 0.01])
+    assert is_ic_plateau("lgbm_alpha", n=3) is True
+
+
+def test_is_ic_plateau_improving_series_silent(tmp_db):
+    from analysis.retrain_roi import is_ic_plateau
+
+    _insert_deltas(tmp_db, "lgbm_alpha", [0.01, 0.02, 0.03])
+    assert is_ic_plateau("lgbm_alpha", n=3) is False
+
+
+def test_is_ic_plateau_insufficient_history_silent(tmp_db):
+    from analysis.retrain_roi import is_ic_plateau
+
+    # Only 2 deltas — not yet enough to decide
+    _insert_deltas(tmp_db, "lgbm_alpha", [0.01, 0.01])
+    assert is_ic_plateau("lgbm_alpha", n=3) is False


### PR DESCRIPTION
## Summary

Tracks retrain return-on-investment so the `KnowledgeAdaptionAgent` can
distinguish "model is stale" from "retraining is no longer earning its
keep" — a flat or degrading IC trajectory is evidence of feature drift,
not staleness, and blindly retraining masks the real issue.

### Schema

- `data/db.py:init_db` adds a nullable `test_ic_delta REAL` column to
  `model_metadata` via idempotent `ALTER TABLE ADD COLUMN`, guarded by a
  `PRAGMA table_info` check so legacy rows are preserved.

### Producer

- `strategies/ml_signal.py::_write_metadata` queries the previous
  `test_ic` for the same `model_name` and persists
  `test_ic_delta = new_test_ic - previous_test_ic` on retrain #2
  onward. Retrain #1 stays `NULL`.

### Consumer

- New `analysis/retrain_roi.py`:
  - `retrain_roi(model_name, n=6) -> (pd.Series, float)` — last `n`
    non-null deltas (chronological) + simple linear-regression slope
    (deltas-per-retrain).
  - `is_ic_plateau(model_name, n=3) -> bool` — True when at least `n`
    deltas exist AND the slope is non-positive.

### Agent demotion

- `KnowledgeAdaptionAgent._resolve_plateau` honours
  `context['plateau_detected']` override for tests, otherwise calls
  `is_ic_plateau("lgbm_alpha", n=3)`. When the flag is True the verdict
  ladder demotes a would-be `fresh` to `monitor` with reasoning
  `"IC plateau over 3 retrains — feature drift suspected"`.
- `plateau_detected` is exposed in `AgentSignal.metadata` so
  `ml_execution` / `ensemble_signal` consumers can also react.

Stale / retrain / IC-decay / regime-gap verdicts are unaffected — the
plateau demotion only triggers on what would otherwise have been a
`fresh` verdict.

## Test plan

- [x] `ruff check .` — all checks passed
- [x] `pytest tests/ -m "not integration" --cov=. --cov-fail-under=76` — 1293 passed, coverage 77.36%
- [x] `bandit -r . -ll --exclude ./.git,./tests` — 0 HIGH severity issues
- [x] `pip-audit -r requirements.txt --ignore-vuln PYSEC-2022-42969` — no known vulnerabilities
- [x] New `tests/test_retrain_roi.py` — 10 cases: empty, improving, flat, degrading, null-filtering, insufficient-history
- [x] New `test_plateau_demotes_fresh_to_monitor` + `test_plateau_false_keeps_fresh` + `test_plateau_does_not_override_retrain`

Closes #122

https://claude.ai/code/session_01F5uD99ywUodQgPr5vXyEvU