### PR TITLE
fix: polygon_backfill writes through to DuckDB when active (#184)

### DIFF
--- a/cron/polygon_backfill.py
+++ b/cron/polygon_backfill.py
@@ -152,6 +152,7 @@ def backfill(
         return {}
 
     from adapters.market_data.polygon_adapter import PolygonAdapter
+    from data import duckdb_cache as _duckdb_cache
     from data.db import init_db
     from data.fetcher import _cache_write
 
@@ -182,13 +183,20 @@ def backfill(
             continue
 
         counts[ticker] = len(bars)
-        cache_hit = False
+        sqlite_cached = False
+        duckdb_cached = False
         if cacheable and bars:
             try:
                 df = _bars_to_dataframe(bars)
                 if not df.empty:
                     _cache_write(ticker, cache_period, df)
-                    cache_hit = True
+                    sqlite_cached = True
+                    # Mirror data/fetcher.fetch_ohlcv: when DuckDB is the
+                    # active TSDB, write through to the columnar cache so
+                    # walk-forward reads do not need a SQLite warm-up hop.
+                    if _duckdb_cache.is_active():
+                        _duckdb_cache.write(ticker, cache_period, df)
+                        duckdb_cached = True
             except Exception as exc:
                 logger.warning(
                     "polygon_backfill: cache write failed",
@@ -202,7 +210,8 @@ def backfill(
             start=start_s,
             end=end_s,
             cache_period=cache_period if cacheable else None,
-            cached=cache_hit,
+            sqlite_cached=sqlite_cached,
+            duckdb_cached=duckdb_cached,
         )
     return counts
 

--- a/tests/test_e2e_polygon_backfill_to_fetch_ohlcv.py
+++ b/tests/test_e2e_polygon_backfill_to_fetch_ohlcv.py
@@ -109,13 +109,6 @@ def test_backfill_populates_sqlite_then_fetch_ohlcv_hits_cache(
     assert df["Close"].iloc[-1] == pytest.approx(100.5 + 29)
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="https://github.com/ghostlobster/quant-platform/issues/184 — "
-           "polygon_backfill writes only the SQLite cache. DuckDB is warmed "
-           "lazily by the next fetch_ohlcv call. Fix lands separately; this "
-           "test flips to PASS when backfill double-writes both caches.",
-)
 def test_backfill_populates_duckdb_when_active(
     fake_polygon, isolated_caches, monkeypatch,
 ):


### PR DESCRIPTION
Closes #184.

## Summary

`cron.polygon_backfill` was only writing the SQLite JSON cache; the DuckDB columnar cache was warmed lazily by the next `data.fetcher.fetch_ohlcv` call. This PR mirrors the double-write that `fetch_ohlcv` already does on the network-fetch path so walk-forward bulk reads hit DuckDB immediately after a backfill.

- **`cron/polygon_backfill.py`**
  - When `TSDB_PROVIDER=duckdb` is active, every successful daily-timeframe pull now also calls `data.duckdb_cache.write(ticker, cache_period, df)`. The DuckDB write is a no-op when the env var is unset, so existing setups are unaffected.
  - The structured-log line now distinguishes `sqlite_cached` from `duckdb_cached` so operators can verify both caches.
- **`tests/test_e2e_polygon_backfill_to_fetch_ohlcv.py`**
  - Removes the `xfail(strict=True)` marker on `test_backfill_populates_duckdb_when_active` — the e2e test that surfaced this bug now passes.

Surfaced by the e2e regression suite added in #185.

## Test plan

- [x] `pytest tests/test_e2e_polygon_backfill_to_fetch_ohlcv.py tests/test_polygon_backfill.py -v` — 20 pass (was 19 + 1 xfail before this PR)
- [x] `pytest tests/ -m "not integration" --cov=. --cov-fail-under=76` — 1454 pass, 1 xfail (#183), coverage 77.42%
- [x] `ruff check .` — clean
- [x] `bandit -r . -ll` — 0 HIGH severity
- [x] `pip-audit` — no known vulns

https://claude.ai/code/session_01WmG6mAtgV1nr1c9NPxBAD8

---
_Generated by [Claude Code](https://claude.ai/code/session_01WmG6mAtgV1nr1c9NPxBAD8)_