### PR TITLE
feat: recover P1.1 pre-trade guard implementation (#139)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -87,3 +87,13 @@ LOG_LEVEL=INFO
 # RF_LS_MODEL_PATH=models/rf_long_short.pkl
 # CNN_ALPHA_MODEL_PATH=models/cnn_alpha.pt
 # DL_ALPHA_MODEL_PATH=models/dl_alpha.pt
+
+# Pre-trade risk guard (#139) — every dimension is optional. Unset means
+# no restriction on that axis; a guard instance with zero dimensions is a
+# no-op. The kill-switch file is honoured by every broker adapter.
+# MAX_POSITION_PCT=0.05              # reject if post-trade symbol weight > fraction of equity
+# MAX_DAILY_LOSS_PCT=0.02            # reject all orders when today's realised+unrealised PnL ≤ -fraction × equity
+# MAX_GROSS_EXPOSURE=1.5             # reject if post-trade Σ|position value| / equity > fraction
+# MAX_ORDERS_PER_DAY=50              # hard cap on accepted orders per UTC day
+# SYMBOL_BLOCKLIST=                  # comma-separated tickers, case-insensitive (e.g. "PENNY,MEME")
+# KILLSWITCH_FILE=.killswitch        # path to the kill-switch flag; touch to halt, remove to resume

--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ coverage-integration.xml
 htmlcov/
 .pytest_cache/
 .coverage
+
+# Pre-trade kill-switch flag (#139) — never commit; operator-local state
+.killswitch

--- a/adapters/broker/alpaca_adapter.py
+++ b/adapters/broker/alpaca_adapter.py
@@ -9,12 +9,16 @@ import logging
 from typing import Optional
 
 import broker.alpaca_bridge as _bridge
+from risk.pretrade_guard import GuardLimits, GuardViolation, PreTradeGuard
 
 logger = logging.getLogger(__name__)
 
 
 class AlpacaBrokerAdapter:
     """BrokerProvider backed by the existing Alpaca bridge."""
+
+    def __init__(self) -> None:
+        self._guard = PreTradeGuard(GuardLimits.from_env(), self)
 
     def get_account_info(self) -> dict:
         result = _bridge.get_account()
@@ -43,6 +47,22 @@ class AlpacaBrokerAdapter:
         order_type: str = "market",
         limit_price: Optional[float] = None,
     ) -> dict:
