### PR TITLE
test: e2e regression suite for Phase-1 features

### DIFF
--- a/tests/test_e2e_bracket_lifecycle.py
+++ b/tests/test_e2e_bracket_lifecycle.py
@@ -1,0 +1,126 @@
+"""
+tests/test_e2e_bracket_lifecycle.py — bracket-order chain end to end.
+
+Walks the full ``OrderIntent → PaperBrokerAdapter.place_bracket → parent
+fill (buy/sell) → paper_bracket_orders pending row → check_brackets price
+tick → child fill → portfolio flat`` pipeline on a real paper-trader DB.
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+import broker.paper_trader as pt
+import data.db as db_module
+from providers.broker import OrderIntent
+
+
+@pytest.fixture
+def paper_env(tmp_path, monkeypatch):
+    monkeypatch.setattr(db_module, "_DB_PATH", str(tmp_path / "quant.db"))
+    monkeypatch.setattr(pt, "STARTING_CASH", 100_000.0)
+    monkeypatch.setattr(pt, "MAX_DRAWDOWN_PCT", 0.99)
+    pt.init_paper_tables()
+    return tmp_path
+
+
+def test_bracket_take_profit_lifecycle(paper_env):
+    """A long bracket with TP=110 fills the parent at 100, ignores
+    interim ticks, and closes the child when price crosses TP."""
+    from adapters.broker.paper_adapter import PaperBrokerAdapter
+
+    intent = OrderIntent(
+        symbol="SPY", qty=10, side="buy",
+        limit_price=100.0,           # paper adapter uses limit_price as the fill
+        take_profit=110.0,
+        stop_loss=95.0,
+    )
+    broker = PaperBrokerAdapter()
+    parent = broker.place_bracket(intent)
+    assert parent["status"] == "parent_filled"
+    assert parent["ticker"] == "SPY"
+    assert parent["children"]["take_profit"] == 110.0
+    assert parent["children"]["stop_loss"] == 95.0
+
+    # Position is open, one bracket pending.
+    portfolio = pt.get_portfolio()
+    assert set(portfolio["Ticker"]) == {"SPY"}
+    assert portfolio.iloc[0]["Shares"] == pytest.approx(10.0)
+    assert len(pt.get_pending_brackets()) == 1
+
+    # Interim tick below TP: still pending.
+    no_fire = pt.check_brackets({"SPY": 105.0})
+    assert no_fire == []
+    assert len(pt.get_pending_brackets()) == 1
+
+    # Cross TP: bracket fires.
+    fires = pt.check_brackets({"SPY": 112.0})
+    assert len(fires) == 1
+    assert fires[0]["reason"] == "take_profit"
+    assert pt.get_portfolio().empty
+    assert pt.get_pending_brackets() == []
+
+
+def test_bracket_stop_loss_lifecycle(paper_env):
+    """The stop-loss leg fires when the price crosses below the SL level."""
+    from adapters.broker.paper_adapter import PaperBrokerAdapter
+
+    intent = OrderIntent(
+        symbol="SPY", qty=10, side="buy",
+        limit_price=100.0,
+        stop_loss=95.0,
+    )
+    PaperBrokerAdapter().place_bracket(intent)
+
+    fires = pt.check_brackets({"SPY": 94.0})
+    assert len(fires) == 1
+    assert fires[0]["reason"] == "stop_loss"
+    assert pt.get_portfolio().empty
+
+
+def test_bracket_trailing_stop_tracks_peak(paper_env):
+    """Trailing stop slides up with the price and fires on a 5% pullback
+    from the running peak."""
+    from adapters.broker.paper_adapter import PaperBrokerAdapter
+
+    intent = OrderIntent(
+        symbol="SPY", qty=10, side="buy",
+        limit_price=100.0,
+        trail_percent=0.05,
+    )
+    PaperBrokerAdapter().place_bracket(intent)
+
+    # Tick up to $120 establishes a new peak; trigger is 120 × 0.95 = 114.
+    pt.check_brackets({"SPY": 120.0})
+    no_fire = pt.check_brackets({"SPY": 117.0})  # still above 114
+    assert no_fire == []
+
+    fires = pt.check_brackets({"SPY": 113.0})    # crosses trigger
+    assert len(fires) == 1
+    assert fires[0]["reason"] == "trail"
+    assert pt.get_portfolio().empty
+
+
+def test_bracket_cancel_prevents_future_fill(paper_env):
+    """Cancelling a bracket before it triggers leaves the position open
+    and ignores subsequent price ticks."""
+    from adapters.broker.paper_adapter import PaperBrokerAdapter
+
+    intent = OrderIntent(
+        symbol="SPY", qty=10, side="buy",
+        limit_price=100.0,
+        stop_loss=90.0,
+    )
+    parent = PaperBrokerAdapter().place_bracket(intent)
+    assert pt.cancel_bracket(parent["bracket_id"]) is True
+
+    # No pending brackets → check_brackets is a no-op even on a deep dip.
+    fires = pt.check_brackets({"SPY": 80.0})
+    assert fires == []
+    assert pt.get_pending_brackets() == []
+    # The parent position is still open — cancellation only affects the children.
+    assert set(pt.get_portfolio()["Ticker"]) == {"SPY"}

--- a/tests/test_e2e_monthly_retrain_to_mlflow.py
+++ b/tests/test_e2e_monthly_retrain_to_mlflow.py
@@ -1,0 +1,144 @@
+"""
+tests/test_e2e_monthly_retrain_to_mlflow.py — retrain → registry log/promote.
+
+Walks the full ``cron.monthly_ml_retrain.main → MLSignal.train →
+checkpoint pickle → ModelRegistryProvider.log_model → promote("Staging")``
+chain. The vendor MLflow client is replaced with a captured-call
+``FakeRegistry``; LightGBM is bypassed via a ``FakeMLSignal`` so the
+test runs without GPU or training data.
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+import cron.monthly_ml_retrain as retrain
+
+
+class _FakeRegistry:
+    def __init__(self) -> None:
+        self.logged: list[dict] = []
+        self.promoted: list[tuple[str, str, str]] = []
+
+    def log_model(self, run_name, model_path, metrics, tags=None):
+        self.logged.append(
+            {
+                "run_name": run_name,
+                "model_path": model_path,
+                "metrics": dict(metrics),
+                "tags": dict(tags or {}),
+            }
+        )
+        return "run-e2e-1"
+
+    def promote(self, model_name, run_id, stage):
+        self.promoted.append((model_name, run_id, stage))
+
+
+class _FakeMLSignal:
+    """Stand-in for strategies.ml_signal.MLSignal that records train calls
+    and writes a 1-byte pickle so the registry log_model has a path that
+    exists."""
+
+    last_instance: "_FakeMLSignal | None" = None
+
+    def __init__(self) -> None:
+        self._model_path = os.environ.get("LGBM_ALPHA_MODEL_PATH", "models/lgbm_alpha.pkl")
+        os.makedirs(os.path.dirname(self._model_path), exist_ok=True)
+        with open(self._model_path, "wb") as f:
+            f.write(b"\x00")  # tiny placeholder so log_model can attach an artifact
+        self.train_calls: list[tuple] = []
+        _FakeMLSignal.last_instance = self
+
+    def train(self, tickers, period="2y", lgbm_params=None):
+        self.train_calls.append((tuple(tickers), period, lgbm_params))
+        return {
+            "train_ic":   0.052,
+            "test_ic":    0.041,
+            "train_icir": 0.92,
+            "test_icir":  0.74,
+            "n_train_samples": 1234,
+            "n_test_samples":   456,
+        }
+
+
+@pytest.fixture
+def fake_signal_and_registry(tmp_path, monkeypatch):
+    """Replace MLSignal + load_best_params + get_model_registry."""
+    monkeypatch.setenv("LGBM_ALPHA_MODEL_PATH", str(tmp_path / "models/lgbm.pkl"))
+    monkeypatch.setattr(retrain, "_LGBM_AVAILABLE", True)
+    monkeypatch.setattr(retrain, "MLSignal", _FakeMLSignal)
+    monkeypatch.setattr(
+        "strategies.ml_tuning.load_best_params", lambda name: None,
+    )
+    fake = _FakeRegistry()
+    monkeypatch.setattr(
+        "providers.model_registry.get_model_registry", lambda: fake,
+    )
+    return fake
+
+
+def test_retrain_logs_to_registry_and_promotes_to_staging(
+    fake_signal_and_registry, monkeypatch,
+):
+    monkeypatch.setenv("WF_TICKERS", "SPY,QQQ")
+    monkeypatch.setenv("ML_TRAIN_PERIOD", "1y")
+    monkeypatch.setenv("MODEL_REGISTRY_ENABLED", "1")
+
+    retrain.main([])  # no CLI flag → fall back to env
+
+    fake = fake_signal_and_registry
+    assert len(fake.logged) == 1
+    entry = fake.logged[0]
+    assert entry["run_name"] == "lgbm_alpha_retrain"
+    assert entry["metrics"]["train_ic"] == pytest.approx(0.052)
+    assert entry["metrics"]["test_ic"] == pytest.approx(0.041)
+    assert entry["metrics"]["n_train"] == 1234
+    assert entry["tags"]["source"] == "cron.monthly_ml_retrain"
+    assert entry["tags"]["period"] == "1y"
+    assert entry["tags"]["tickers"] == "SPY,QQQ"
+    assert entry["tags"]["n_tickers"] == "2"
+
+    assert fake.promoted == [("lgbm_alpha", "run-e2e-1", "Staging")]
+
+    # The fake MLSignal recorded the train invocation.
+    sig = _FakeMLSignal.last_instance
+    assert sig is not None
+    assert sig.train_calls == [(("SPY", "QQQ"), "1y", None)]
+
+
+def test_retrain_skips_registry_when_no_log_to_mlflow(
+    fake_signal_and_registry, monkeypatch,
+):
+    monkeypatch.setenv("WF_TICKERS", "SPY")
+    retrain.main(["--no-log-to-mlflow"])
+    assert fake_signal_and_registry.logged == []
+    assert fake_signal_and_registry.promoted == []
+
+
+def test_retrain_swallows_registry_exception_after_local_save(
+    fake_signal_and_registry, monkeypatch,
+):
+    """A broken registry must not propagate — the local checkpoint has
+    already been written and the cron should exit successfully."""
+
+    class _BrokenRegistry(_FakeRegistry):
+        def log_model(self, *args, **kwargs):
+            raise RuntimeError("tracking server down")
+
+    broken = _BrokenRegistry()
+    monkeypatch.setattr(
+        "providers.model_registry.get_model_registry", lambda: broken,
+    )
+    monkeypatch.setenv("WF_TICKERS", "SPY")
+
+    # Must not raise — main() exits zero even when the registry breaks.
+    retrain.main([])
+
+    # The exception was caught — no successful log/promote recorded.
+    assert broken.logged == []
+    assert broken.promoted == []

