### PR TITLE
P1.6: monthly retrain logs to MLflow registry (#144)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,13 @@ ALPACA_BASE_URL=https://paper-api.alpaca.markets
 # Set MARKET_DATA_PROVIDER=polygon to route OHLCV reads through Polygon.
 POLYGON_API_KEY=your_polygon_api_key_here
 
+# Model registry (#144) — MLflow logs each monthly retrain checkpoint +
+# IC metrics. Opt-out with MODEL_REGISTRY_ENABLED=0 for offline dev.
+# MODEL_REGISTRY_PROVIDER=mlflow       # mlflow | mock (default: mlflow)
+# MODEL_REGISTRY_ENABLED=1             # monthly_ml_retrain calls registry.log_model
+# MLFLOW_TRACKING_URI=http://localhost:5000  # via docker-compose sidecar
+# MLFLOW_REGISTERED_MODEL=lgbm_alpha   # overrides registered-model name
+
 # TSDB hot path (#143) — swap data/fetcher's bulk-read cache from SQLite
 # JSON blobs to DuckDB's columnar storage. Leave unset (default=sqlite)
 # for single-ticker work; set to duckdb for walk-forward / multi-ticker

--- a/cron/monthly_ml_retrain.py
+++ b/cron/monthly_ml_retrain.py
@@ -1,23 +1,29 @@
 """
 Monthly ML model retraining cron job.
 
-Retrains the LightGBM alpha model on the configured ticker universe and saves
-a fresh checkpoint to the path specified by LGBM_ALPHA_MODEL_PATH.
+Retrains the LightGBM alpha model on the configured ticker universe, saves
+a fresh checkpoint to the path specified by ``LGBM_ALPHA_MODEL_PATH``, and
+(optionally) logs the checkpoint + IC metrics to the MLflow tracking
+registry via :func:`providers.model_registry.get_model_registry`.
 
 Run manually:
-    python -m cron.monthly_ml_retrain
+    python -m cron.monthly_ml_retrain [--log-to-mlflow | --no-log-to-mlflow]
 
 Schedule (runs after monthly walk-forward at 06:00):
     0 7 1 * * cd /path/to/quant-platform && .venv/bin/python -m cron.monthly_ml_retrain
 
 ENV vars
 -------
-    WF_TICKERS           Comma-separated tickers (default: SPY,QQQ,AAPL,MSFT,TSLA)
-    ML_TRAIN_PERIOD      yfinance period string for training data (default: 2y)
+    WF_TICKERS             Comma-separated tickers (default: SPY,QQQ,AAPL,MSFT,TSLA)
+    ML_TRAIN_PERIOD        yfinance period string for training data (default: 2y)
     LGBM_ALPHA_MODEL_PATH  Checkpoint path (default: models/lgbm_alpha.pkl)
+    MODEL_REGISTRY_ENABLED 0 | 1 — opt in to the MLflow log step (default: 1)
+    MLFLOW_REGISTERED_MODEL name under which the run is registered
+                            (default: lgbm_alpha)
 """
 from __future__ import annotations
 
+import argparse
 import os
 import sys
 
@@ -27,14 +33,111 @@ from utils.logger import get_logger
 log = get_logger("cron.monthly_ml_retrain")
 
 DEFAULT_TICKERS = "SPY,QQQ,AAPL,MSFT,TSLA"
+_REGISTERED_MODEL_DEFAULT = "lgbm_alpha"
 
 
-def main() -> None:
+def _build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="cron.monthly_ml_retrain",
+        description="Monthly retrain of the LightGBM alpha model.",
+    )
+    parser.add_argument(
+        "--log-to-mlflow",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help=(
+            "Log the fresh checkpoint + IC metrics to MLflow after training. "
+            "When unset, falls back to MODEL_REGISTRY_ENABLED (default: on). "
+            "Disable with --no-log-to-mlflow for dry runs / offline dev."
+        ),
+    )
+    return parser
+
+
+def _resolve_registry_flag(flag: bool | None) -> bool:
+    if flag is not None:
+        return flag
+    raw = os.environ.get("MODEL_REGISTRY_ENABLED", "1").strip().lower()
+    return raw in ("1", "true", "yes", "on")
+
+
+def _log_to_registry(model_path: str, train_result: dict, tickers: list[str], period: str) -> str | None:
+    """Best-effort MLflow log. Returns the run_id on success, ``None`` otherwise.
+
+    Any exception here is swallowed with a warning so a broken registry
+    never halts the nightly retrain — the local checkpoint has already
+    been written at this point.
+    """
+    try:
+        from providers.model_registry import get_model_registry
+
+        registry = get_model_registry()
+    except Exception as exc:
+        log.warning("ml_retrain: model_registry unavailable", error=str(exc))
+        return None
+
+    registered_name = os.environ.get(
+        "MLFLOW_REGISTERED_MODEL", _REGISTERED_MODEL_DEFAULT,
+    )
+    metrics = {
+        "train_ic":   float(train_result.get("train_ic", 0.0) or 0.0),
+        "test_ic":    float(train_result.get("test_ic", 0.0) or 0.0),
+        "train_icir": float(train_result.get("train_icir", 0.0) or 0.0),
+        "test_icir":  float(train_result.get("test_icir", 0.0) or 0.0),
+        "n_train":    float(train_result.get("n_train_samples", 0) or 0),
+        "n_test":     float(train_result.get("n_test_samples", 0) or 0),
+    }
+    tags = {
+        "model_name": registered_name,
+        "period": period,
+        "n_tickers": str(len(tickers)),
+        "tickers": ",".join(tickers),
+        "source": "cron.monthly_ml_retrain",
+    }
+    try:
+        run_id = registry.log_model(
+            run_name=f"{registered_name}_retrain",
+            model_path=model_path,
+            metrics=metrics,
+            tags=tags,
+        )
+    except Exception as exc:
+        log.warning("ml_retrain: registry.log_model failed", error=str(exc))
+        return None
+
+    if not run_id:
+        log.info("ml_retrain: registry logged nothing (adapter returned empty run_id)")
+        return None
+
+    # Best-effort promotion: every successful retrain moves the new version
+    # into `Staging`. Operators manually promote to `Production`.
+    try:
+        registry.promote(registered_name, run_id, "Staging")
+    except Exception as exc:
+        log.warning("ml_retrain: registry.promote failed", error=str(exc))
+
+    log.info(
+        "ml_retrain: mlflow logged",
+        run_id=run_id,
+        registered_model=registered_name,
+        **{k: round(v, 4) for k, v in metrics.items() if isinstance(v, float)},
+    )
+    return run_id
+
+
+def main(argv: list[str] | None = None) -> None:
+    args = _build_arg_parser().parse_args(argv)
+    log_to_registry = _resolve_registry_flag(args.log_to_mlflow)
+
     tickers_str = os.environ.get("WF_TICKERS", DEFAULT_TICKERS)
     tickers = [t.strip() for t in tickers_str.split(",") if t.strip()]
     period = os.environ.get("ML_TRAIN_PERIOD", "2y")
 