+        try:
+            self._guard.check(symbol, qty, side, limit_price)
+        except GuardViolation as violation:
+            logger.warning(
+                "pretrade_guard_reject symbol=%s qty=%s side=%s reason=%s",
+                symbol, qty, side, violation.reason,
+            )
+            return {
+                "symbol": symbol.upper(),
+                "qty": qty,
+                "side": side,
+                "order_type": order_type,
+                "status": "rejected",
+                "reason": violation.reason,
+            }
+
         if order_type != "market":
             logger.warning(
                 "AlpacaBrokerAdapter: only market orders supported; "

--- a/adapters/broker/ibkr_adapter.py
+++ b/adapters/broker/ibkr_adapter.py
@@ -13,14 +13,19 @@ and the import chain is valid.
 """
 from __future__ import annotations
 
+import logging
 import os
 from typing import Optional
+
+from risk.pretrade_guard import GuardLimits, GuardViolation, PreTradeGuard
 
 try:
     import ibapi as _ibapi  # noqa: F401  (import check only)
     _IBAPI_AVAILABLE = True
 except ImportError:
     _IBAPI_AVAILABLE = False
+
+logger = logging.getLogger(__name__)
 
 
 class IBKRAdapter:
@@ -35,6 +40,7 @@ class IBKRAdapter:
         self._host = os.environ.get("IBKR_HOST", "127.0.0.1")
         self._port = int(os.environ.get("IBKR_PORT", "7497"))
         self._client_id = int(os.environ.get("IBKR_CLIENT_ID", "1"))
+        self._guard = PreTradeGuard(GuardLimits.from_env(), self)
 
     def get_account_info(self) -> dict:
         raise NotImplementedError("IBKRAdapter: full implementation pending Phase 2")
@@ -50,6 +56,21 @@ class IBKRAdapter:
         order_type: str = "market",
         limit_price: Optional[float] = None,
     ) -> dict:
+        try:
+            self._guard.check(symbol, qty, side, limit_price)
+        except GuardViolation as violation:
+            logger.warning(
+                "pretrade_guard_reject symbol=%s qty=%s side=%s reason=%s",
+                symbol, qty, side, violation.reason,
+            )
+            return {
+                "symbol": symbol.upper(),
+                "qty": qty,
+                "side": side,
+                "order_type": order_type,
+                "status": "rejected",
+                "reason": violation.reason,
+            }
         raise NotImplementedError("IBKRAdapter: full implementation pending Phase 2")
 
     def cancel_order(self, order_id: str) -> bool:

--- a/adapters/broker/paper_adapter.py
+++ b/adapters/broker/paper_adapter.py
@@ -9,6 +9,8 @@ import logging
 import threading
 from typing import Optional
 
+from risk.pretrade_guard import GuardLimits, GuardViolation, PreTradeGuard
+
 logger = logging.getLogger(__name__)
 
 # Thread-safe singleton init guard
@@ -35,6 +37,7 @@ class PaperBrokerAdapter:
         self._orders: dict[str, dict] = {}  # local order store (in-memory)
         self._order_counter = 0
         self._lock = threading.Lock()
+        self._guard = PreTradeGuard(GuardLimits.from_env(), self)
 
     def get_account_info(self) -> dict:
         from broker.paper_trader import get_account
@@ -64,6 +67,22 @@ class PaperBrokerAdapter:
         order_type: str = "market",
         limit_price: Optional[float] = None,
     ) -> dict:
+        try:
+            self._guard.check(symbol, qty, side, limit_price)
+        except GuardViolation as violation:
+            logger.warning(
+                "pretrade_guard_reject symbol=%s qty=%s side=%s reason=%s",
+                symbol, qty, side, violation.reason,
+            )
+            return {
+                "symbol": symbol.upper(),
+                "qty": qty,
+                "side": side,
+                "order_type": order_type,
+                "status": "rejected",
+                "reason": violation.reason,
+            }
+
         from broker.paper_trader import buy, sell
         # For paper trading we need a price — use limit_price or fetch live price.
         price = limit_price

--- a/adapters/broker/schwab_adapter.py
+++ b/adapters/broker/schwab_adapter.py
@@ -10,14 +10,19 @@ Full implementation is Phase 2 scope.
 """
 from __future__ import annotations
 
+import logging
 import os
 from typing import Optional
+
+from risk.pretrade_guard import GuardLimits, GuardViolation, PreTradeGuard
 
 try:
     import schwab as _schwab  # noqa: F401  (import check only)
     _SCHWAB_AVAILABLE = True
 except ImportError:
     _SCHWAB_AVAILABLE = False
+
+logger = logging.getLogger(__name__)
 
 
 class SchwabAdapter:
@@ -33,6 +38,7 @@ class SchwabAdapter:
         self._secret_key = os.environ.get("SCHWAB_SECRET_KEY", "")
         self._account_id = os.environ.get("SCHWAB_ACCOUNT_ID", "")
         self._token_path = os.environ.get("SCHWAB_TOKEN_PATH", "./schwab_token.json")
+        self._guard = PreTradeGuard(GuardLimits.from_env(), self)
 
     def get_account_info(self) -> dict:
         raise NotImplementedError("SchwabAdapter: full implementation pending Phase 2")
@@ -48,6 +54,21 @@ class SchwabAdapter:
         order_type: str = "market",
         limit_price: Optional[float] = None,
     ) -> dict:
+        try:
+            self._guard.check(symbol, qty, side, limit_price)
+        except GuardViolation as violation:
+            logger.warning(
+                "pretrade_guard_reject symbol=%s qty=%s side=%s reason=%s",
+                symbol, qty, side, violation.reason,
+            )
+            return {
+                "symbol": symbol.upper(),
+                "qty": qty,
+                "side": side,
+                "order_type": order_type,
+                "status": "rejected",
+                "reason": violation.reason,
+            }
         raise NotImplementedError("SchwabAdapter: full implementation pending Phase 2")
 
     def cancel_order(self, order_id: str) -> bool:

--- a/cron/daily_ml_execute.py
+++ b/cron/daily_ml_execute.py
@@ -42,6 +42,7 @@ import argparse
 import os
 import sys
 
+from risk.pretrade_guard import install_killswitch_handler
 from strategies.ml_execution import execute_ml_signals
 from strategies.ml_signal import _LGBM_AVAILABLE, MLSignal
 from utils.logger import get_logger
@@ -114,6 +115,8 @@ def _check_knowledge_gate() -> int | None:
 def main(argv: list[str] | None = None) -> None:
     parser = _build_arg_parser()
     args = parser.parse_args(argv)
+
+    install_killswitch_handler()
 
     enforce_gate = _resolve_gate_enforcement(args.enforce_knowledge_gate)
 

--- a/risk/pretrade_guard.py
+++ b/risk/pretrade_guard.py
@@ -1,0 +1,345 @@
+"""
+risk/pretrade_guard.py — deterministic pre-trade risk gate + kill-switch.
+
+Every broker adapter calls ``PreTradeGuard.check()`` before placing an
+order. Any limit violation raises ``GuardViolation`` with a machine-readable
+reason; adapters convert that into a structured
+``{"status": "rejected", "reason": ...}`` response so cron flows stay
+non-fatal.
+
+Limits are optional — unset env vars mean "no restriction" on that
+dimension. The operator kill-switch is a file (default ``.killswitch``) that
+the adapter checks on every order and that a SIGTERM handler creates on
+signal. Removing the file resumes trading.
+
+ENV vars
+--------
+    MAX_POSITION_PCT         fraction of equity a single symbol may occupy
+    MAX_DAILY_LOSS_PCT       fraction of equity; realised+unrealised PnL floor
+    MAX_GROSS_EXPOSURE       fraction of equity; ``Σ|position value| / equity``
+    MAX_ORDERS_PER_DAY       hard cap on accepted orders per UTC day
+    SYMBOL_BLOCKLIST         comma-separated tickers (case-insensitive)
+    KILLSWITCH_FILE          path to the kill-switch flag (default .killswitch)
+"""
+from __future__ import annotations
+
+import os
+import signal
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import TYPE_CHECKING, Callable
+
+import structlog
+
+if TYPE_CHECKING:
+    from providers.broker import BrokerProvider
+
+logger = structlog.get_logger(__name__)
+
+
+class GuardViolation(Exception):
+    """Raised when an order violates a pre-trade limit or the kill-switch."""
+
+    def __init__(self, reason: str, detail: str = "") -> None:
+        super().__init__(f"{reason}: {detail}" if detail else reason)
+        self.reason = reason
+        self.detail = detail
+
+
+def _parse_float(env_name: str) -> float | None:
+    raw = os.environ.get(env_name)
+    if raw is None or raw.strip() == "":
+        return None
+    try:
+        return float(raw)
+    except ValueError:
+        logger.warning("pretrade_guard: bad float env var", var=env_name, value=raw)
+        return None
+
+
+def _parse_int(env_name: str) -> int | None:
+    raw = os.environ.get(env_name)
+    if raw is None or raw.strip() == "":
+        return None
+    try:
+        return int(raw)
+    except ValueError:
+        logger.warning("pretrade_guard: bad int env var", var=env_name, value=raw)
+        return None
+
+
+def _parse_blocklist(env_name: str) -> frozenset[str]:
+    raw = os.environ.get(env_name, "")
+    return frozenset(
+        t.strip().upper() for t in raw.split(",") if t.strip()
+    )
+
+
+@dataclass(frozen=True)
+class GuardLimits:
+    """Pre-trade limit configuration. Unset fields mean no restriction."""
+
+    max_position_pct: float | None = None
+    max_daily_loss_pct: float | None = None
+    max_gross_exposure: float | None = None
+    max_orders_per_day: int | None = None
+    symbol_blocklist: frozenset[str] = field(default_factory=frozenset)
+    killswitch_path: Path = field(default_factory=lambda: Path(".killswitch"))
+
+    @classmethod
+    def from_env(cls) -> GuardLimits:
+        """Build ``GuardLimits`` from the documented env vars."""
+        killswitch_raw = os.environ.get("KILLSWITCH_FILE", ".killswitch")
+        return cls(
+            max_position_pct=_parse_float("MAX_POSITION_PCT"),
+            max_daily_loss_pct=_parse_float("MAX_DAILY_LOSS_PCT"),
+            max_gross_exposure=_parse_float("MAX_GROSS_EXPOSURE"),
+            max_orders_per_day=_parse_int("MAX_ORDERS_PER_DAY"),
+            symbol_blocklist=_parse_blocklist("SYMBOL_BLOCKLIST"),
+            killswitch_path=Path(killswitch_raw),
+        )
+
+    def any_active(self) -> bool:
+        """True when at least one dimension is configured."""
+        return (
+            self.max_position_pct is not None
+            or self.max_daily_loss_pct is not None
+            or self.max_gross_exposure is not None
+            or self.max_orders_per_day is not None
+            or bool(self.symbol_blocklist)
+        )
+
+
+class PreTradeGuard:
+    """Stateful pre-trade gate bound to a specific ``BrokerProvider``."""
+
+    def __init__(
+        self,
+        limits: GuardLimits,
+        broker: "BrokerProvider",
+        clock: Callable[[], datetime] = lambda: datetime.now(timezone.utc),
+    ) -> None:
+        self._limits = limits
+        self._broker = broker
+        self._clock = clock
+        self._day_key: str | None = None
+        self._orders_today: int = 0
+
+    @property
+    def limits(self) -> GuardLimits:
+        return self._limits
+
+    def check(
+        self,
+        symbol: str,
+        qty: float,
+        side: str,
+        limit_price: float | None = None,
+    ) -> None:
+        """Raise :class:`GuardViolation` if the order is rejected.
+
+        Bumps the accepted-order counter on success so callers do not need
+        to track it. A violation leaves the counter untouched.
+        """
+        symbol_u = symbol.upper()
+        self._rollover_day()
+
+        # Kill-switch comes first — fail closed.
+        if self._limits.killswitch_path.exists():
+            raise GuardViolation(
+                "killswitch",
+                f"{self._limits.killswitch_path} present",
+            )
+
+        if symbol_u in self._limits.symbol_blocklist:
+            raise GuardViolation("symbol_blocklist", symbol_u)
+
+        if (
+            self._limits.max_orders_per_day is not None
+            and self._orders_today >= self._limits.max_orders_per_day
+        ):
+            raise GuardViolation(
+                "max_orders_per_day",
+                f"{self._orders_today}/{self._limits.max_orders_per_day}",
+            )
+
+        # Remaining dimensions need account state.
+        if self._needs_account_state():
+            equity, positions = self._account_snapshot()
+            if equity > 0:
+                self._check_position_pct(symbol_u, qty, limit_price, equity, positions)
+                self._check_gross_exposure(symbol_u, qty, side, limit_price, equity, positions)
+                self._check_daily_loss(equity, positions)
+
+        # Accept.
+        self._orders_today += 1
+
+    def _needs_account_state(self) -> bool:
+        return (
+            self._limits.max_position_pct is not None
+            or self._limits.max_gross_exposure is not None
+            or self._limits.max_daily_loss_pct is not None
+        )
+
+    def _account_snapshot(self) -> tuple[float, list[dict]]:
+        try:
+            account = self._broker.get_account_info() or {}
+            positions = self._broker.get_positions() or []
+        except Exception as exc:  # pragma: no cover — defensive
+            logger.warning("pretrade_guard: account snapshot failed", error=str(exc))
+            return 0.0, []
+
+        equity_raw = account.get("equity") or account.get("portfolio_value") or 0.0
+        try:
+            equity = float(equity_raw)
+        except (TypeError, ValueError):
+            equity = 0.0
+        return equity, positions
+
+    @staticmethod
+    def _order_notional(qty: float, limit_price: float | None) -> float:
+        if limit_price is None or limit_price <= 0:
+            return 0.0
+        return abs(float(qty) * float(limit_price))
+
+    @staticmethod
+    def _position_notional(pos: dict) -> float:
+        market_value = pos.get("market_value")
+        if market_value is not None:
+            try:
+                return abs(float(market_value))
+            except (TypeError, ValueError):
+                pass
+        qty = pos.get("qty") or 0
+        price = pos.get("avg_entry_price") or pos.get("current_price") or 0
+        try:
+            return abs(float(qty) * float(price))
+        except (TypeError, ValueError):
+            return 0.0
+
+    def _check_position_pct(
+        self,
+        symbol: str,
+        qty: float,
+        limit_price: float | None,
+        equity: float,
+        positions: list[dict],
+    ) -> None:
+        if self._limits.max_position_pct is None:
+            return
+        order_notional = self._order_notional(qty, limit_price)
+        if order_notional <= 0:
+            return
+        existing = 0.0
+        for p in positions:
+            if (p.get("symbol") or "").upper() == symbol:
+                existing = self._position_notional(p)
+                break
+        post_weight = (existing + order_notional) / equity
+        if post_weight > self._limits.max_position_pct:
+            raise GuardViolation(
+                "max_position_pct",
+                f"weight={post_weight:.4f} cap={self._limits.max_position_pct:.4f}",
+            )
+
+    def _check_gross_exposure(
+        self,
+        symbol: str,
+        qty: float,
+        side: str,
+        limit_price: float | None,
+        equity: float,
+        positions: list[dict],
+    ) -> None:
+        if self._limits.max_gross_exposure is None:
+            return
+        order_notional = self._order_notional(qty, limit_price)
+        if order_notional <= 0:
+            return
+        gross = sum(self._position_notional(p) for p in positions)
+        projected = (gross + order_notional) / equity
+        if projected > self._limits.max_gross_exposure:
+            raise GuardViolation(
+                "max_gross_exposure",
+                f"gross={projected:.4f} cap={self._limits.max_gross_exposure:.4f}",
+            )
+
+    def _check_daily_loss(self, equity: float, positions: list[dict]) -> None:
+        if self._limits.max_daily_loss_pct is None:
+            return
+        realised = _realised_pnl_today(self._clock)
+        unrealised = 0.0
+        for p in positions:
+            raw = p.get("unrealized_pl") or p.get("unrealised_pl")
+            if raw is None:
+                continue
+            try:
+                unrealised += float(raw)
+            except (TypeError, ValueError):
+                continue
+        pnl = realised + unrealised
+        floor = -self._limits.max_daily_loss_pct * equity
+        if pnl <= floor:
+            raise GuardViolation(
+                "max_daily_loss_pct",
+                f"pnl={pnl:.2f} floor={floor:.2f}",
+            )
+
+    def _rollover_day(self) -> None:
+        today = self._clock().strftime("%Y-%m-%d")
+        if self._day_key != today:
+            self._day_key = today
+            self._orders_today = 0
+
+
+def _realised_pnl_today(clock: Callable[[], datetime]) -> float:
+    """Sum today's realised P&L from the trading journal (UTC day)."""
+    try:
+        from journal.trading_journal import get_journal
+    except ImportError:  # pragma: no cover — defensive
+        return 0.0
+    today = clock().strftime("%Y-%m-%d")
+    try:
+        df = get_journal(start_date=today)
+    except Exception as exc:  # pragma: no cover — defensive
+        logger.warning("pretrade_guard: journal read failed", error=str(exc))
+        return 0.0
+    if df is None or df.empty or "pnl" not in df.columns:
+        return 0.0
+    return float(df["pnl"].fillna(0.0).sum())
+
+
+# ── Kill-switch SIGTERM handler ─────────────────────────────────────────────
+
+def install_killswitch_handler(
+    path: Path | str | None = None,
+    signals: tuple[int, ...] = (signal.SIGTERM,),
+) -> Path:
+    """Install a SIGTERM handler that creates the kill-switch file.
+
+    Operators remove the file manually to resume trading. The returned path
+    is the one that will be created on signal.
+    """
+    resolved = Path(path) if path is not None else Path(
+        os.environ.get("KILLSWITCH_FILE", ".killswitch")
+    )
+
+    def _handler(signum, frame):  # noqa: ARG001 — signal API
+        try:
+            resolved.touch(exist_ok=True)
+            logger.error(
+                "pretrade_guard: killswitch engaged via signal",
+                signum=signum,
+                path=str(resolved),
+            )
+        except OSError as exc:  # pragma: no cover — defensive
+            logger.error(
+                "pretrade_guard: failed to write killswitch",
+                error=str(exc),
+                path=str(resolved),
+            )
+
+    for sig in signals:
+        signal.signal(sig, _handler)
+    return resolved