--- a/tests/test_e2e_polygon_backfill_to_fetch_ohlcv.py
+++ b/tests/test_e2e_polygon_backfill_to_fetch_ohlcv.py
@@ -1,0 +1,158 @@
+"""
+tests/test_e2e_polygon_backfill_to_fetch_ohlcv.py — backfill → cache → read.
+
+End-to-end check that ``cron.polygon_backfill`` populates both the SQLite
+JSON cache and the DuckDB columnar cache, and that a subsequent
+``data.fetcher.fetch_ohlcv`` for the same ``(ticker, period)`` hits the
+cache without ever calling yfinance.
+
+Network is mocked at the boundary: we patch ``adapters.market_data.
+polygon_adapter._requests`` to return a deterministic Polygon payload
+and assert ``yfinance.download`` is never invoked.
+"""
+from __future__ import annotations
+
+import os
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+import adapters.market_data.polygon_adapter as polymod
+import cron.polygon_backfill as backfill
+import data.db as db_module
+
+
+def _polygon_payload(rows: int) -> dict:
+    base_t = 1_700_000_000_000  # ms
+    one_day_ms = 86_400_000
+    return {
+        "results": [
+            {
+                "t": base_t + i * one_day_ms,
+                "o": 100.0 + i,
+                "h": 101.0 + i,
+                "l":  99.0 + i,
+                "c": 100.5 + i,
+                "v": 1_000 * (i + 1),
+            }
+            for i in range(rows)
+        ],
+    }
+
+
+@pytest.fixture
+def fake_polygon(monkeypatch):
+    """Stub Polygon HTTP — the adapter receives a pre-baked payload."""
+    payload = _polygon_payload(30)
+
+    class _Resp:
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return payload
+
+    monkeypatch.setattr(
+        polymod,
+        "_requests",
+        SimpleNamespace(get=lambda *args, **kwargs: _Resp()),
+    )
+    return payload
+
+
+@pytest.fixture
+def isolated_caches(tmp_path, monkeypatch):
+    monkeypatch.setattr(db_module, "_DB_PATH", str(tmp_path / "quant.db"))
+    monkeypatch.setenv("DUCKDB_PATH", str(tmp_path / "quant_tsdb.duckdb"))
+    # Reset the DuckDB connection singleton between tests.
+    import adapters.tsdb.duckdb_adapter as dad
+
+    dad._connection = None
+    yield tmp_path
+    dad._connection = None
+
+
+def test_backfill_populates_sqlite_then_fetch_ohlcv_hits_cache(
+    fake_polygon, isolated_caches, monkeypatch,
+):
+    """SQLite path: backfill writes price_cache; fetch_ohlcv reads it
+    without touching yfinance."""
+    monkeypatch.setenv("POLYGON_API_KEY", "key")
+    monkeypatch.setenv("TSDB_PROVIDER", "sqlite")  # default — only SQLite path
+
+    rc = backfill.main([
+        "--tickers", "AAPL", "--days", "30",
+        "--timeframe", "1Day", "--period", "1mo",
+    ])
+    assert rc == 0
+
+    # If fetch_ohlcv falls through to yfinance, the test fails loudly.
+    import yfinance
+
+    monkeypatch.setattr(
+        yfinance,
+        "download",
+        lambda *a, **kw: (_ for _ in ()).throw(
+            AssertionError("yfinance.download must not be called when cache is warm"),
+        ),
+    )
+    from data.fetcher import fetch_ohlcv
+
+    df = fetch_ohlcv("AAPL", "1mo")
+    assert len(df) == 30
+    assert list(df.columns) == ["Open", "High", "Low", "Close", "Volume"]
+    # Polygon stub returns close = 100.5 + i.
+    assert df["Close"].iloc[0] == pytest.approx(100.5)
+    assert df["Close"].iloc[-1] == pytest.approx(100.5 + 29)
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="https://github.com/ghostlobster/quant-platform/issues/184 — "
+           "polygon_backfill writes only the SQLite cache. DuckDB is warmed "
+           "lazily by the next fetch_ohlcv call. Fix lands separately; this "
+           "test flips to PASS when backfill double-writes both caches.",
+)
+def test_backfill_populates_duckdb_when_active(
+    fake_polygon, isolated_caches, monkeypatch,
+):
+    """DuckDB path: backfill writes to BOTH caches when TSDB_PROVIDER=duckdb."""
+    duckdb = pytest.importorskip("duckdb")  # noqa: F841
+
+    monkeypatch.setenv("POLYGON_API_KEY", "key")
+    monkeypatch.setenv("TSDB_PROVIDER", "duckdb")
+
+    rc = backfill.main([
+        "--tickers", "AAPL", "--days", "30",
+        "--timeframe", "1Day", "--period", "1mo",
+    ])
+    assert rc == 0
+
+    from data import duckdb_cache as dc
+
+    cached = dc.read("AAPL", "1mo", ttl_seconds=3600)
+    assert cached is not None
+    assert len(cached) == 30
+    assert list(cached.columns) == ["Open", "High", "Low", "Close", "Volume"]
+
+
+def test_backfill_intraday_does_not_warm_sqlite_cache(
+    fake_polygon, isolated_caches, monkeypatch,
+):
+    """Intraday timeframes are fetched but skip the daily-only cache schema."""
+    monkeypatch.setenv("POLYGON_API_KEY", "key")
+    monkeypatch.setenv("TSDB_PROVIDER", "sqlite")
+
+    rc = backfill.main([
+        "--tickers", "AAPL", "--days", "5",
+        "--timeframe", "5Min", "--period", "5d",
+    ])
+    assert rc == 0
+
+    from data.fetcher import _cache_read
+
+    # Intraday → no SQLite cache row written.
+    assert _cache_read("AAPL", "5d") is None