-    log.info("ml_retrain: starting", n_tickers=len(tickers), period=period)
+    log.info(
+        "ml_retrain: starting",
+        n_tickers=len(tickers), period=period,
+        log_to_registry=log_to_registry,
+    )
 
     try:
         if not _LGBM_AVAILABLE:
@@ -50,7 +153,8 @@ def main() -> None:
         else:
             log.info("ml_retrain: no tuned params found, using defaults")
 
-        result = MLSignal().train(tickers, period=period, lgbm_params=best_params)
+        signal = MLSignal()
+        result = signal.train(tickers, period=period, lgbm_params=best_params)
 
         log.info(
             "ml_retrain: complete",
@@ -61,6 +165,9 @@ def main() -> None:
             n_train=result["n_train_samples"],
             n_test=result["n_test_samples"],
         )
+
+        if log_to_registry:
+            _log_to_registry(signal._model_path, result, tickers, period)
 
     except RuntimeError as exc:
         log.error("ml_retrain: runtime error", error=str(exc))

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,3 +61,19 @@ services:
     restart: unless-stopped
     depends_on:
       - prometheus
+
+  mlflow:
+    image: ghcr.io/mlflow/mlflow:v2.22.1
+    ports:
+      - "5000:5000"
+    command: >
+      mlflow server
+      --host 0.0.0.0
+      --port 5000
+      --backend-store-uri sqlite:///mlruns/mlflow.db
+      --default-artifact-root /mlruns/artifacts
+    volumes:
+      - ./mlruns:/mlruns
+    environment:
+      MLFLOW_TRACKING_URI: http://mlflow:5000
+    restart: unless-stopped