--- a/scheduler/alerts.py
+++ b/scheduler/alerts.py
@@ -574,6 +574,15 @@ def start_knowledge_health_scheduler(
     expr = cron_expr or _os.environ.get("KNOWLEDGE_HEALTH_CRON", "0 * * * *")
     trigger = CronTrigger.from_crontab(expr)
 
+    # Install the kill-switch SIGTERM handler so a TERM'd scheduler also
+    # flags the broker adapters to reject any further orders.
+    try:
+        from risk.pretrade_guard import install_killswitch_handler
+
+        install_killswitch_handler()
+    except (ValueError, OSError) as exc:  # pragma: no cover — signal-only failure paths
+        logger.warning("killswitch_handler_install_failed", error=str(exc))
+
     scheduler = BackgroundScheduler()
     scheduler.add_job(
         knowledge_health_job,

--- a/tests/test_pretrade_guard.py
+++ b/tests/test_pretrade_guard.py
@@ -1,0 +1,224 @@
+"""
+tests/test_pretrade_guard.py — tests for risk/pretrade_guard.py.
+
+Every case builds a ``GuardLimits`` directly (not ``from_env``) for
+determinism and uses a tiny in-memory ``FakeBroker`` to avoid network /
+SDK dependencies. Where a test exercises the daily-loss check, the trading
+journal is redirected to a per-test temp SQLite file via JOURNAL_DB_PATH.
+"""
+from __future__ import annotations
+
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+import journal.trading_journal as jt
+from risk.pretrade_guard import GuardLimits, GuardViolation, PreTradeGuard
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+class FakeBroker:
+    """Minimal BrokerProvider stand-in for guard tests."""
+
+    def __init__(self, equity: float = 100_000.0, positions: list[dict] | None = None):
+        self.equity = equity
+        self._positions = positions or []
+
+    def get_account_info(self) -> dict:
+        return {"equity": self.equity, "cash": self.equity}
+
+    def get_positions(self) -> list[dict]:
+        return list(self._positions)
+
+    # The BrokerProvider Protocol has more methods, but the guard only
+    # calls get_account_info + get_positions, so the rest are omitted.
+
+
+@pytest.fixture
+def journal_db(tmp_path, monkeypatch):
+    """Isolate trading_journal to a per-test SQLite file."""
+    monkeypatch.setenv("JOURNAL_DB_PATH", str(tmp_path / "journal.db"))
+    jt.init_journal_table()
+    return tmp_path
+
+
+# ── 1. Blocklist ─────────────────────────────────────────────────────────────
+
+def test_blocklist_rejects():
+    broker = FakeBroker()
+    guard = PreTradeGuard(
+        GuardLimits(symbol_blocklist=frozenset({"XYZ"})),
+        broker,
+    )
+    # Blocklisted → rejected.
+    with pytest.raises(GuardViolation) as exc:
+        guard.check("XYZ", 10, "buy")
+    assert exc.value.reason == "symbol_blocklist"
+    # Non-blocklisted → accepted.
+    guard.check("AAPL", 10, "buy")
+
+
+# ── 2. Max position % ────────────────────────────────────────────────────────
+
+def test_max_position_pct_rejects_oversized():
+    # 1% cap on $100k equity → $1000 notional max. A 20×$100 = $2000 order
+    # violates the cap.
+    broker = FakeBroker(equity=100_000.0)
+    guard = PreTradeGuard(GuardLimits(max_position_pct=0.01), broker)
+    with pytest.raises(GuardViolation) as exc:
+        guard.check("AAPL", 20, "buy", limit_price=100.0)
+    assert exc.value.reason == "max_position_pct"
+    # 5×$100 = $500 is under the cap.
+    guard.check("AAPL", 5, "buy", limit_price=100.0)
+
+
+# ── 3. Max gross exposure ────────────────────────────────────────────────────
+
+def test_max_gross_exposure_rejects():
+    # 150% cap; existing positions at 140% of equity; a new 20% buy would
+    # push projected gross to 160%.
+    existing = [
+        {"symbol": "SPY", "market_value": 140_000.0},
+    ]
+    broker = FakeBroker(equity=100_000.0, positions=existing)
+    guard = PreTradeGuard(GuardLimits(max_gross_exposure=1.5), broker)
+    with pytest.raises(GuardViolation) as exc:
+        guard.check("QQQ", 100, "buy", limit_price=200.0)  # $20k
+    assert exc.value.reason == "max_gross_exposure"
+
+
+# ── 4. Max daily loss % (halt) ───────────────────────────────────────────────
+
+def test_max_daily_loss_halts(journal_db):
+    # Log a realised loss = -$6,000 today; cap 5% of $100k = $5k → any
+    # new order must be rejected.
+    trade_id = jt.log_entry(
+        ticker="AAPL", side="BUY", qty=10, price=100.0,
+        signal_source="test", regime="", notes="",
+    )
+    jt.log_exit(trade_id, price=40.0, pnl=-6000.0, exit_reason="stop", notes="")
+    broker = FakeBroker(equity=100_000.0)
+    guard = PreTradeGuard(GuardLimits(max_daily_loss_pct=0.05), broker)
+    with pytest.raises(GuardViolation) as exc:
+        guard.check("AAPL", 1, "buy", limit_price=100.0)
+    assert exc.value.reason == "max_daily_loss_pct"
+
+
+# ── 5. Max orders per day (accepted count only) ──────────────────────────────
+
+def test_max_orders_per_day_counts_accepted_only():
+    broker = FakeBroker()
+    guard = PreTradeGuard(
+        GuardLimits(
+            max_orders_per_day=3,
+            symbol_blocklist=frozenset({"BAD"}),
+        ),
+        broker,
+    )
+    # Three accepted orders succeed.
+    for _ in range(3):
+        guard.check("AAPL", 1, "buy")
+    # Fourth accepted-order attempt rejects.
+    with pytest.raises(GuardViolation) as exc:
+        guard.check("AAPL", 1, "buy")
+    assert exc.value.reason == "max_orders_per_day"
+
+    # Rejections do NOT increment the counter — reset the day and confirm
+    # blocklist rejections leave headroom.
+    fresh = PreTradeGuard(
+        GuardLimits(
+            max_orders_per_day=2,
+            symbol_blocklist=frozenset({"BAD"}),
+        ),
+        broker,
+    )
+    with pytest.raises(GuardViolation):
+        fresh.check("BAD", 1, "buy")  # rejected — does not count
+    with pytest.raises(GuardViolation):
+        fresh.check("BAD", 1, "buy")  # rejected — does not count
+    fresh.check("AAPL", 1, "buy")  # 1st accepted
+    fresh.check("AAPL", 1, "buy")  # 2nd accepted
+    with pytest.raises(GuardViolation) as exc2:
+        fresh.check("AAPL", 1, "buy")  # 3rd would exceed cap
+    assert exc2.value.reason == "max_orders_per_day"
+
+
+# ── 6. Kill-switch file ──────────────────────────────────────────────────────
+
+def test_killswitch_file_blocks(tmp_path: Path):
+    killswitch = tmp_path / "killswitch.flag"
+    killswitch.touch()
+    broker = FakeBroker()
+    guard = PreTradeGuard(GuardLimits(killswitch_path=killswitch), broker)
+    with pytest.raises(GuardViolation) as exc:
+        guard.check("AAPL", 1, "buy")
+    assert exc.value.reason == "killswitch"
+
+    # Remove the file → trading resumes.
+    killswitch.unlink()
+    guard.check("AAPL", 1, "buy")
+
+
+# ── 7. Default (all unset) — no restrictions ─────────────────────────────────
+
+def test_all_limits_unset_allows():
+    broker = FakeBroker()
+    guard = PreTradeGuard(GuardLimits(), broker)
+    # Any order passes; no exceptions.
+    for qty in (1, 10, 1_000_000):
+        guard.check("AAPL", qty, "buy", limit_price=100.0)
+
+
+# ── 8. from_env parses every documented variable ─────────────────────────────
+
+def test_from_env_parses(monkeypatch, tmp_path: Path):
+    ks_path = tmp_path / "ks"
+    monkeypatch.setenv("MAX_POSITION_PCT", "0.1")
+    monkeypatch.setenv("MAX_DAILY_LOSS_PCT", "0.03")
+    monkeypatch.setenv("MAX_GROSS_EXPOSURE", "1.8")
+    monkeypatch.setenv("MAX_ORDERS_PER_DAY", "25")
+    monkeypatch.setenv("SYMBOL_BLOCKLIST", "penny, meme ,spam")
+    monkeypatch.setenv("KILLSWITCH_FILE", str(ks_path))
+
+    limits = GuardLimits.from_env()
+    assert limits.max_position_pct == 0.1
+    assert limits.max_daily_loss_pct == 0.03
+    assert limits.max_gross_exposure == 1.8
+    assert limits.max_orders_per_day == 25
+    assert limits.symbol_blocklist == frozenset({"PENNY", "MEME", "SPAM"})
+    assert limits.killswitch_path == ks_path
+    assert limits.any_active() is True
+
+
+# ── 9. Day rollover resets the per-day counter ───────────────────────────────
+
+def test_day_rollover_resets_order_count():
+    broker = FakeBroker()
+    # Mutable clock so the test can advance the UTC day.
+    current = {"now": datetime(2026, 4, 19, 9, 0, tzinfo=timezone.utc)}
+
+    def _clock():
+        return current["now"]
+
+    guard = PreTradeGuard(
+        GuardLimits(max_orders_per_day=2),
+        broker,
+        clock=_clock,
+    )
+    guard.check("AAPL", 1, "buy")
+    guard.check("AAPL", 1, "buy")
+    with pytest.raises(GuardViolation):
+        guard.check("AAPL", 1, "buy")
+
+    # Advance to next UTC day — counter resets.
+    current["now"] = datetime(2026, 4, 20, 0, 5, tzinfo=timezone.utc)
+    guard.check("AAPL", 1, "buy")
+    guard.check("AAPL", 1, "buy")
+    with pytest.raises(GuardViolation) as exc:
+        guard.check("AAPL", 1, "buy")
+    assert exc.value.reason == "max_orders_per_day"


### PR DESCRIPTION
Recovers the pre-trade guard + kill-switch implementation from #139.

The original PR #163 was squash-merged before the implementation commit landed on the PR head — only the review record was captured. This PR applies the implementation commit (`96d9716`) cleanly on top of the current `main`.

## Summary

- `risk/pretrade_guard.py` — `PreTradeGuard` + `GuardLimits.from_env()` enforcing max position %, max daily loss %, max gross exposure, max orders/day, symbol block-list.
- Every broker adapter's `place_order()` now routes through the guard; on violation returns `{"status": "rejected", "reason": ...}` instead of raising.
- `.killswitch` file + SIGTERM handler installed by `cron/daily_ml_execute.py` and `scheduler/alerts.py`.
- `.env.example` + `.gitignore` updated.
- `tests/test_pretrade_guard.py` — 9 deterministic cases (network-free), all passing.

## Test plan

- [x] `pytest tests/test_pretrade_guard.py -v` — 9/9 pass (verified locally)
- [x] `pytest tests/ -m "not integration" --cov=. --cov-fail-under=76` — 1351 pass, coverage 76.28%
- [x] `ruff check .` — clean
- [x] `bandit -r . -ll` — 0 HIGH severity
- [x] `pip-audit` — no known vulns

Closes #139 (was not closed by the previous PR because the implementation did not land).

https://claude.ai/code/session_01WmG6mAtgV1nr1c9NPxBAD8