--- a/tests/test_e2e_pretrade_guard_rejects_oversized.py
+++ b/tests/test_e2e_pretrade_guard_rejects_oversized.py
@@ -1,0 +1,106 @@
+"""
+tests/test_e2e_pretrade_guard_rejects_oversized.py — end-to-end pre-trade
+guard chain.
+
+Exercises the full ``OrderIntent → adapter.place_order → PreTradeGuard
+→ broker.get_account_info → reject path → no journal entry`` chain on a
+real ``PaperBrokerAdapter`` against a tmp SQLite quant.db. No mocks
+beyond redirecting the on-disk DB paths.
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+import broker.paper_trader as pt
+import data.db as db_module
+import journal.trading_journal as jt
+
+
+@pytest.fixture
+def paper_env(tmp_path, monkeypatch):
+    """Isolate paper_trader + journal to per-test tmp SQLite files."""
+    monkeypatch.setattr(db_module, "_DB_PATH", str(tmp_path / "quant.db"))
+    monkeypatch.setenv("JOURNAL_DB_PATH", str(tmp_path / "journal.db"))
+    monkeypatch.setattr(pt, "STARTING_CASH", 100_000.0)
+    # Disable the legacy paper-trader circuit breaker so the guard alone
+    # decides accept / reject.
+    monkeypatch.setattr(pt, "MAX_DRAWDOWN_PCT", 0.99)
+    pt.init_paper_tables()
+    jt.init_journal_table()
+    return tmp_path
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="https://github.com/ghostlobster/quant-platform/issues/183 — "
+           "PreTradeGuard reads `equity`/`portfolio_value` but the paper "
+           "broker returns `total_value`, so dollar-sizing limits silently "
+           "no-op. Fix lands separately; this test flips to PASS when the "
+           "guard's _account_snapshot also accepts `total_value`.",
+)
+def test_guard_rejects_oversized_then_accepts_relaxed(paper_env, monkeypatch):
+    """Tightening MAX_POSITION_PCT rejects a $10k order against $100k equity;
+    relaxing the env var lets the same order fill."""
+    from adapters.broker.paper_adapter import PaperBrokerAdapter
+
+    # 0.5% of equity → $500 cap. A 100×$100 = $10k buy must be rejected.
+    monkeypatch.setenv("MAX_POSITION_PCT", "0.005")
+    broker = PaperBrokerAdapter()
+
+    rejected = broker.place_order("AAPL", qty=100, side="buy", limit_price=100.0)
+    assert rejected["status"] == "rejected"
+    assert rejected["reason"] == "max_position_pct"
+    # No fill happened — portfolio is empty, no journal row written.
+    assert pt.get_portfolio().empty
+    assert jt.get_journal().empty
+
+    # Relaxing the env to 50% leaves headroom; the same order now fills.
+    monkeypatch.setenv("MAX_POSITION_PCT", "0.5")
+    relaxed_broker = PaperBrokerAdapter()
+    filled = relaxed_broker.place_order("AAPL", qty=100, side="buy", limit_price=100.0)
+    assert filled["status"] == "filled"
+    portfolio = pt.get_portfolio()
+    assert set(portfolio["Ticker"]) == {"AAPL"}
+    assert portfolio.iloc[0]["Shares"] == pytest.approx(100.0)
+
+
+def test_blocklist_rejects_then_unset_allows(paper_env, monkeypatch):
+    from adapters.broker.paper_adapter import PaperBrokerAdapter
+
+    monkeypatch.setenv("SYMBOL_BLOCKLIST", "MEME, SCAM")
+    broker = PaperBrokerAdapter()
+    rejected = broker.place_order("meme", qty=1, side="buy", limit_price=10.0)
+    assert rejected["status"] == "rejected"
+    assert rejected["reason"] == "symbol_blocklist"
+    assert pt.get_portfolio().empty
+
+    # Unrelated symbol still goes through.
+    ok = broker.place_order("AAPL", qty=1, side="buy", limit_price=10.0)
+    assert ok["status"] == "filled"
+
+
+def test_killswitch_blocks_then_release_resumes(paper_env, monkeypatch, tmp_path):
+    """Touching the kill-switch file blocks every adapter; removing the file
+    resumes trading."""
+    killswitch = tmp_path / "killswitch.flag"
+    monkeypatch.setenv("KILLSWITCH_FILE", str(killswitch))
+
+    from adapters.broker.paper_adapter import PaperBrokerAdapter
+
+    killswitch.touch()
+    broker = PaperBrokerAdapter()
+    blocked = broker.place_order("AAPL", qty=1, side="buy", limit_price=100.0)
+    assert blocked["status"] == "rejected"
+    assert blocked["reason"] == "killswitch"
+    assert pt.get_portfolio().empty
+
+    # Remove the flag, fresh adapter, order proceeds.
+    killswitch.unlink()
+    broker2 = PaperBrokerAdapter()
+    ok = broker2.place_order("AAPL", qty=1, side="buy", limit_price=100.0)
+    assert ok["status"] == "filled"

--- a/tests/test_e2e_risk_exporter_tick_to_alert.py
+++ b/tests/test_e2e_risk_exporter_tick_to_alert.py
@@ -1,0 +1,150 @@
+"""
+tests/test_e2e_risk_exporter_tick_to_alert.py — risk-exporter scheduler tick.
+
+End-to-end verification of the P1.2 risk-dashboard chain: a single call
+to ``risk_exporter_job(broker)`` resolves equity + positions from the
+broker, daily P&L from the journal, drawdown from
+``portfolio_value_series``, updates the Prometheus gauges, and broadcasts
+a drawdown alert through ``alerts.channels.broadcast`` once the breach
+crosses the configured threshold.
+
+Network is stubbed at the boundary: ``alerts.channels.broadcast`` and
+``risk.metrics_exporter._portfolio_value_series`` are monkeypatched.
+The scheduler tick itself is exercised via the public
+``risk_exporter_job`` entry-point.
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+import journal.trading_journal as jt
+from risk import metrics_exporter as me
+
+
+class FakeBroker:
+    """Minimal BrokerProvider stand-in; only the methods the exporter calls."""
+
+    def __init__(self, equity: float, positions: list[dict] | None = None):
+        self.equity = equity
+        self._positions = positions or []
+
+    def get_account_info(self) -> dict:
+        return {"equity": self.equity}
+
+    def get_positions(self) -> list[dict]:
+        return list(self._positions)
+
+
+@pytest.fixture(autouse=True)
+def _reset_alert_state():
+    me.reset_alert_state()
+    yield
+    me.reset_alert_state()
+
+
+@pytest.fixture
+def journal_db(tmp_path, monkeypatch):
+    monkeypatch.setenv("JOURNAL_DB_PATH", str(tmp_path / "journal.db"))
+    jt.init_journal_table()
+    return tmp_path
+
+
+def test_drawdown_breach_fires_alert_then_cooldown(monkeypatch, journal_db):
+    """Tick 1 breaches the threshold and broadcasts; tick 2 (within
+    cooldown) is silent; tick 3 after cooldown re-broadcasts."""
+    # Seed journal with -$12k realised PnL today.
+    trade_id = jt.log_entry(
+        ticker="SPY", side="BUY", qty=10, price=100.0,
+        signal_source="e2e_test", regime="", notes="",
+    )
+    jt.log_exit(trade_id, price=-100.0, pnl=-12_000.0, exit_reason="stop", notes="")
+
+    # Portfolio history climbed to $120k peak before the dip.
+    monkeypatch.setattr(
+        me, "_portfolio_value_series",
+        lambda: [100_000.0, 110_000.0, 120_000.0],
+    )
+
+    monkeypatch.setenv("MAX_DRAWDOWN_PCT", "0.10")
+    monkeypatch.setenv("RISK_ALERT_COOLDOWN", "100")  # 100s for clearer timing
+
+    received: list[tuple[str, str]] = []
+
+    def _fake_broadcast(subject, body, channels=None):
+        received.append((subject, body))
+        return {"ok": 1}
+
+    monkeypatch.setattr("alerts.channels.broadcast", _fake_broadcast)
+
+    broker = FakeBroker(equity=100_000.0, positions=[])
+
+    # Tick 1: drawdown = (100 - 120) / 120 = -0.166..., below the -0.10 cap.
+    snap = me.compute_risk_snapshot(broker)
+    assert snap.drawdown == pytest.approx(-1 / 6)
+    me.update_risk_gauges(snap)
+    fired = me.maybe_alert_drawdown(snap, now=1000.0)
+    assert fired is True
+    assert len(received) == 1
+    subject, body = received[0]
+    assert subject == "Drawdown alert"
+    assert "16.67" in body or "-0.17" in body or "-0.16" in body  # rendered drawdown
+
+    # Tick 2 (within cooldown): no second broadcast.
+    silenced = me.maybe_alert_drawdown(snap, now=1050.0)
+    assert silenced is False
+    assert len(received) == 1
+
+    # Tick 3 (cooldown elapsed): broadcasts again.
+    refired = me.maybe_alert_drawdown(snap, now=1200.0)
+    assert refired is True
+    assert len(received) == 2
+
+
+def test_no_alert_when_within_threshold(monkeypatch, journal_db):
+    """Drawdown above the threshold (e.g. -3%) does not broadcast."""
+    monkeypatch.setattr(
+        me, "_portfolio_value_series",
+        lambda: [100_000.0, 102_000.0],
+    )
+    monkeypatch.setenv("MAX_DRAWDOWN_PCT", "0.10")
+
+    sent: list = []
+    monkeypatch.setattr(
+        "alerts.channels.broadcast",
+        lambda s, b, channels=None: sent.append((s, b)),
+    )
+
+    broker = FakeBroker(equity=99_000.0)
+    snap = me.compute_risk_snapshot(broker)
+    # drawdown = (99 - 102) / 102 ≈ -0.029, above -0.10
+    assert snap.drawdown > -0.05
+    me.update_risk_gauges(snap)
+    assert me.maybe_alert_drawdown(snap, now=0.0) is False
+    assert sent == []
+
+
+def test_risk_exporter_job_returns_payload(monkeypatch, journal_db):
+    """The scheduler-callable entry-point returns a dict with every gauge
+    field plus the `alerted` flag."""
+    monkeypatch.setattr(me, "_portfolio_value_series", lambda: [])
+    monkeypatch.delenv("MAX_DRAWDOWN_PCT", raising=False)
+
+    broker = FakeBroker(
+        equity=100_000.0,
+        positions=[{"symbol": "SPY", "market_value": 30_000.0, "unrealized_pl": 250.0}],
+    )
+    payload = me.risk_exporter_job(broker)
+    assert set(payload).issuperset(
+        {"equity", "gross_exposure", "net_exposure", "daily_pnl",
+         "var_95", "drawdown", "alerted"},
+    )
+    assert payload["equity"] == 100_000.0
+    assert payload["gross_exposure"] == pytest.approx(0.3)
+    assert payload["net_exposure"] == pytest.approx(0.3)
+    assert payload["daily_pnl"] == pytest.approx(250.0)
+    assert payload["alerted"] is False


