### PR TITLE
P1.3: bracket / OCO / trailing-stop orders (#141)

### DIFF
--- a/adapters/broker/alpaca_adapter.py
+++ b/adapters/broker/alpaca_adapter.py
@@ -82,6 +82,55 @@ class AlpacaBrokerAdapter:
             "filled_avg_price": order.filled_avg_price,
         }
 
+    def place_bracket(self, intent) -> dict:
+        """Route a bracket intent through the Alpaca bracket-order endpoint."""
+        try:
+            self._guard.check(
+                intent.symbol, intent.qty, intent.side, intent.limit_price,
+            )
+        except GuardViolation as violation:
+            logger.warning(
+                "pretrade_guard_reject symbol=%s qty=%s side=%s reason=%s",
+                intent.symbol, intent.qty, intent.side, violation.reason,
+            )
+            return {
+                "symbol": intent.symbol.upper(),
+                "qty": intent.qty,
+                "side": intent.side,
+                "status": "rejected",
+                "reason": violation.reason,
+            }
+
+        order = _bridge.place_bracket_order(
+            intent.symbol,
+            intent.qty,
+            intent.side,
+            take_profit=intent.take_profit,
+            stop_loss=intent.stop_loss,
+            trail_percent=intent.trail_percent,
+        )
+        if order is None:
+            return {
+                "status": "failed",
+                "symbol": intent.symbol.upper(),
+                "qty": intent.qty,
+                "side": intent.side,
+            }
+        return {
+            "order_id": order.order_id,
+            "symbol": order.ticker,
+            "qty": order.qty,
+            "side": order.side,
+            "order_type": order.order_type,
+            "status": order.status,
+            "filled_avg_price": order.filled_avg_price,
+            "children": {
+                "take_profit": intent.take_profit,
+                "stop_loss": intent.stop_loss,
+                "trail_percent": intent.trail_percent,
+            },
+        }
+
     def cancel_order(self, order_id: str) -> bool:
         # alpaca_bridge only exposes cancel_all; delegate and warn.
         logger.warning(

--- a/adapters/broker/ibkr_adapter.py
+++ b/adapters/broker/ibkr_adapter.py
@@ -73,6 +73,25 @@ class IBKRAdapter:
             }
         raise NotImplementedError("IBKRAdapter: full implementation pending Phase 2")
 
+    def place_bracket(self, intent) -> dict:
+        try:
+            self._guard.check(
+                intent.symbol, intent.qty, intent.side, intent.limit_price,
+            )
+        except GuardViolation as violation:
+            logger.warning(
+                "pretrade_guard_reject symbol=%s qty=%s side=%s reason=%s",
+                intent.symbol, intent.qty, intent.side, violation.reason,
+            )
+            return {
+                "symbol": intent.symbol.upper(),
+                "qty": intent.qty,
+                "side": intent.side,
+                "status": "rejected",
+                "reason": violation.reason,
+            }
+        raise NotImplementedError("IBKRAdapter: full implementation pending Phase 2")
+
     def cancel_order(self, order_id: str) -> bool:
         raise NotImplementedError("IBKRAdapter: full implementation pending Phase 2")
 

--- a/adapters/broker/paper_adapter.py
+++ b/adapters/broker/paper_adapter.py
@@ -131,6 +131,45 @@ class PaperBrokerAdapter:
             self._orders[order_id] = result
         return result
 
+    def place_bracket(self, intent) -> dict:
+        """Fill the parent leg and record the TP/SL/trail children."""
+        try:
+            self._guard.check(
+                intent.symbol, intent.qty, intent.side, intent.limit_price,
+            )
+        except GuardViolation as violation:
+            logger.warning(
+                "pretrade_guard_reject symbol=%s qty=%s side=%s reason=%s",
+                intent.symbol, intent.qty, intent.side, violation.reason,
+            )
+            return {
+                "symbol": intent.symbol.upper(),
+                "qty": intent.qty,
+                "side": intent.side,
+                "status": "rejected",
+                "reason": violation.reason,
+            }
+
+        price = intent.limit_price
+        if price is None:
+            try:
+                from data.fetcher import fetch_latest_price
+                info = fetch_latest_price(intent.symbol)
+                price = info.get("price") or 100.0
+            except Exception:
+                price = 100.0
+
+        from broker.paper_trader import place_bracket as _place
+        return _place(
+            intent.symbol,
+            intent.qty,
+            intent.side,
+            entry_price=price,
+            take_profit=intent.take_profit,
+            stop_loss=intent.stop_loss,
+            trail_percent=intent.trail_percent,
+        )
+
     def cancel_order(self, order_id: str) -> bool:
         # Paper orders fill immediately — nothing to cancel.
         logger.debug("PaperBrokerAdapter.cancel_order: paper orders fill instantly; no-op")

--- a/adapters/broker/schwab_adapter.py
+++ b/adapters/broker/schwab_adapter.py
@@ -71,6 +71,25 @@ class SchwabAdapter:
             }
         raise NotImplementedError("SchwabAdapter: full implementation pending Phase 2")
 
