### PR TITLE
feat: scheduled knowledge health check via APScheduler (#116)

### DIFF
--- a/.claude/agents/cron-runner.md
+++ b/.claude/agents/cron-runner.md
@@ -1,6 +1,6 @@
 ---
 name: cron-runner
-description: Run one of the ML cron jobs (cron.daily_ml_execute or cron.monthly_ml_retrain) locally with optional ticker override, and return a compact summary of the structured log output. Use when the caller wants to trigger a cron job without flooding the main context with training/trade logs.
+description: Run one of the ML cron jobs (cron.daily_ml_execute, cron.monthly_ml_retrain, or the scheduler.alerts knowledge_health_job) locally with optional ticker override, and return a compact summary of the structured log output. Use when the caller wants to trigger a cron job without flooding the main context with training/trade logs.
 tools: Bash, Read
 ---
 
@@ -10,13 +10,13 @@ structured log line. You do NOT commit, push, tag, or modify `cron/` or
 
 ## Input
 
-- `mode`: `daily` or `monthly`.
+- `mode`: `daily`, `monthly`, or `knowledge-health`.
 - `tickers` (optional): comma-separated list. If present, export
   `WF_TICKERS=<value>` **for the subprocess only** — do not mutate any
-  persistent shell state.
+  persistent shell state. Ignored for `knowledge-health`.
 
 Reject any other `mode` with the usage line:
-`cron-runner <daily|monthly> [TICKER1,TICKER2,...]`.
+`cron-runner <daily|monthly|knowledge-health> [TICKER1,TICKER2,...]`.
 
 ## Dispatch
 
@@ -24,8 +24,9 @@ Reject any other `mode` with the usage line:
 |---|---|---|
 | `daily` | `python -m cron.daily_ml_execute` | `cron/daily_ml_execute.py` |
 | `monthly` | `python -m cron.monthly_ml_retrain` | `cron/monthly_ml_retrain.py` |
+| `knowledge-health` | `python -c "from scheduler.alerts import knowledge_health_job; import json; print(json.dumps(knowledge_health_job(), default=str))"` | `scheduler/alerts.py:knowledge_health_job` |
 
-Both commands are pre-approved in `.claude/settings.json`.
+All three commands are pre-approved in `.claude/settings.json`.
 
 ## Pre-flight (daily only)
 

--- a/.claude/commands/run-cron.md
+++ b/.claude/commands/run-cron.md
@@ -1,6 +1,6 @@
 ---
-description: Manually run a cron job (cron.daily_ml_execute or cron.monthly_ml_retrain) locally with optional ticker override, and summarise the structured log output. Delegates to the `cron-runner` subagent so training/trade logs stay out of the main context.
-argument-hint: daily|monthly [TICKER1,TICKER2,...]
+description: Manually run a cron job (cron.daily_ml_execute, cron.monthly_ml_retrain, or the scheduler.alerts knowledge_health_job) locally with optional ticker override, and summarise the structured log output. Delegates to the `cron-runner` subagent so training/trade logs stay out of the main context.
+argument-hint: daily|monthly|knowledge-health [TICKER1,TICKER2,...]
 tools: []
 ---
 
@@ -10,14 +10,15 @@ returns only the parsed summary of the final structured log line.
 
 ## Arguments
 
-- First arg (required): `daily` or `monthly`.
+- First arg (required): `daily`, `monthly`, or `knowledge-health`.
 - Second arg (optional): comma-separated ticker list (forwarded as
   `WF_TICKERS` for the subprocess only; never mutates the user's shell).
+  Ignored for `knowledge-health` (the job reads no ticker context).
 
 Reject anything else with:
 
 ```
-/run-cron daily|monthly [TICKER1,TICKER2,...]
+/run-cron daily|monthly|knowledge-health [TICKER1,TICKER2,...]
 ```
 
 ## Dispatch

--- a/app.py
+++ b/app.py
@@ -2,7 +2,10 @@
 Quant Platform — Main Streamlit Entry Point
 Run with: streamlit run app.py
 """
+import os as _bootstrap_os
+
 import streamlit as st
+import structlog as _bootstrap_structlog
 
 import config
 from broker.paper_trader import init_paper_tables
@@ -20,7 +23,7 @@ from pages import (
     screener,
     shared,
 )
-from scheduler.alerts import init_alerts_table
+from scheduler.alerts import init_alerts_table, start_knowledge_health_scheduler
 
 # ── App bootstrap ─────────────────────────────────────────────────────────────
 config.configure_logging()
@@ -28,6 +31,19 @@ init_db()
 init_paper_tables()
 init_alerts_table()
 init_journal_table()
+
+# Opt-in hourly knowledge health check (#116). Requires the operator to set
+# ENABLE_KNOWLEDGE_HEALTH_JOB=1 so dev sessions don't get surprise background
+# jobs. KNOWLEDGE_HEALTH_CRON / KNOWLEDGE_HEALTH_ENABLED fine-tune the schedule.
+if _bootstrap_os.environ.get("ENABLE_KNOWLEDGE_HEALTH_JOB", "").strip().lower() in (
+    "1", "true", "yes", "on",
+):
+    try:
+        start_knowledge_health_scheduler()
+    except Exception as _exc:
+        _bootstrap_structlog.get_logger(__name__).warning(
+            "knowledge_health_job: bootstrap failed", error=str(_exc),
+        )
 
 st.set_page_config(
     page_title="Quant Platform",

--- a/cron/README.md
+++ b/cron/README.md
@@ -169,3 +169,52 @@ Exit codes emitted by the job: `0` success, `1` fatal error (missing
 lightgbm, no trained model, unexpected exception), `2` knowledge gate
 tripped. The agent's own 24h alert cooldown dedupes alerts so the cron
 does not spam on every run.
+
+---
+
+# Knowledge Health Job (push-based verdict)
+
+Runs `KnowledgeAdaptionAgent().run({})` on a cron schedule so staleness is
+detected even on quiet days (no votes, no trade flow). Exposed as
+`scheduler.alerts.knowledge_health_job` and scheduled via
+`scheduler.alerts.start_knowledge_health_scheduler` (APScheduler
+`BackgroundScheduler`). The agent's own 24h alert cooldown dedupes
+retrain alerts, so scheduling hourly does **not** spam operators.
+
+## Opt-in in the app
+
+The Streamlit bootstrap starts the scheduler only when
+`ENABLE_KNOWLEDGE_HEALTH_JOB=1`, so dev sessions do not get surprise
+background jobs:
+
+```bash
+ENABLE_KNOWLEDGE_HEALTH_JOB=1 streamlit run app.py
+```
+
+## Manual run (one-shot)
+
+```bash
+python -c "from scheduler.alerts import knowledge_health_job; knowledge_health_job()"
+# or, via the slash command
+/run-cron knowledge-health
+```
+
+The Claude Code `/run-cron knowledge-health` dispatches to the
+`cron-runner` subagent which emits the compact verdict summary.
+
+## Environment variables
+
+| Variable                      | Default         | Description                                        |
+|-------------------------------|-----------------|----------------------------------------------------|
+| `ENABLE_KNOWLEDGE_HEALTH_JOB` | (unset)         | `1` → app bootstrap starts the scheduler           |
+| `KNOWLEDGE_HEALTH_ENABLED`    | `1`             | Kill-switch — set `0` to skip without re-deploy     |
+| `KNOWLEDGE_HEALTH_CRON`       | `0 * * * *`     | Crontab-style schedule (top of every hour)         |
+| `KNOWLEDGE_ALERT_COOLDOWN`    | `86400`         | Seconds between retrain alerts (inherited)         |
+
+## Verdict → log level
+
+| Recommendation | Log level | Structured payload                                      |
+|----------------|-----------|---------------------------------------------------------|
+| `fresh`        | INFO      | `recommendation, signal, confidence, reasoning`         |
+| `monitor`      | INFO      | same                                                    |
+| `retrain`      | WARNING   | same (agent fires its own alert with 24h cooldown)      |

--- a/scheduler/alerts.py
+++ b/scheduler/alerts.py
@@ -492,3 +492,101 @@ def run_anomaly_checks(
         fired.append(anomaly)
 
     return fired
+
+
+# ── Knowledge-adaption health check scheduler hook ────────────────────────────
+
+# Shared agent instance so the 24h alert cooldown (_last_alert_at on the
+# agent) actually throttles across scheduled runs. Used by
+# ``knowledge_health_job`` and injectable from tests.
+_knowledge_agent_singleton = None
+
+
+def _get_knowledge_agent():
+    """Return (lazy) the process-wide KnowledgeAdaptionAgent singleton."""
+    global _knowledge_agent_singleton
+    if _knowledge_agent_singleton is None:
+        from agents.knowledge_agent import KnowledgeAdaptionAgent
+
+        _knowledge_agent_singleton = KnowledgeAdaptionAgent()
+    return _knowledge_agent_singleton
+
+
+def knowledge_health_job() -> dict:
+    """Run the KnowledgeAdaptionAgent once and emit a structured log line.
+
+    Intended for APScheduler — see ``start_knowledge_health_scheduler``. The
+    agent's own 24h alert stamp (``_last_alert_at``) dedupes retrain alerts
+    so scheduling the job hourly does not spam operators.
+
+    Returns the agent's ``metadata`` dict so the caller can introspect the
+    verdict (useful in tests and for the ``/run-cron knowledge-health``
+    slash command).
+    """
+    agent = _get_knowledge_agent()
+    sig = agent.run({})
+    recommendation = (sig.metadata or {}).get("recommendation", "monitor")
+    log_fn = logger.warning if recommendation == "retrain" else logger.info
+    log_fn(
+        "knowledge_health_job: verdict",
+        recommendation=recommendation,
+        signal=sig.signal,
+        confidence=sig.confidence,
+        reasoning=sig.reasoning,
+    )
+    return dict(sig.metadata or {})
+
+
+def start_knowledge_health_scheduler(
+    cron_expr: str | None = None,
+    paused: bool = False,
+):
+    """Build a ``BackgroundScheduler`` that runs ``knowledge_health_job``
+    on a cron schedule.
+
+    Parameters
+    ----------
+    cron_expr : crontab-style schedule. Defaults to ``KNOWLEDGE_HEALTH_CRON``
+                env var, falling back to ``"0 * * * *"`` (top of every hour).
+    paused    : start the scheduler in paused state — useful for tests that
+                only want to inspect the registered jobs without actually
+                firing them.
+
+    Returns
+    -------
+    The started ``BackgroundScheduler`` instance, or ``None`` when
+    ``KNOWLEDGE_HEALTH_ENABLED`` is explicitly set to ``0`` / ``false``.
+
+    Operators opt in via ``ENABLE_KNOWLEDGE_HEALTH_JOB=1`` in the app
+    bootstrap; ``KNOWLEDGE_HEALTH_ENABLED`` is a per-scheduler kill-switch
+    for quickly disabling the job without re-deploying.
+    """
+    import os as _os
+
+    enabled = _os.environ.get("KNOWLEDGE_HEALTH_ENABLED", "1").strip().lower()
+    if enabled in ("0", "false", "no", "off"):
+        logger.info("knowledge_health_job: disabled via KNOWLEDGE_HEALTH_ENABLED")
+        return None
+
+    from apscheduler.schedulers.background import BackgroundScheduler
+    from apscheduler.triggers.cron import CronTrigger
+
+    expr = cron_expr or _os.environ.get("KNOWLEDGE_HEALTH_CRON", "0 * * * *")
+    trigger = CronTrigger.from_crontab(expr)
+
+    scheduler = BackgroundScheduler()
+    scheduler.add_job(
+        knowledge_health_job,
+        trigger=trigger,
+        id="knowledge_health_job",
+        name="Knowledge adaption health check",
+        replace_existing=True,
+        max_instances=1,
+        coalesce=True,
+    )
+    if paused:
+        scheduler.start(paused=True)
+    else:
+        scheduler.start()
+    logger.info("knowledge_health_job: scheduled", cron_expr=expr)
+    return scheduler

--- a/tests/test_knowledge_health_job.py
+++ b/tests/test_knowledge_health_job.py
@@ -1,0 +1,146 @@
+"""Tests for scheduler.alerts:knowledge_health_job + scheduler bootstrap (#116)."""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _reset_singleton(monkeypatch):
+    """Ensure each test gets a fresh agent singleton — the module-level cache
+    would otherwise share alert timestamps across unrelated tests."""
+    import scheduler.alerts as alerts
+
+    monkeypatch.setattr(alerts, "_knowledge_agent_singleton", None)
+
+
+def _agent_returning(recommendation: str, signal: str = "bullish"):
+    sig = MagicMock()
+    sig.signal = signal
+    sig.confidence = 0.8
+    sig.reasoning = f"mock verdict: {recommendation}"
+    sig.metadata = {"recommendation": recommendation, "regime": "trending_bull"}
+    agent = MagicMock()
+    agent.run.return_value = sig
+    return agent
+
+
+def test_knowledge_health_job_logs_info_on_fresh(monkeypatch):
+    import scheduler.alerts as alerts
+
+    fake_agent = _agent_returning("fresh", signal="bullish")
+    monkeypatch.setattr(alerts, "_knowledge_agent_singleton", fake_agent)
+
+    with patch.object(alerts.logger, "info") as info_log, \
+         patch.object(alerts.logger, "warning") as warn_log:
+        result = alerts.knowledge_health_job()
+
+    assert result["recommendation"] == "fresh"
+    info_log.assert_called()
+    warn_log.assert_not_called()
+    fake_agent.run.assert_called_once_with({})
+
+
+def test_knowledge_health_job_logs_warning_on_retrain(monkeypatch):
+    import scheduler.alerts as alerts
+
+    fake_agent = _agent_returning("retrain", signal="bearish")
+    monkeypatch.setattr(alerts, "_knowledge_agent_singleton", fake_agent)
+
+    with patch.object(alerts.logger, "warning") as warn_log:
+        result = alerts.knowledge_health_job()
+
+    assert result["recommendation"] == "retrain"
+    warn_log.assert_called()
+
+
+def test_knowledge_health_job_monitor_uses_info(monkeypatch):
+    import scheduler.alerts as alerts
+
+    fake_agent = _agent_returning("monitor", signal="neutral")
+    monkeypatch.setattr(alerts, "_knowledge_agent_singleton", fake_agent)
+
+    with patch.object(alerts.logger, "info") as info_log, \
+         patch.object(alerts.logger, "warning") as warn_log:
+        alerts.knowledge_health_job()
+
+    info_log.assert_called()
+    warn_log.assert_not_called()
+
+
+def test_agent_singleton_reused_across_calls(monkeypatch):
+    # The shared singleton is what makes the 24h alert stamp survive across
+    # scheduled runs — assert the factory doesn't rebuild it every call.
+    import scheduler.alerts as alerts
+
+    calls = []
+
+    class _FakeAgent:
+        def run(self, context):
+            calls.append(context)
+            return _agent_returning("fresh").run({})
+
+    monkeypatch.setattr(
+        "agents.knowledge_agent.KnowledgeAdaptionAgent", _FakeAgent,
+    )
+    # First call constructs the singleton, subsequent calls reuse it.
+    alerts.knowledge_health_job()
+    first = alerts._knowledge_agent_singleton
+    alerts.knowledge_health_job()
+    second = alerts._knowledge_agent_singleton
+
+    assert first is second
+    assert len(calls) == 2
+
+
+def test_scheduler_disabled_via_env(monkeypatch):
+    import scheduler.alerts as alerts
+
+    monkeypatch.setenv("KNOWLEDGE_HEALTH_ENABLED", "0")
+    assert alerts.start_knowledge_health_scheduler() is None
+
+
+def test_scheduler_registers_hourly_job(monkeypatch):
+    import scheduler.alerts as alerts
+
+    monkeypatch.delenv("KNOWLEDGE_HEALTH_ENABLED", raising=False)
+    monkeypatch.delenv("KNOWLEDGE_HEALTH_CRON", raising=False)
+    scheduler = alerts.start_knowledge_health_scheduler(paused=True)
+    try:
+        assert scheduler is not None
+        jobs = scheduler.get_jobs()
+        assert len(jobs) == 1
+        job = jobs[0]
+        assert job.id == "knowledge_health_job"
+        # Default cron is top-of-hour; confirm the trigger reflects that
+        assert "hour='*'" in str(job.trigger) or "minute='0'" in str(job.trigger)
+    finally:
+        scheduler.shutdown(wait=False)
+
+
+def test_scheduler_honours_cron_expr(monkeypatch):
+    import scheduler.alerts as alerts
+
+    scheduler = alerts.start_knowledge_health_scheduler(
+        cron_expr="*/15 * * * *", paused=True,
+    )
+    try:
+        assert scheduler is not None
+        jobs = scheduler.get_jobs()
+        assert len(jobs) == 1
+        assert "*/15" in str(jobs[0].trigger)
+    finally:
+        scheduler.shutdown(wait=False)
+
+
+def test_scheduler_reads_cron_from_env(monkeypatch):
+    import scheduler.alerts as alerts
+
+    monkeypatch.setenv("KNOWLEDGE_HEALTH_CRON", "0 */2 * * *")
+    scheduler = alerts.start_knowledge_health_scheduler(paused=True)
+    try:
+        assert scheduler is not None
+        assert "*/2" in str(scheduler.get_jobs()[0].trigger)
+    finally:
+        scheduler.shutdown(wait=False)


### PR DESCRIPTION
## Summary

Adds a push-based scheduler for the `KnowledgeAdaptionAgent` so model
staleness is detected even on quiet days (no votes, no trade flow).

- `scheduler/alerts.py::knowledge_health_job()` — runs the agent once,
  emits a structured log line (INFO for fresh/monitor, WARNING for
  retrain). The agent's 24h `_last_alert_at` stamp dedupes retrain
  alerts so hourly scheduling does not spam operators.
- `scheduler/alerts.py::start_knowledge_health_scheduler()` — builds an
  APScheduler `BackgroundScheduler` with a `CronTrigger`. Reads
  `KNOWLEDGE_HEALTH_CRON` (default `"0 * * * *"`), honours
  `KNOWLEDGE_HEALTH_ENABLED=0` as a kill-switch.
- Process-wide `_knowledge_agent_singleton` so the alert cooldown stamp
  survives across scheduled runs.
- `app.py` starts the scheduler when
  `ENABLE_KNOWLEDGE_HEALTH_JOB=1` — opt-in so dev sessions don't get
  surprise background jobs.

### Operator hooks

- `/run-cron knowledge-health` slash command dispatches via the
  `cron-runner` subagent (new row in the dispatch table).
- `cron/README.md` gains a "Knowledge Health Job" section with the env
  vars, manual-run recipe, and verdict → log-level table.

## Test plan

- [x] `ruff check .` — all checks passed
- [x] `pytest tests/ -m "not integration" --cov=. --cov-fail-under=76` — 1293 passed, coverage 77.54%
- [x] `bandit -r . -ll --exclude ./.git,./tests` — 0 HIGH severity issues
- [x] `pip-audit -r requirements.txt --ignore-vuln PYSEC-2022-42969` — no known vulnerabilities
- [x] New `tests/test_knowledge_health_job.py` — 8 cases covering:
  - verdict → log level (fresh/monitor/retrain)
  - agent singleton reuse
  - scheduler disabled via env
  - default cron + custom cron + env-var cron

Closes #116

https://claude.ai/code/session_01F5uD99ywUodQgPr5vXyEvU