### PR DESCRIPTION
Adds an end-to-end regression suite for the six Phase-1 features merged in PRs #165–#172.

## Summary

Five files under `tests/test_e2e_*.py`, each exercising the chain a real run would traverse rather than a single component in isolation:

| File | Chain |
|---|---|
| `test_e2e_pretrade_guard_rejects_oversized.py` | OrderIntent → adapter.place_order → PreTradeGuard → broker.get_account_info → reject path → no journal entry |
| `test_e2e_bracket_lifecycle.py` | OrderIntent (bracket) → place_bracket → check_brackets → child fill → portfolio flat |
| `test_e2e_polygon_backfill_to_fetch_ohlcv.py` | cron.polygon_backfill → SQLite + DuckDB caches → fetch_ohlcv hit → no yfinance call |
| `test_e2e_risk_exporter_tick_to_alert.py` | risk_exporter_job → snapshot → gauges + drawdown breach → broadcast |
| `test_e2e_monthly_retrain_to_mlflow.py` | cron.monthly_ml_retrain → checkpoint → registry.log_model → promote("Staging") |

Network is mocked at the boundary (Polygon HTTP, alerts.channels.broadcast, model_registry); SQLite + journal + paper-trader run for real on per-test tmp paths.

## Bugs surfaced

The discovery phase turned up two real bugs in already-merged code. Filed as separate issues so the e2e PR ships clean:

- **#183 — PreTradeGuard misses paper broker equity** (High). Guard reads `equity`/`portfolio_value`; paper broker returns `total_value`. Dollar-sizing limits silently no-op against the paper adapter.
- **#184 — polygon_backfill skips DuckDB write when TSDB_PROVIDER=duckdb** (Low). DuckDB cache is only warmed lazily by the next `fetch_ohlcv` call, not directly by the backfill cron.

Both are tracked via `xfail(strict=True)` markers on the relevant tests so the suite stays green today and the markers flip to PASS in the resolution PRs.

## Test plan

- [x] `pytest tests/test_e2e_*.py -v` — 14 pass, 2 xfail (#183, #184)
- [x] `pytest tests/ -m "not integration" --cov=. --cov-fail-under=76` — 1453 pass, 42 skipped, 2 xfail, coverage 77.50%
- [x] `ruff check .` — clean
- [x] `bandit -r . -ll` — 0 HIGH severity
- [x] `pip-audit` — no known vulns
- [ ] After merge: open follow-up PRs that close #183 and #184 and remove the xfail markers.

https://claude.ai/code/session_01WmG6mAtgV1nr1c9NPxBAD8

---
_Generated by [Claude Code](https://claude.ai/code/session_01WmG6mAtgV1nr1c9NPxBAD8)_