+    def place_bracket(self, intent) -> dict:
+        try:
+            self._guard.check(
+                intent.symbol, intent.qty, intent.side, intent.limit_price,
+            )
+        except GuardViolation as violation:
+            logger.warning(
+                "pretrade_guard_reject symbol=%s qty=%s side=%s reason=%s",
+                intent.symbol, intent.qty, intent.side, violation.reason,
+            )
+            return {
+                "symbol": intent.symbol.upper(),
+                "qty": intent.qty,
+                "side": intent.side,
+                "status": "rejected",
+                "reason": violation.reason,
+            }
+        raise NotImplementedError("SchwabAdapter: full implementation pending Phase 2")
+
     def cancel_order(self, order_id: str) -> bool:
         raise NotImplementedError("SchwabAdapter: full implementation pending Phase 2")
 

--- a/broker/alpaca_bridge.py
+++ b/broker/alpaca_bridge.py
@@ -125,6 +125,76 @@ def place_market_order(ticker: str, qty: float, side: str) -> Optional[AlpacaOrd
         return None
 
 
+def place_bracket_order(
+    ticker: str,
+    qty: float,
+    side: str,
+    take_profit: Optional[float] = None,
+    stop_loss: Optional[float] = None,
+    trail_percent: Optional[float] = None,
+) -> Optional[AlpacaOrder]:
+    """Place a market-entry bracket order with TP / SL or trailing-stop legs.
+
+    Alpaca native format — ``order_class: "bracket"`` carries ``take_profit``
+    and ``stop_loss`` sub-objects. Trailing stops piggyback on ``stop_loss``
+    via ``trail_percent`` when set in place of a fixed ``stop_price``.
+
+    Returns an :class:`AlpacaOrder` on success or ``None`` when the broker
+    is not configured / request fails.
+    """
+    if qty <= 0:
+        raise ValueError(f"qty must be positive, got {qty}")
+    if side not in ("buy", "sell"):
+        raise ValueError(f"side must be 'buy' or 'sell', got {side}")
+    if take_profit is None and stop_loss is None and trail_percent is None:
+        raise ValueError(
+            "place_bracket_order requires at least one of take_profit, "
+            "stop_loss, trail_percent"
+        )
+    if not _is_configured():
+        logger.warning("Alpaca not configured — bracket order not placed")
+        return None
+
+    payload: dict = {
+        "symbol": ticker.upper(),
+        "qty": str(qty),
+        "side": side,
+        "type": "market",
+        "time_in_force": "gtc",
+        "order_class": "bracket",
+    }
+    if take_profit is not None:
+        payload["take_profit"] = {"limit_price": str(take_profit)}
+    if trail_percent is not None:
+        payload["stop_loss"] = {"trail_percent": str(trail_percent * 100)}
+    elif stop_loss is not None:
+        payload["stop_loss"] = {"stop_price": str(stop_loss)}
+
+    try:
+        import requests
+        cfg = _get_config()
+        r = requests.post(
+            f"{cfg['base_url']}/v2/orders",
+            headers=_get_headers(),
+            json=payload,
+            timeout=10,
+        )
+        r.raise_for_status()
+        data = r.json()
+        return AlpacaOrder(
+            order_id=data.get("id", ""),
+            ticker=ticker,
+            qty=qty,
+            side=side,
+            order_type="bracket",
+            status=data.get("status", "unknown"),
+            filled_avg_price=data.get("filled_avg_price"),
+        )
+    except Exception as e:
+        logger.error("Alpaca place_bracket_order failed: %s", type(e).__name__)
+        return None
+
+
 def cancel_all_orders() -> bool:
     """Cancel all open orders. Returns True on success."""
     if not _is_configured():

--- a/broker/paper_trader.py
+++ b/broker/paper_trader.py
@@ -85,6 +85,28 @@ def init_paper_tables() -> None:
                 realised_pnl  REAL               -- NULL for buys
             )
         """)
+        # P1.3 — bracket / OCO / trailing-stop child orders. Parent fills
+        # immediately via buy()/sell(); this table tracks the pending
+        # take-profit / stop-loss / trailing-stop legs until check_brackets()
+        # fires them.
+        conn.execute("""
+            CREATE TABLE IF NOT EXISTS paper_bracket_orders (
+                id              INTEGER PRIMARY KEY AUTOINCREMENT,
+                parent_order_id TEXT    NOT NULL,
+                ticker          TEXT    NOT NULL,
+                parent_side     TEXT    NOT NULL,  -- BUY | SELL (the opened side)
+                shares          REAL    NOT NULL,
+                parent_price    REAL    NOT NULL,
+                take_profit     REAL,
+                stop_loss       REAL,
+                trail_percent   REAL,
+                peak_price      REAL,              -- running watermark for trailing stop
+                status          TEXT    NOT NULL,  -- pending | filled | cancelled
+                created_at      REAL    NOT NULL,
+                closed_at       REAL,
+                close_reason    TEXT               -- take_profit | stop_loss | trail | manual
+            )
+        """)
 
         # Seed account row if absent
         existing = conn.execute("SELECT id FROM paper_account WHERE id=1").fetchone()
@@ -554,3 +576,231 @@ def execute_algo(
         logger.warning("Failed to log execution analytics: %s", _log_exc)
 
     return result
+
+
+# ── P1.3 — bracket / OCO / trailing-stop simulation ──────────────────────────
+
+def place_bracket(
+    ticker: str,
+    shares: float,
+    side: str,
+    entry_price: float,
+    take_profit: Optional[float] = None,
+    stop_loss: Optional[float] = None,
+    trail_percent: Optional[float] = None,
+) -> dict:
+    """Fill a bracket-order parent and record the pending children.
+
+    The parent market leg is executed immediately via ``buy``/``sell`` so
+    the simulator behaves identically to a live bracket that fills
+    instantly. Children (TP / SL / trailing stop) stay pending in
+    ``paper_bracket_orders`` until :func:`check_brackets` evaluates them
+    against a current-price feed.
+    """
+    side_norm = side.lower().strip()
+    if side_norm not in ("buy", "sell"):
+        raise ValueError(f"side must be 'buy' or 'sell', got {side!r}")
+    if take_profit is None and stop_loss is None and trail_percent is None:
+        raise ValueError(
+            "place_bracket requires at least one of take_profit, "
+            "stop_loss, trail_percent"
+        )
+
+    # Fill the parent leg.
+    if side_norm == "buy":
+        parent = buy(ticker, shares, entry_price)
+    else:
+        parent = sell(ticker, shares, entry_price)
+
+    parent_order_id = f"paper-bracket-{int(time.time() * 1000)}"
+    now = time.time()
+
+    conn = get_connection()
+    try:
+        with conn:
+            cur = conn.execute(
+                """
+                INSERT INTO paper_bracket_orders (
+                    parent_order_id, ticker, parent_side, shares,
+                    parent_price, take_profit, stop_loss, trail_percent,
+                    peak_price, status, created_at
+                )
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'pending', ?)
+                """,
+                (
+                    parent_order_id,
+                    ticker.upper().strip(),
+                    side_norm.upper(),
+                    float(shares),
+                    float(entry_price),
+                    take_profit,
+                    stop_loss,
+                    trail_percent,
+                    float(entry_price),
+                    now,
+                ),
+            )
+            bracket_id = cur.lastrowid
+    finally:
+        conn.close()
+
+    logger.info(
+        "Paper bracket opened id=%d parent=%s side=%s tp=%s sl=%s trail=%s",
+        bracket_id, parent_order_id, side_norm, take_profit, stop_loss, trail_percent,
+    )
+
+    return {
+        "order_id": parent_order_id,
+        "bracket_id": bracket_id,
+        "ticker": ticker.upper().strip(),
+        "side": side_norm,
+        "qty": float(shares),
+        "status": "parent_filled",
+        "parent_fill": parent,
+        "children": {
+            "take_profit": take_profit,
+            "stop_loss": stop_loss,
+            "trail_percent": trail_percent,
+        },
+    }
+
+
+def _close_bracket(
+    conn,
+    row: sqlite3.Row,
+    reason: str,
+    fill_price: float,
+) -> dict:
+    """Internal: close an open bracket by flipping the parent side."""
+    closing_side = "sell" if row["parent_side"].lower() == "buy" else "buy"
+    if closing_side == "sell":
+        fill = sell(row["ticker"], row["shares"], fill_price)
+    else:
+        fill = buy(row["ticker"], row["shares"], fill_price)
+
+    conn.execute(
+        """
+        UPDATE paper_bracket_orders
+        SET status='filled', closed_at=?, close_reason=?
+        WHERE id=?
+        """,
+        (time.time(), reason, row["id"]),
+    )
+    return {
+        "bracket_id": row["id"],
+        "ticker": row["ticker"],
+        "shares": row["shares"],
+        "reason": reason,
+        "fill_price": fill_price,
+        "child_fill": fill,
+    }
+
+
+def check_brackets(current_prices: dict[str, float]) -> list[dict]:
+    """Evaluate every pending bracket against ``current_prices``.
+
+    Fires take-profit / stop-loss / trailing-stop children when triggered;
+    updates ``peak_price`` on trailing brackets on every tick. Returns a
+    list of filled child orders (empty when nothing fires).
+    """
+    conn = get_connection()
+    fires: list[dict] = []
+    try:
+        rows = conn.execute(
+            "SELECT * FROM paper_bracket_orders WHERE status='pending'"
+        ).fetchall()
+        for row in rows:
+            ticker = row["ticker"]
+            price = current_prices.get(ticker)
+            if price is None:
+                continue
+            price = float(price)
+
+            parent_side = row["parent_side"].lower()
+            tp = row["take_profit"]
+            sl = row["stop_loss"]
+            trail = row["trail_percent"]
+            peak = row["peak_price"] if row["peak_price"] is not None else row["parent_price"]
+
+            if parent_side == "buy":
+                # Long bracket — TP fires when price >= tp, SL / trail fire below.
+                if tp is not None and price >= float(tp):
+                    with conn:
+                        fires.append(_close_bracket(conn, row, "take_profit", price))
+                    continue
+                if sl is not None and price <= float(sl):
+                    with conn:
+                        fires.append(_close_bracket(conn, row, "stop_loss", price))
+                    continue
+                if trail is not None:
+                    new_peak = max(peak, price)
+                    if new_peak != peak:
+                        with conn:
+                            conn.execute(
+                                "UPDATE paper_bracket_orders SET peak_price=? WHERE id=?",
+                                (new_peak, row["id"]),
+                            )
+                        peak = new_peak
+                    trigger = peak * (1.0 - float(trail))
+                    if price <= trigger:
+                        with conn:
+                            fires.append(_close_bracket(conn, row, "trail", price))
+                        continue
+            else:
+                # Short bracket — TP fires when price <= tp, SL / trail above.
+                if tp is not None and price <= float(tp):
+                    with conn:
+                        fires.append(_close_bracket(conn, row, "take_profit", price))
+                    continue
+                if sl is not None and price >= float(sl):
+                    with conn:
+                        fires.append(_close_bracket(conn, row, "stop_loss", price))
+                    continue
+                if trail is not None:
+                    new_peak = min(peak, price)
+                    if new_peak != peak:
+                        with conn:
+                            conn.execute(
+                                "UPDATE paper_bracket_orders SET peak_price=? WHERE id=?",
+                                (new_peak, row["id"]),
+                            )
+                        peak = new_peak
+                    trigger = peak * (1.0 + float(trail))
+                    if price >= trigger:
+                        with conn:
+                            fires.append(_close_bracket(conn, row, "trail", price))
+                        continue
+    finally:
+        conn.close()
+    return fires
+
+
+def cancel_bracket(bracket_id: int) -> bool:
+    """Mark a pending bracket cancelled. Returns True when a row was updated."""
+    conn = get_connection()
+    try:
+        with conn:
+            cur = conn.execute(
+                """
+                UPDATE paper_bracket_orders
+                SET status='cancelled', closed_at=?, close_reason='manual'
+                WHERE id=? AND status='pending'
+                """,
+                (time.time(), bracket_id),
+            )
+            return cur.rowcount > 0
+    finally:
+        conn.close()
+
+
+def get_pending_brackets() -> list[dict]:
+    """Return every pending bracket row as a list of dicts."""
+    conn = get_connection()
+    try:
+        rows = conn.execute(
+            "SELECT * FROM paper_bracket_orders WHERE status='pending' "
+            "ORDER BY created_at ASC"
+        ).fetchall()
+        return [dict(r) for r in rows]
+    finally:
+        conn.close()

--- a/providers/broker.py
+++ b/providers/broker.py
@@ -11,7 +11,50 @@ ENV vars
 from __future__ import annotations
 
 import os
+from dataclasses import dataclass
 from typing import Optional, Protocol, runtime_checkable
+
+
+@dataclass(frozen=True)
+class OrderIntent:
+    """Declarative order payload supporting single-leg and bracket orders.
+
+    ``take_profit`` / ``stop_loss`` / ``trail_percent`` are optional.
+    At least one of them must be set for a bracket order; when all three
+    are ``None`` the intent collapses to an ordinary market/limit order.
+    """
+
+    symbol: str
+    qty: float
+    side: str                       # "buy" | "sell"
+    order_type: str = "market"      # "market" | "limit"
+    limit_price: Optional[float] = None
+    take_profit: Optional[float] = None
+    stop_loss: Optional[float] = None
+    trail_percent: Optional[float] = None
+
+    def is_bracket(self) -> bool:
+        return (
+            self.take_profit is not None
+            or self.stop_loss is not None
+            or self.trail_percent is not None
+        )
+
+    def __post_init__(self) -> None:
+        if self.qty <= 0:
+            raise ValueError(f"qty must be > 0, got {self.qty}")
+        if self.side.lower() not in ("buy", "sell"):
+            raise ValueError(f"side must be 'buy' or 'sell', got {self.side!r}")
+        if self.order_type.lower() not in ("market", "limit"):
+            raise ValueError(
+                f"order_type must be 'market' or 'limit', got {self.order_type!r}"
+            )
+        if self.order_type.lower() == "limit" and self.limit_price is None:
+            raise ValueError("limit_price is required when order_type='limit'")
+        if self.trail_percent is not None and self.trail_percent <= 0:
+            raise ValueError(
+                f"trail_percent must be > 0 when set, got {self.trail_percent}"
+            )
 
 
 @runtime_checkable
@@ -48,6 +91,16 @@ class BrokerProvider(Protocol):
         Returns
         -------
         dict with at least: order_id, status, symbol, qty, side
+        """
+        ...
+
+    def place_bracket(self, intent: OrderIntent) -> dict:
+        """Place a bracket order — parent fill plus take-profit / stop-loss /
+        trailing-stop children.
+
+        Returns a dict with at least: ``order_id``, ``status``, ``symbol``,
+        ``qty``, ``side`` plus ``children`` — a list of child-order dicts
+        describing the pending TP/SL/trail legs.
         """
         ...
 