--- a/tests/test_monthly_ml_retrain.py
+++ b/tests/test_monthly_ml_retrain.py
@@ -30,7 +30,7 @@ def test_main_calls_train_with_default_tickers(mock_cls):
     mock_cls.return_value = mock_instance
 
     from cron.monthly_ml_retrain import main
-    main()
+    main([])
 
     mock_instance.train.assert_called_once()
     call_args = mock_instance.train.call_args
@@ -53,7 +53,7 @@ def test_main_respects_wf_tickers_env(mock_cls, monkeypatch=None):
         # Reload to pick up fresh env; call main directly with patched env
         with patch.dict(os.environ, {"WF_TICKERS": "SPY,GLD,TLT"}):
             # Call main which reads the env var at runtime
-            mod.main()
+            mod.main([])
         call_args = mock_instance.train.call_args
         tickers = call_args[0][0]
         assert "SPY" in tickers
@@ -72,7 +72,7 @@ def test_main_uses_ml_train_period_env(mock_cls):
 
     with patch.dict(os.environ, {"ML_TRAIN_PERIOD": "1y"}):
         from cron.monthly_ml_retrain import main
-        main()
+        main([])
 
     call_kwargs = mock_instance.train.call_args[1]
     assert call_kwargs.get("period") == "1y"
@@ -82,7 +82,7 @@ def test_main_uses_ml_train_period_env(mock_cls):
 def test_main_exits_when_lgbm_unavailable():
     from cron.monthly_ml_retrain import main
     with pytest.raises(SystemExit) as exc_info:
-        main()
+        main([])
     assert exc_info.value.code == 1
 
 
@@ -95,7 +95,7 @@ def test_main_exits_on_runtime_error(mock_cls):
 
     from cron.monthly_ml_retrain import main
     with pytest.raises(SystemExit) as exc_info:
-        main()
+        main([])
     assert exc_info.value.code == 1
 
 
@@ -108,7 +108,7 @@ def test_main_exits_on_unexpected_exception(mock_cls):
 
     from cron.monthly_ml_retrain import main
     with pytest.raises(SystemExit) as exc_info:
-        main()
+        main([])
     assert exc_info.value.code == 1
 
 
@@ -124,7 +124,7 @@ def test_main_passes_tuned_params_when_available(mock_cls, mock_load):
     mock_cls.return_value = mock_instance
 
     from cron.monthly_ml_retrain import main
-    main()
+    main([])
 
     call_kwargs = mock_instance.train.call_args[1]
     assert call_kwargs.get("lgbm_params") == tuned
@@ -140,7 +140,7 @@ def test_main_passes_none_when_no_tuned_params(mock_cls, mock_load):
     mock_cls.return_value = mock_instance
 
     from cron.monthly_ml_retrain import main
-    main()
+    main([])
 
     call_kwargs = mock_instance.train.call_args[1]
     assert call_kwargs.get("lgbm_params") is None
@@ -155,7 +155,7 @@ def test_main_strips_whitespace_from_tickers(mock_cls):
 
     with patch.dict(os.environ, {"WF_TICKERS": " AAPL , MSFT , TSLA "}):
         from cron.monthly_ml_retrain import main
-        main()
+        main([])
 
     tickers = mock_instance.train.call_args[0][0]
     assert "AAPL" in tickers

