### PR TITLE
fix: polygon_backfill persists bars to price_cache

### DIFF
--- a/cron/polygon_backfill.py
+++ b/cron/polygon_backfill.py
@@ -4,21 +4,30 @@ cron/polygon_backfill.py — one-shot cache warmup against Polygon.io.
 Usage
 -----
     python -m cron.polygon_backfill [--tickers AAPL,SPY] [--timeframe 1Day]
-                                    [--days 365]
+                                    [--days 365] [--period 1y]
 
 Behaviour
 ---------
 Pulls ``--days`` of bars for each ticker at the requested ``--timeframe``
 resolution via :class:`adapters.market_data.polygon_adapter.PolygonAdapter`
-and stores them in the ``data/fetcher.py`` SQLite cache. Falls back
-silently when ``POLYGON_API_KEY`` is absent so the cron is safe to run
-on any host.
+and, for daily bars, persists them into the ``data/fetcher.py`` SQLite
+``price_cache`` table under ``(ticker, --period)``. Subsequent calls to
+:func:`data.fetcher.fetch_ohlcv(ticker, period)` will hit the cache without
+round-tripping yfinance.
+
+Non-daily timeframes (``5Min`` / ``1Hour`` / ...) are fetched and counted
+but not cached — the cache schema stores daily OHLCV keyed by yfinance
+period strings; intraday caching is a follow-up.
+
+Falls back silently when ``POLYGON_API_KEY`` is absent so the cron is safe
+to run on any host.
 
 ENV vars
 --------
     POLYGON_BACKFILL_TICKERS   comma-separated tickers (default: WF_TICKERS env or SPY,QQQ)
     POLYGON_BACKFILL_DAYS      history window in days (default: 365)
     POLYGON_BACKFILL_TIMEFRAME timeframe string (default: 1Day)
+    POLYGON_BACKFILL_PERIOD    cache-key period string (default: derived from --days)
 """
 from __future__ import annotations
 
@@ -34,6 +43,30 @@ logger = structlog.get_logger(__name__)
 DEFAULT_TIMEFRAME = "1Day"
 DEFAULT_DAYS = 365
 DEFAULT_TICKERS = "SPY,QQQ"
+
+# yfinance-style period strings in ascending order of coverage.
+_PERIOD_BUCKETS: tuple[tuple[int, str], ...] = (
+    (1,    "1d"),
+    (5,    "5d"),
+    (30,   "1mo"),
+    (90,   "3mo"),
+    (180,  "6mo"),
+    (365,  "1y"),
+    (730,  "2y"),
+    (1825, "5y"),
+)
+
+
+def _period_for_days(days: int) -> str:
+    """Pick the smallest yfinance period string that covers ``days``.
+
+    This keeps the cache key compatible with :func:`data.fetcher.fetch_ohlcv`
+    so a subsequent call with the same ``period`` argument hits the cache.
+    """
+    for threshold, label in _PERIOD_BUCKETS:
+        if days <= threshold:
+            return label
+    return "5y"
 
 
 def _default_ticker_list() -> str:
@@ -63,11 +96,53 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         type=int,
         default=int(os.environ.get("POLYGON_BACKFILL_DAYS", DEFAULT_DAYS)),
     )
+    parser.add_argument(
+        "--period",
+        default=os.environ.get("POLYGON_BACKFILL_PERIOD"),
+        help=(
+            "yfinance period string used as the cache key "
+            "(default: derived from --days). Must match the period later "
+            "passed to data.fetcher.fetch_ohlcv for a cache hit."
+        ),
+    )
     return parser
 
 
-def backfill(tickers: list[str], timeframe: str, days: int) -> dict:
-    """Pull bars for each ticker and return a per-ticker row-count dict.
+def _bars_to_dataframe(bars: list[dict]):
+    """Convert Polygon bar dicts to the cache's OHLCV DataFrame shape."""
+    import pandas as pd
+
+    if not bars:
+        return pd.DataFrame(columns=["Open", "High", "Low", "Close", "Volume"])
+    rows = []
+    idx = []
+    for bar in bars:
+        t_ms = bar.get("t")
+        if t_ms is None:
+            continue
+        ts = pd.Timestamp(int(t_ms), unit="ms", tz="UTC").tz_convert(None)
+        idx.append(ts)
+        rows.append(
+            {
+                "Open": bar.get("o"),
+                "High": bar.get("h"),
+                "Low": bar.get("l"),
+                "Close": bar.get("c"),
+                "Volume": bar.get("v"),
+            }
+        )
+    df = pd.DataFrame(rows, index=pd.DatetimeIndex(idx))
+    df = df.dropna(subset=["Close"])
+    return df
+
+
+def backfill(
+    tickers: list[str],
+    timeframe: str,
+    days: int,
+    period: str | None = None,
+) -> dict:
+    """Pull bars for each ticker, cache the daily ones, and return counts.
 
     Returns an empty dict when ``POLYGON_API_KEY`` is not set so callers can
     run this cron unconditionally and no-op in local dev.
@@ -77,6 +152,12 @@ def backfill(tickers: list[str], timeframe: str, days: int) -> dict:
         return {}
 
     from adapters.market_data.polygon_adapter import PolygonAdapter
+    from data.db import init_db
+    from data.fetcher import _cache_write
+
+    init_db()  # ensure price_cache table exists before we upsert
+    cache_period = period or _period_for_days(days)
+    cacheable = timeframe.strip() == "1Day"
 
     end = date.today()
     start = end - timedelta(days=days)
@@ -99,13 +180,29 @@ def backfill(tickers: list[str], timeframe: str, days: int) -> dict:
             )
             counts[ticker] = 0
             continue
+
         counts[ticker] = len(bars)
+        cache_hit = False
+        if cacheable and bars:
+            try:
+                df = _bars_to_dataframe(bars)
+                if not df.empty:
+                    _cache_write(ticker, cache_period, df)
+                    cache_hit = True
+            except Exception as exc:
+                logger.warning(
+                    "polygon_backfill: cache write failed",
+                    ticker=ticker,
+                    error=str(exc),
+                )
         logger.info(
             "polygon_backfill: pulled",
             ticker=ticker,
             bars=len(bars),
             start=start_s,
             end=end_s,
+            cache_period=cache_period if cacheable else None,
+            cached=cache_hit,
         )
     return counts
 
@@ -113,7 +210,7 @@ def backfill(tickers: list[str], timeframe: str, days: int) -> dict:
 def main(argv: list[str] | None = None) -> int:
     args = _build_arg_parser().parse_args(argv)
     tickers = [t.strip() for t in args.tickers.split(",") if t.strip()]
-    counts = backfill(tickers, args.timeframe, args.days)
+    counts = backfill(tickers, args.timeframe, args.days, period=args.period)
     if not counts:
         logger.info("polygon_backfill: nothing to do")
         return 0

--- a/tests/test_polygon_backfill.py
+++ b/tests/test_polygon_backfill.py
@@ -1,16 +1,27 @@
 """
 tests/test_polygon_backfill.py — tests for cron/polygon_backfill.py.
 