--- a/tests/test_bracket_orders.py
+++ b/tests/test_bracket_orders.py
@@ -1,0 +1,169 @@
+"""
+tests/test_bracket_orders.py — tests for OrderIntent + paper bracket sim.
+
+Each case uses a temporary SQLite file via :func:`data.db._DB_PATH` and
+``PAPER_STARTING_CASH`` so nothing hits a shared DB or live broker.
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+import broker.paper_trader as pt
+import data.db as db_module
+from providers.broker import OrderIntent
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+@pytest.fixture
+def paper_db(tmp_path, monkeypatch):
+    monkeypatch.setattr(db_module, "_DB_PATH", str(tmp_path / "paper.db"))
+    monkeypatch.setattr(pt, "STARTING_CASH", 100_000.0)
+    monkeypatch.setattr(pt, "MAX_DRAWDOWN_PCT", 0.99)  # disable circuit breaker for tests
+    pt.init_paper_tables()
+    return tmp_path
+
+
+# ── OrderIntent validation ────────────────────────────────────────────────────
+
+def test_order_intent_rejects_non_positive_qty():
+    with pytest.raises(ValueError, match="qty"):
+        OrderIntent(symbol="AAPL", qty=0, side="buy")
+
+
+def test_order_intent_rejects_bad_side():
+    with pytest.raises(ValueError, match="side"):
+        OrderIntent(symbol="AAPL", qty=1, side="long")
+
+
+def test_order_intent_rejects_limit_without_price():
+    with pytest.raises(ValueError, match="limit_price"):
+        OrderIntent(symbol="AAPL", qty=1, side="buy", order_type="limit")
+
+
+def test_order_intent_is_bracket_flag():
+    plain = OrderIntent(symbol="AAPL", qty=1, side="buy")
+    assert plain.is_bracket() is False
+
+    tp_only = OrderIntent(symbol="AAPL", qty=1, side="buy", take_profit=100.0)
+    assert tp_only.is_bracket() is True
+
+    trail = OrderIntent(symbol="AAPL", qty=1, side="buy", trail_percent=0.02)
+    assert trail.is_bracket() is True
+
+
+def test_order_intent_rejects_non_positive_trail():
+    with pytest.raises(ValueError, match="trail_percent"):
+        OrderIntent(symbol="AAPL", qty=1, side="buy", trail_percent=0)
+
+
+# ── place_bracket parent fill ─────────────────────────────────────────────────
+
+def test_place_bracket_requires_at_least_one_child(paper_db):
+    with pytest.raises(ValueError, match="take_profit"):
+        pt.place_bracket("AAPL", shares=10, side="buy", entry_price=100.0)
+
+
+def test_place_bracket_fills_parent_and_records_pending(paper_db):
+    result = pt.place_bracket(
+        "AAPL", shares=10, side="buy", entry_price=100.0,
+        take_profit=110.0, stop_loss=95.0,
+    )
+    assert result["status"] == "parent_filled"
+    assert result["ticker"] == "AAPL"
+    assert result["qty"] == 10.0
+    # Parent leg actually debited cash and opened a position.
+    portfolio = pt.get_portfolio()
+    assert set(portfolio["Ticker"]) == {"AAPL"}
+    assert portfolio.iloc[0]["Shares"] == 10.0
+    # Child order recorded as pending.
+    pending = pt.get_pending_brackets()
+    assert len(pending) == 1
+    assert pending[0]["take_profit"] == 110.0
+    assert pending[0]["stop_loss"] == 95.0
+    assert pending[0]["status"] == "pending"
+
+
+# ── check_brackets: take-profit, stop-loss, trailing-stop ─────────────────────
+
+def test_check_brackets_fires_take_profit(paper_db):
+    pt.place_bracket(
+        "AAPL", shares=10, side="buy", entry_price=100.0,
+        take_profit=110.0, stop_loss=95.0,
+    )
+    fires = pt.check_brackets({"AAPL": 112.0})
+    assert len(fires) == 1
+    assert fires[0]["reason"] == "take_profit"
+    # Position closed.
+    assert pt.get_portfolio().empty
+    # No pending brackets remain.
+    assert pt.get_pending_brackets() == []
+
+
+def test_check_brackets_fires_stop_loss(paper_db):
+    pt.place_bracket(
+        "AAPL", shares=10, side="buy", entry_price=100.0,
+        take_profit=110.0, stop_loss=95.0,
+    )
+    fires = pt.check_brackets({"AAPL": 94.0})
+    assert len(fires) == 1
+    assert fires[0]["reason"] == "stop_loss"
+    assert pt.get_portfolio().empty
+
+
+def test_check_brackets_trailing_stop_tracks_peak(paper_db):
+    pt.place_bracket(
+        "AAPL", shares=10, side="buy", entry_price=100.0,
+        trail_percent=0.05,
+    )
+    # Tick up to $120 (peak). Trailing stop is now $120 * 0.95 = $114.
+    pt.check_brackets({"AAPL": 120.0})
+    fires = pt.check_brackets({"AAPL": 117.0})
+    assert fires == []  # still above trigger
+    fires = pt.check_brackets({"AAPL": 113.0})
+    assert len(fires) == 1
+    assert fires[0]["reason"] == "trail"
+
+
+def test_check_brackets_ignores_missing_prices(paper_db):
+    pt.place_bracket(
+        "AAPL", shares=10, side="buy", entry_price=100.0,
+        stop_loss=90.0,
+    )
+    fires = pt.check_brackets({"TSLA": 10.0})
+    assert fires == []
+    # Still pending.
+    assert len(pt.get_pending_brackets()) == 1
+
+
+# ── Short-side bracket (sell entry) ───────────────────────────────────────────
+
+def test_short_bracket_take_profit_triggers_on_downside(paper_db):
+    # Open a 5-share long first, then a bracket short closes it on TP.
+    pt.buy("AAPL", 5, 100.0)
+    pt.place_bracket(
+        "AAPL", shares=5, side="sell", entry_price=100.0,
+        take_profit=90.0, stop_loss=105.0,
+    )
+    fires = pt.check_brackets({"AAPL": 88.0})
+    assert len(fires) == 1
+    assert fires[0]["reason"] == "take_profit"
+
+
+# ── cancel_bracket ────────────────────────────────────────────────────────────
+
+def test_cancel_bracket_marks_pending_cancelled(paper_db):
+    result = pt.place_bracket(
+        "AAPL", shares=10, side="buy", entry_price=100.0,
+        stop_loss=90.0,
+    )
+    assert pt.cancel_bracket(result["bracket_id"]) is True
+    # Subsequent price ticks must not re-fire a cancelled bracket.
+    fires = pt.check_brackets({"AAPL": 85.0})
+    assert fires == []
+    # No pending rows left.
+    assert pt.get_pending_brackets() == []

--- a/tests/test_broker_adapters_bracket.py
+++ b/tests/test_broker_adapters_bracket.py
@@ -1,0 +1,256 @@
+"""
+tests/test_broker_adapters_bracket.py — adapter-layer wiring for P1.3.
+
+Covers PaperBrokerAdapter.place_bracket (happy path + guard reject) and
+the Alpaca bracket-order payload (mocks ``requests.post``). IBKR/Schwab
+stubs are sanity-checked for the guard-then-NotImplementedError flow.
+"""
+from __future__ import annotations
+
+import os
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+import broker.alpaca_bridge as alpaca_bridge
+import broker.paper_trader as pt
+import data.db as db_module
+from providers.broker import OrderIntent
+
+
+@pytest.fixture
+def paper_env(tmp_path, monkeypatch):
+    monkeypatch.setattr(db_module, "_DB_PATH", str(tmp_path / "paper.db"))
+    monkeypatch.setattr(pt, "STARTING_CASH", 100_000.0)
+    monkeypatch.setattr(pt, "MAX_DRAWDOWN_PCT", 0.99)
+    pt.init_paper_tables()
+    yield tmp_path
+
+
+# ── PaperBrokerAdapter.place_bracket ──────────────────────────────────────────
+
+def test_paper_adapter_place_bracket_happy_path(paper_env, monkeypatch):
+    monkeypatch.delenv("MAX_POSITION_PCT", raising=False)
+    from adapters.broker.paper_adapter import PaperBrokerAdapter
+
+    broker = PaperBrokerAdapter()
+    intent = OrderIntent(
+        symbol="AAPL", qty=5, side="buy",
+        limit_price=100.0, take_profit=110.0, stop_loss=95.0,
+    )
+    result = broker.place_bracket(intent)
+    assert result["status"] == "parent_filled"
+    assert result["ticker"] == "AAPL"
+    # Child recorded as pending.
+    assert len(pt.get_pending_brackets()) == 1
+
+
+def test_paper_adapter_place_bracket_guard_rejects(paper_env, monkeypatch):
+    # Symbol blocklist should stop the order before any fill.
+    monkeypatch.setenv("SYMBOL_BLOCKLIST", "AAPL")
+    from adapters.broker.paper_adapter import PaperBrokerAdapter
+
+    broker = PaperBrokerAdapter()
+    intent = OrderIntent(
+        symbol="AAPL", qty=5, side="buy",
+        limit_price=100.0, stop_loss=95.0,
+    )
+    result = broker.place_bracket(intent)
+    assert result["status"] == "rejected"
+    assert result["reason"] == "symbol_blocklist"
+    # No pending bracket created.
+    assert pt.get_pending_brackets() == []
+
+
+# ── AlpacaBrokerAdapter.place_bracket (bridge call mocked) ────────────────────
+
+def test_alpaca_adapter_place_bracket_passes_children_through(monkeypatch):
+    from adapters.broker.alpaca_adapter import AlpacaBrokerAdapter
+
+    captured: dict = {}
+
+    def _fake_place_bracket_order(ticker, qty, side, *, take_profit, stop_loss, trail_percent):
+        captured.update(
+            ticker=ticker, qty=qty, side=side,
+            take_profit=take_profit, stop_loss=stop_loss,
+            trail_percent=trail_percent,
+        )
+        return alpaca_bridge.AlpacaOrder(
+            order_id="abc", ticker=ticker, qty=qty, side=side,
+            order_type="bracket", status="accepted",
+        )
+
+    monkeypatch.setattr(alpaca_bridge, "place_bracket_order", _fake_place_bracket_order)
+    broker = AlpacaBrokerAdapter()
+    intent = OrderIntent(
+        symbol="AAPL", qty=10, side="buy",
+        take_profit=120.0, trail_percent=0.05,
+    )
+    result = broker.place_bracket(intent)
+    assert result["order_id"] == "abc"
+    assert result["status"] == "accepted"
+    assert result["children"]["take_profit"] == 120.0
+    assert result["children"]["trail_percent"] == 0.05
+    assert captured["take_profit"] == 120.0
+    assert captured["trail_percent"] == 0.05
+
+
+def test_alpaca_adapter_place_bracket_handles_bridge_failure(monkeypatch):
+    from adapters.broker.alpaca_adapter import AlpacaBrokerAdapter
+
+    monkeypatch.setattr(alpaca_bridge, "place_bracket_order", lambda *a, **kw: None)
+    broker = AlpacaBrokerAdapter()
+    intent = OrderIntent(symbol="AAPL", qty=10, side="buy", stop_loss=95.0)
+    result = broker.place_bracket(intent)
+    assert result["status"] == "failed"
+
+
+def test_alpaca_adapter_place_bracket_guard_rejects(monkeypatch):
+    monkeypatch.setenv("SYMBOL_BLOCKLIST", "AAPL")
+    from adapters.broker.alpaca_adapter import AlpacaBrokerAdapter
+
+    broker = AlpacaBrokerAdapter()
+    intent = OrderIntent(symbol="AAPL", qty=10, side="buy", stop_loss=95.0)
+    result = broker.place_bracket(intent)
+    assert result["status"] == "rejected"
+    assert result["reason"] == "symbol_blocklist"
+
+
+# ── Alpaca bridge place_bracket_order payload ─────────────────────────────────
+
+def test_alpaca_bridge_place_bracket_builds_payload(monkeypatch):
+    monkeypatch.setattr(alpaca_bridge, "ALPACA_API_KEY", "key")
+    monkeypatch.setattr(alpaca_bridge, "ALPACA_SECRET_KEY", "secret")
+    captured: dict = {}
+
+    class _FakeResponse:
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return {"id": "bracket-1", "status": "accepted"}
+
+    def _fake_post(url, headers=None, json=None, timeout=None):
+        captured["url"] = url
+        captured["json"] = json
+        return _FakeResponse()
+
+    fake_requests = SimpleNamespace(post=_fake_post)
+    monkeypatch.setitem(sys.modules, "requests", fake_requests)
+
+    order = alpaca_bridge.place_bracket_order(
+        "AAPL", qty=5, side="buy",
+        take_profit=110.0, stop_loss=95.0,
+    )
+    assert order is not None
+    assert order.order_id == "bracket-1"
+    payload = captured["json"]
+    assert payload["order_class"] == "bracket"
+    assert payload["take_profit"] == {"limit_price": "110.0"}
+    assert payload["stop_loss"] == {"stop_price": "95.0"}
+
+
+def test_alpaca_bridge_place_bracket_uses_trail_percent(monkeypatch):
+    monkeypatch.setattr(alpaca_bridge, "ALPACA_API_KEY", "key")
+    monkeypatch.setattr(alpaca_bridge, "ALPACA_SECRET_KEY", "secret")
+    captured: dict = {}
+
+    class _FakeResponse:
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return {"id": "bracket-2", "status": "accepted"}
+
+    def _fake_post(url, headers=None, json=None, timeout=None):
+        captured["json"] = json
+        return _FakeResponse()
+
+    monkeypatch.setitem(sys.modules, "requests", SimpleNamespace(post=_fake_post))
+    alpaca_bridge.place_bracket_order(
+        "AAPL", qty=5, side="buy",
+        take_profit=110.0, trail_percent=0.03,
+    )
+    # trail_percent takes precedence over stop_loss in the stop leg.
+    assert captured["json"]["stop_loss"] == {"trail_percent": "3.0"}
+
+
+def test_alpaca_bridge_place_bracket_requires_at_least_one_child():
+    with pytest.raises(ValueError, match="take_profit"):
+        alpaca_bridge.place_bracket_order("AAPL", qty=5, side="buy")
+
+
+def test_alpaca_bridge_place_bracket_rejects_bad_side():
+    with pytest.raises(ValueError, match="side"):
+        alpaca_bridge.place_bracket_order(
+            "AAPL", qty=5, side="hold", stop_loss=95.0,
+        )
+
+
+def test_alpaca_bridge_place_bracket_rejects_non_positive_qty():
+    with pytest.raises(ValueError, match="qty"):
+        alpaca_bridge.place_bracket_order(
+            "AAPL", qty=0, side="buy", stop_loss=95.0,
+        )
+
+
+def test_alpaca_bridge_place_bracket_not_configured(monkeypatch):
+    monkeypatch.setattr(alpaca_bridge, "ALPACA_API_KEY", "")
+    monkeypatch.setattr(alpaca_bridge, "ALPACA_SECRET_KEY", "")
+    monkeypatch.delenv("ALPACA_API_KEY", raising=False)
+    monkeypatch.delenv("ALPACA_SECRET_KEY", raising=False)
+    assert alpaca_bridge.place_bracket_order(
+        "AAPL", qty=5, side="buy", stop_loss=95.0,
+    ) is None
+
+
+# ── IBKR / Schwab stubs — guard precedes NotImplementedError ──────────────────
+
+def test_ibkr_adapter_place_bracket_guard_rejects(monkeypatch):
+    monkeypatch.setenv("SYMBOL_BLOCKLIST", "AAPL")
+    # Force the ibapi availability flag without actually importing ibapi.
+    import adapters.broker.ibkr_adapter as ibkr_mod
+
+    monkeypatch.setattr(ibkr_mod, "_IBAPI_AVAILABLE", True)
+    broker = ibkr_mod.IBKRAdapter()
+    intent = OrderIntent(symbol="AAPL", qty=5, side="buy", stop_loss=95.0)
+    result = broker.place_bracket(intent)
+    assert result["status"] == "rejected"
+    assert result["reason"] == "symbol_blocklist"
+
+
+def test_ibkr_adapter_place_bracket_not_implemented(monkeypatch):
+    import adapters.broker.ibkr_adapter as ibkr_mod
+
+    monkeypatch.setattr(ibkr_mod, "_IBAPI_AVAILABLE", True)
+    monkeypatch.delenv("SYMBOL_BLOCKLIST", raising=False)
+    broker = ibkr_mod.IBKRAdapter()
+    intent = OrderIntent(symbol="AAPL", qty=5, side="buy", stop_loss=95.0)
+    with pytest.raises(NotImplementedError):
+        broker.place_bracket(intent)
+
+
+def test_schwab_adapter_place_bracket_guard_rejects(monkeypatch):
+    monkeypatch.setenv("SYMBOL_BLOCKLIST", "AAPL")
+    import adapters.broker.schwab_adapter as schwab_mod
+
+    monkeypatch.setattr(schwab_mod, "_SCHWAB_AVAILABLE", True)
+    broker = schwab_mod.SchwabAdapter()
+    intent = OrderIntent(symbol="AAPL", qty=5, side="buy", stop_loss=95.0)
+    result = broker.place_bracket(intent)
+    assert result["status"] == "rejected"
+    assert result["reason"] == "symbol_blocklist"
+
+
+def test_schwab_adapter_place_bracket_not_implemented(monkeypatch):
+    import adapters.broker.schwab_adapter as schwab_mod
+
+    monkeypatch.setattr(schwab_mod, "_SCHWAB_AVAILABLE", True)
+    monkeypatch.delenv("SYMBOL_BLOCKLIST", raising=False)
+    broker = schwab_mod.SchwabAdapter()
+    intent = OrderIntent(symbol="AAPL", qty=5, side="buy", stop_loss=95.0)
+    with pytest.raises(NotImplementedError):
+        broker.place_bracket(intent)


### PR DESCRIPTION
Closes #141.

## Summary

P1.3 of the indie-quant roadmap. Adds bracket / OCO / trailing-stop support across every broker adapter.

- `providers/broker.py` — new `OrderIntent` dataclass (symbol, qty, side, order_type, limit_price, take_profit, stop_loss, trail_percent) plus `BrokerProvider.place_bracket(intent)` in the Protocol.
- `broker/paper_trader.py` — new `paper_bracket_orders` table, `place_bracket()`, `check_brackets(current_prices)`, `cancel_bracket()`, `get_pending_brackets()`. Parent leg fills immediately via `buy`/`sell`; children stay pending until a price tick triggers TP / SL / trailing-stop.
- `broker/alpaca_bridge.py` — new `place_bracket_order()` that builds Alpaca's native `order_class: "bracket"` payload; `trail_percent` overrides a fixed `stop_loss` on the stop leg.
- `adapters/broker/{paper,alpaca,ibkr,schwab}_adapter.py` — all four get `place_bracket()`. Paper / Alpaca are functional; IBKR / Schwab route through the pre-trade guard first then raise `NotImplementedError` (matches the existing `place_order` behaviour — full implementation lands with P2).
- Guard (#139) wraps every adapter's `place_bracket()` so bracket orders honour the same position / exposure / kill-switch limits.

## Test plan

- [x] `pytest tests/test_bracket_orders.py tests/test_broker_adapters_bracket.py -v` — 28 pass (verified locally)
- [x] `pytest tests/ -m "not integration" --cov=. --cov-fail-under=76` — 1391 pass, coverage 76.90%
- [x] `ruff check .` — clean
- [x] `bandit -r . -ll` — 0 HIGH severity
- [x] `pip-audit` — no known vulns
- [ ] Manual: paper-trade a bracket order, confirm `journal_trades.db` records the TP / SL fills

https://claude.ai/code/session_01WmG6mAtgV1nr1c9NPxBAD8