--- a/tests/test_monthly_ml_retrain_mlflow.py
+++ b/tests/test_monthly_ml_retrain_mlflow.py
@@ -1,0 +1,165 @@
+"""
+tests/test_monthly_ml_retrain_mlflow.py — MLflow wiring in monthly_ml_retrain.
+
+Mocks :func:`providers.model_registry.get_model_registry` to verify the
+cron logs IC metrics and tags at the documented shape without requiring
+mlflow to be installed.
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+import cron.monthly_ml_retrain as retrain
+
+
+class _FakeRegistry:
+    def __init__(self) -> None:
+        self.logged: list[dict] = []
+        self.promoted: list[tuple[str, str, str]] = []
+
+    def log_model(self, run_name, model_path, metrics, tags=None):
+        self.logged.append(
+            {
+                "run_name": run_name,
+                "model_path": model_path,
+                "metrics": dict(metrics),
+                "tags": dict(tags or {}),
+            }
+        )
+        return "run-42"
+
+    def promote(self, model_name, run_id, stage):
+        self.promoted.append((model_name, run_id, stage))
+
+
+@pytest.fixture
+def fake_result() -> dict:
+    return {
+        "train_ic":   0.051,
+        "test_ic":    0.043,
+        "train_icir": 0.9,
+        "test_icir":  0.72,
+        "n_train_samples": 1234,
+        "n_test_samples":   567,
+    }
+
+
+def _fake_registry_factory(fake: _FakeRegistry):
+    import providers.model_registry as pmr
+
+    return pmr, fake
+
+
+# ── Flag resolution ─────────────────────────────────────────────────────────
+
+def test_resolve_flag_cli_wins_over_env(monkeypatch):
+    monkeypatch.setenv("MODEL_REGISTRY_ENABLED", "0")
+    assert retrain._resolve_registry_flag(True) is True
+
+
+def test_resolve_flag_env_default_on(monkeypatch):
+    monkeypatch.delenv("MODEL_REGISTRY_ENABLED", raising=False)
+    assert retrain._resolve_registry_flag(None) is True
+
+
+@pytest.mark.parametrize("raw", ["0", "false", "no", "off"])
+def test_resolve_flag_env_disables(monkeypatch, raw):
+    monkeypatch.setenv("MODEL_REGISTRY_ENABLED", raw)
+    assert retrain._resolve_registry_flag(None) is False
+
+
+# ── _log_to_registry happy path ─────────────────────────────────────────────
+
+def test_log_to_registry_happy_path(monkeypatch, fake_result):
+    fake = _FakeRegistry()
+    monkeypatch.setattr(
+        "providers.model_registry.get_model_registry", lambda: fake,
+    )
+    monkeypatch.setenv("MLFLOW_REGISTERED_MODEL", "lgbm_alpha_test")
+
+    run_id = retrain._log_to_registry(
+        model_path="/tmp/model.pkl",
+        train_result=fake_result,
+        tickers=["SPY", "QQQ"],
+        period="2y",
+    )
+    assert run_id == "run-42"
+    assert len(fake.logged) == 1
+    logged = fake.logged[0]
+    assert logged["run_name"] == "lgbm_alpha_test_retrain"
+    assert logged["model_path"] == "/tmp/model.pkl"
+    assert logged["metrics"]["train_ic"] == pytest.approx(0.051)
+    assert logged["metrics"]["test_ic"] == pytest.approx(0.043)
+    assert logged["metrics"]["n_train"] == 1234
+    assert logged["tags"]["model_name"] == "lgbm_alpha_test"
+    assert logged["tags"]["period"] == "2y"
+    assert logged["tags"]["n_tickers"] == "2"
+    assert logged["tags"]["tickers"] == "SPY,QQQ"
+    assert logged["tags"]["source"] == "cron.monthly_ml_retrain"
+    assert fake.promoted == [("lgbm_alpha_test", "run-42", "Staging")]
+
+
+def test_log_to_registry_empty_run_id_is_noop(monkeypatch, fake_result):
+    class _Silent(_FakeRegistry):
+        def log_model(self, *args, **kwargs):
+            super().log_model(*args, **kwargs)
+            return ""  # MLflow adapter returns empty when mlflow missing
+
+    fake = _Silent()
+    monkeypatch.setattr(
+        "providers.model_registry.get_model_registry", lambda: fake,
+    )
+    assert (
+        retrain._log_to_registry("/tmp/m.pkl", fake_result, ["SPY"], "1y") is None
+    )
+    # log_model was still called; promote was not.
+    assert len(fake.logged) == 1
+    assert fake.promoted == []
+
+
+def test_log_to_registry_swallows_log_model_exception(monkeypatch, fake_result):
+    class _Broken(_FakeRegistry):
+        def log_model(self, *args, **kwargs):
+            raise RuntimeError("disk full")
+
+    monkeypatch.setattr(
+        "providers.model_registry.get_model_registry", lambda: _Broken(),
+    )
+    # Must return None and not raise — a broken registry never halts the cron.
+    assert (
+        retrain._log_to_registry("/tmp/m.pkl", fake_result, ["SPY"], "1y") is None
+    )
+
+
+def test_log_to_registry_swallows_registry_unavailable(monkeypatch, fake_result):
+    def _boom():
+        raise ImportError("mlflow missing")
+
+    monkeypatch.setattr(
+        "providers.model_registry.get_model_registry", _boom,
+    )
+    assert (
+        retrain._log_to_registry("/tmp/m.pkl", fake_result, ["SPY"], "1y") is None
+    )
+
+
+def test_log_to_registry_swallows_promote_exception(monkeypatch, fake_result):
+    class _PartBroken(_FakeRegistry):
+        def promote(self, *args, **kwargs):
+            raise RuntimeError("permission denied")
+
+    fake = _PartBroken()
+    monkeypatch.setattr(
+        "providers.model_registry.get_model_registry", lambda: fake,
+    )
+    run_id = retrain._log_to_registry(
+        "/tmp/m.pkl", fake_result, ["SPY"], "1y",
+    )
+    # Log still succeeded even though promotion raised.
+    assert run_id == "run-42"
+    assert len(fake.logged) == 1


### PR DESCRIPTION
Closes #144.

## Summary

P1.6 of the indie-quant roadmap. `adapters/model_registry/mlflow_adapter.py` was sitting unused — `cron/monthly_ml_retrain.py` still pickled the checkpoint to disk and nothing else. This PR wires the retrain cron into the existing `ModelRegistryProvider` factory so every successful retrain lands in MLflow with IC metrics + a Staging promotion.

- **`cron/monthly_ml_retrain.py`**
  - New `--log-to-mlflow / --no-log-to-mlflow` CLI flag; falls back to `MODEL_REGISTRY_ENABLED` env var (default `1`).
  - New `--help` surface (`argparse.BooleanOptionalAction`).
  - `_log_to_registry(model_path, train_result, tickers, period)` — calls `registry.log_model` with IC metrics and tags (model_name, period, ticker list, source). Best-effort `registry.promote(..., "Staging")` after a successful log. Every exception is swallowed with a warning so a broken tracking server never halts the cron after the checkpoint is written.
- **`docker-compose.yml`** — new `mlflow` sidecar (mlflow 2.22.1, SQLite backend store under `./mlruns`).
- **`.env.example`** — documents `MODEL_REGISTRY_PROVIDER`, `MODEL_REGISTRY_ENABLED`, `MLFLOW_TRACKING_URI`, `MLFLOW_REGISTERED_MODEL`.
- **`tests/test_monthly_ml_retrain_mlflow.py`** — 11 cases covering flag resolution, happy-path log+promote, empty run_id no-op, log_model exception, registry-unavailable, and promote exception (all non-fatal).
- **`tests/test_monthly_ml_retrain.py`** — existing tests updated to pass `argv=[]` now that `main()` parses CLI flags.

## Test plan

- [x] `pytest tests/test_monthly_ml_retrain_mlflow.py tests/test_monthly_ml_retrain.py -v` — 20/20 pass
- [x] `pytest tests/ -m "not integration" --cov=. --cov-fail-under=76` — 1439 pass, coverage 77.36%
- [x] `ruff check .` — clean
- [x] `bandit -r . -ll` — 0 HIGH severity
- [x] `pip-audit` — no known vulns
- [ ] Manual: `docker-compose up mlflow` → `python -m cron.monthly_ml_retrain --ticker SPY` → visit `http://localhost:5000` → new run + staged model version visible

https://claude.ai/code/session_01WmG6mAtgV1nr1c9NPxBAD8