### PR TITLE
chore(deps): bump pyarrow 23.0.1 -> 24.0.0 (major, approved) (#175)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -32,7 +32,7 @@ plotly==6.6.0
 pluggy==1.6.0
 plyer==2.1.0
 protobuf==7.34.1
-pyarrow==23.0.1
+pyarrow==24.0.0
 pycparser==3.0
 pydeck==0.9.1
 Pygments==2.20.0


### PR DESCRIPTION
Arrow 24 is a major version jump. pyarrow is a transitive dep only (no `import pyarrow` in the codebase; reached via pandas / streamlit / narwhals), so direct code impact is minimal.

Validation pending on CI:
- ruff / pytest + 76% coverage / bandit HIGH / pip-audit
- streamlit boot smoke test Rollback = single-line revert if any gate fails.

Plan approved by user 2026-04-22.