-Monkeypatches :class:`PolygonAdapter` so no HTTP calls fire.
+Monkeypatches :class:`PolygonAdapter` so no HTTP calls fire. Cache writes
+go into a per-test temp SQLite file via ``data.db._DB_PATH``.
 """
 from __future__ import annotations
 
 import os
 import sys
 
+import pytest
+
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
 import cron.polygon_backfill as backfill
+import data.db as db_module
+
+
+def _cache_read(ticker: str, period: str):
+    """Lazy-import to avoid yfinance at collect time (optional local dep)."""
+    from data.fetcher import _cache_read as real
+
+    return real(ticker, period)
 
 
 class _FakeAdapter:
@@ -21,8 +32,19 @@ class _FakeAdapter:
         self.calls.append((symbol, timeframe, start, end))
         if symbol == "FAIL":
             raise RuntimeError("boom")
-        # Return a couple of mock bars.
-        return [{"t": 0, "o": 1, "h": 2, "l": 0.5, "c": 1.5, "v": 10}] * 3
+        # Return a couple of mock bars at one-day intervals.
+        return [
+            {"t": 1_700_000_000_000, "o": 1, "h": 2, "l": 0.5, "c": 1.5, "v": 10},
+            {"t": 1_700_086_400_000, "o": 1.5, "h": 2.5, "l": 1.0, "c": 2.0, "v": 20},
+            {"t": 1_700_172_800_000, "o": 2.0, "h": 3.0, "l": 1.5, "c": 2.5, "v": 30},
+        ]
+
+
+@pytest.fixture
+def temp_db(tmp_path, monkeypatch):
+    """Point data.db._DB_PATH at a per-test SQLite file."""
+    monkeypatch.setattr(db_module, "_DB_PATH", str(tmp_path / "quant.db"))
+    return tmp_path
 
 
 def test_backfill_no_api_key_returns_empty(monkeypatch):
@@ -30,7 +52,7 @@ def test_backfill_no_api_key_returns_empty(monkeypatch):
     assert backfill.backfill(["AAPL"], "1Day", 30) == {}
 
 
-def test_backfill_calls_adapter_for_each_ticker(monkeypatch):
+def test_backfill_calls_adapter_for_each_ticker(monkeypatch, temp_db):
     monkeypatch.setenv("POLYGON_API_KEY", "key")
     fake = _FakeAdapter()
     monkeypatch.setattr(
@@ -44,7 +66,7 @@ def test_backfill_calls_adapter_for_each_ticker(monkeypatch):
     assert fake.calls[0][0] == "AAPL"
 
 
-def test_backfill_swallows_per_ticker_errors(monkeypatch):
+def test_backfill_swallows_per_ticker_errors(monkeypatch, temp_db):
     monkeypatch.setenv("POLYGON_API_KEY", "key")
     fake = _FakeAdapter()
     monkeypatch.setattr(
@@ -61,7 +83,7 @@ def test_main_exits_zero_when_no_api_key(monkeypatch):
     assert rc == 0
 
 
-def test_main_runs_happy_path(monkeypatch):
+def test_main_runs_happy_path(monkeypatch, temp_db):
     monkeypatch.setenv("POLYGON_API_KEY", "key")
     fake = _FakeAdapter()
     monkeypatch.setattr(
@@ -71,3 +93,69 @@ def test_main_runs_happy_path(monkeypatch):
     rc = backfill.main(["--tickers", "AAPL,SPY", "--days", "5", "--timeframe", "1Day"])
     assert rc == 0
     assert {c[0] for c in fake.calls} == {"AAPL", "SPY"}
+
+
+# ── Cache write integration ──────────────────────────────────────────────────
+
+def test_backfill_writes_to_cache_for_daily(monkeypatch, temp_db):
+    monkeypatch.setenv("POLYGON_API_KEY", "key")
+    fake = _FakeAdapter()
+    monkeypatch.setattr(
+        "adapters.market_data.polygon_adapter.PolygonAdapter",
+        lambda: fake,
+    )
+    counts = backfill.backfill(["AAPL"], "1Day", days=30, period="1mo")
+    assert counts == {"AAPL": 3}
+
+    # A subsequent read of the same (ticker, period) must now hit the cache.
+    cached = _cache_read("AAPL", "1mo")
+    assert cached is not None
+    assert not cached.empty
+    assert list(cached.columns) == ["Open", "High", "Low", "Close", "Volume"]
+    assert len(cached) == 3
+
+
+def test_backfill_skips_cache_for_intraday(monkeypatch, temp_db):
+    monkeypatch.setenv("POLYGON_API_KEY", "key")
+    fake = _FakeAdapter()
+    monkeypatch.setattr(
+        "adapters.market_data.polygon_adapter.PolygonAdapter",
+        lambda: fake,
+    )
+    counts = backfill.backfill(["AAPL"], "5Min", days=5)
+    assert counts == {"AAPL": 3}
+    # Non-daily timeframes are counted but not cached.
+    assert _cache_read("AAPL", "5d") is None
+
+
+def test_backfill_period_falls_back_to_days_mapping(monkeypatch, temp_db):
+    monkeypatch.setenv("POLYGON_API_KEY", "key")
+    fake = _FakeAdapter()
+    monkeypatch.setattr(
+        "adapters.market_data.polygon_adapter.PolygonAdapter",
+        lambda: fake,
+    )
+    backfill.backfill(["AAPL"], "1Day", days=365)
+    # 365 days → "1y" bucket.
+    assert _cache_read("AAPL", "1y") is not None
+
+
+# ── Period-bucket helper ─────────────────────────────────────────────────────
+
+@pytest.mark.parametrize(
+    ("days", "expected"),
+    [
+        (1, "1d"),
+        (4, "5d"),
+        (7, "1mo"),
+        (45, "3mo"),
+        (120, "6mo"),
+        (300, "1y"),
+        (500, "2y"),
+        (1500, "5y"),
+        (10000, "5y"),
+    ],
+)
+def test_period_for_days(days, expected):
+    assert backfill._period_for_days(days) == expected
+


### PR DESCRIPTION
Follow-up fix on #168.

## Summary

`cron/polygon_backfill.py` was fetching bars from Polygon and logging row counts but **not persisting** them into the `price_cache` table — so a later `data.fetcher.fetch_ohlcv(ticker, period)` call still hit yfinance on a miss. This PR wires the backfill directly into the existing SQLite cache.

- `cron/polygon_backfill.py`
  - New `--period` arg (default derived from `--days` via the new `_period_for_days` helper → `1d` / `5d` / `1mo` / `3mo` / `6mo` / `1y` / `2y` / `5y`). Matches the cache key `data.fetcher.fetch_ohlcv` uses.
  - New `_bars_to_dataframe` converts Polygon bar dicts (`t`/`o`/`h`/`l`/`c`/`v`) to the cache's OHLCV DataFrame shape (UTC `DatetimeIndex`, `Open`/`High`/`Low`/`Close`/`Volume` columns).
  - Daily timeframes (`1Day`) now go through `data.fetcher._cache_write(ticker, period, df)`. Intraday (`5Min`, `1Hour`, ...) stays fetch-and-count until a schema update adds an intraday cache.
- `tests/test_polygon_backfill.py`
  - +5 cases: daily → cache hit, intraday → no cache write, days-only → bucket fallback, parametrised `_period_for_days`, plus a fixture pointing `data.db._DB_PATH` at a temp SQLite file per test.

## Test plan

- [x] `pytest tests/test_polygon_backfill.py -v` — 17/17 pass (verified locally)
- [x] `pytest tests/ -m "not integration" --cov=. --cov-fail-under=76` — 1419 pass, coverage 77.16%
- [x] `ruff check .` — clean
- [x] `bandit -r . -ll` — 0 HIGH severity
- [x] `pip-audit` — no known vulns

Addresses the concern flagged during Phase-1 review that the Polygon backfill wasn't actually caching anything.

https://claude.ai/code/session_01WmG6mAtgV1nr1c9NPxBAD8