### PR TITLE
P1.7: options multi-leg strategy engine (#145)

### DIFF
--- a/broker/tradier_bridge.py
+++ b/broker/tradier_bridge.py
@@ -344,3 +344,88 @@ def place_option_order(
     except Exception as e:
         logger.error("Tradier place_option_order failed: %s", type(e).__name__)
         return None
+
+
+def _occ_symbol(underlying: str, expiry: str, option_type: str, strike: float) -> str:
+    """Build an OCC option symbol — e.g. SPY240621C00450000 for $450 call.
+
+    Format: ``<UNDERLYING><YYMMDD><C|P><strike×1000, 8-digit zero-padded>``.
+    Tradier accepts OCC symbols on multi-leg orders via the ``option_symbol``
+    sub-field, so we use it whenever a leg does not already carry one.
+    """
+    yymmdd = expiry.replace("-", "")[2:]  # 2024-06-21 -> 240621
+    code = "C" if option_type.lower() == "call" else "P"
+    strike_micros = int(round(float(strike) * 1000))
+    return f"{underlying.upper()}{yymmdd}{code}{strike_micros:08d}"
+
+
+def place_multi_leg(
+    legs: list,
+    *,
+    order_type: str = "market",
+    duration: str = "day",
+) -> Optional[dict]:
+    """Submit a multi-leg options order to Tradier.
+
+    Parameters
+    ----------
+    legs       : list of :class:`strategies.options_legs.OptionLeg`
+                 (or anything that exposes the same attributes).
+                 All legs must share the same ``underlying``.
+    order_type : ``market`` | ``debit`` | ``credit`` | ``even`` (Tradier
+                 multi-leg semantics).
+    duration   : ``day`` | ``gtc``.
+
+    Returns the parsed Tradier order dict on success, ``None`` when the
+    bridge is not configured or the request fails. Raises ``ValueError``
+    on a malformed leg list (mixed underlyings, empty list, etc).
+    """
+    if not legs:
+        raise ValueError("place_multi_leg requires at least one leg")
+    underlyings = {leg.underlying.upper() for leg in legs}
+    if len(underlyings) != 1:
+        raise ValueError(
+            f"all legs must share the same underlying, got {sorted(underlyings)}",
+        )
+    underlying = underlyings.pop()
+
+    if not _is_configured():
+        logger.warning("Tradier not configured — multi-leg order not placed")
+        return None
+
+    payload: dict = {
+        "class": "multileg",
+        "symbol": underlying,
+        "type": order_type,
+        "duration": duration,
+    }
+    for idx, leg in enumerate(legs):
+        sym = leg.option_symbol or _occ_symbol(
+            leg.underlying, leg.expiry, leg.option_type, leg.strike,
+        )
+        payload[f"option_symbol[{idx}]"] = sym
+        payload[f"side[{idx}]"] = leg.side
+        payload[f"quantity[{idx}]"] = str(leg.qty)
+
+    try:
+        import requests
+        cfg = _get_config()
+        r = requests.post(
+            f"{cfg['base_url']}/accounts/{cfg['account_id']}/orders",
+            headers=_get_headers(),
+            data=payload,
+            timeout=10,
+        )
+        r.raise_for_status()
+        data = r.json()
+        order_data = data.get("order", data)
+        return {
+            "order_id": str(order_data.get("id", "")),
+            "status": order_data.get("status", "unknown"),
+            "underlying": underlying,
+            "legs": len(legs),
+            "order_type": order_type,
+        }
+    except Exception as e:
+        logger.error("Tradier place_multi_leg failed: %s", type(e).__name__)
+        return None

--- a/risk/options_sizing.py
+++ b/risk/options_sizing.py
@@ -1,0 +1,123 @@
+"""
+risk/options_sizing.py — Greeks-aware sizing for multi-leg options.
+
+Two helpers:
+
+    delta_neutral_qty(legs, market) -> int
+        Pick the contract count so the portfolio delta exposure stays
+        within ``max_abs_delta_shares`` (default 100 shares-equivalent).
+
+    cap_by_max_vega(legs, market, max_vega_dollars) -> int
+        Pick the contract count so the absolute portfolio vega (in $ per
+        1 vol point) stays within the cap.
+
+Both helpers reuse :func:`analysis.greeks.compute_greeks` so the math is
+the project's canonical Black-Scholes path. Each leg in the input list
+must come from :mod:`strategies.options_legs` and the ``market`` mapping
+must provide ``S`` (underlying spot) and an ``r`` (risk-free rate)
+keyed by ``leg.underlying``, plus per-leg ``T`` (years to expiry) and
+``sigma`` (implied vol).
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from analysis.greeks import compute_greeks
+from strategies.options_legs import OptionLeg
+
+
+@dataclass(frozen=True)
+class LegMarket:
+    """Per-leg market inputs for Black-Scholes."""
+
+    S: float           # underlying spot
+    T: float           # years to expiry
+    sigma: float       # implied vol (annualised)
+    r: float = 0.04    # risk-free rate
+    contract_price: float | None = None  # observed mid for IV solve / pricing
+
+
+def _portfolio_greeks(legs: list[OptionLeg], market: dict[int, LegMarket]) -> dict:
+    """Sum delta (in shares) and vega (in $/vol-point) over signed legs."""
+    total_delta_shares = 0.0
+    total_vega = 0.0
+    for idx, leg in enumerate(legs):
+        m = market[idx]
+        g = compute_greeks(
+            S=m.S, K=leg.strike, T=m.T, r=m.r,
+            sigma=m.sigma, option_type=leg.option_type,
+            contract_price=m.contract_price,
+        )
+        # delta * signed_qty * 100 = exposure in shares-equivalent
+        total_delta_shares += g.delta * leg.signed_qty * 100.0
+        total_vega += g.vega * leg.signed_qty
+    return {"delta_shares": total_delta_shares, "vega": total_vega}
+
+
+def delta_neutral_qty(
+    legs: list[OptionLeg],
+    market: dict[int, LegMarket],
+    *,
+    max_abs_delta_shares: float = 100.0,
+) -> int:
+    """Largest integer multiplier ``m`` so |portfolio delta × m| ≤ cap.
+
+    Returns ``0`` when even a single contract per leg breaches the cap.
+    Useful for premium-harvest structures (short straddle, iron condor)
+    that should sit close to delta-flat.
+    """
+    if max_abs_delta_shares <= 0:
+        raise ValueError(
+            f"max_abs_delta_shares must be > 0, got {max_abs_delta_shares}",
+        )
+    base = _portfolio_greeks(legs, market)
+    delta_one = abs(base["delta_shares"])
+    if delta_one == 0:
+        # Already delta-neutral at qty=1 — caller can scale up freely.
+        return max(1, max(int(leg.qty) for leg in legs))
+    multiplier = max_abs_delta_shares / delta_one
+    return int(multiplier)  # truncate toward zero
+
+
+def cap_by_max_vega(
+    legs: list[OptionLeg],
+    market: dict[int, LegMarket],
+    *,
+    max_vega_dollars: float,
+) -> int:
+    """Largest integer multiplier ``m`` so |portfolio vega × m| ≤ cap.
+
+    Vega is in dollars per 1.0 IV point (matches
+    :func:`analysis.greeks.compute_greeks` convention). Returns ``0``
+    when one contract per leg already exceeds the cap.
+    """
+    if max_vega_dollars <= 0:
+        raise ValueError(
+            f"max_vega_dollars must be > 0, got {max_vega_dollars}",
+        )
+    base = _portfolio_greeks(legs, market)
+    vega_one = abs(base["vega"])
+    if vega_one == 0:
+        return max(1, max(int(leg.qty) for leg in legs))
+    multiplier = max_vega_dollars / vega_one
+    return int(multiplier)
+
+
+def scale_legs(legs: list[OptionLeg], multiplier: int) -> list[OptionLeg]:
+    """Return a fresh leg list with ``leg.qty *= multiplier``.
+
+    Convenience wrapper for the sizer outputs. Multiplier ``0`` returns
+    an empty list — caller decides whether to abort or shrink the
+    construct.
+    """
+    if multiplier <= 0:
+        return []
+    return [
+        OptionLeg(
+            underlying=leg.underlying, expiry=leg.expiry,
+            strike=leg.strike, option_type=leg.option_type,
+            side=leg.side, qty=leg.qty * multiplier,
+            option_symbol=leg.option_symbol,
+        )
+        for leg in legs
+    ]

--- a/strategies/options_legs.py
+++ b/strategies/options_legs.py
@@ -1,0 +1,224 @@
+"""
+strategies/options_legs.py — multi-leg options builders.
+
+Returns ``list[OptionLeg]`` for the four most common indie defined-risk
+structures: vertical spread, iron condor, straddle, calendar. The legs
+are broker-agnostic; the Tradier multi-leg wrapper in
+:mod:`broker.tradier_bridge` (P1.7 ``place_multi_leg``) translates
+``OptionLeg`` into the Tradier order payload.
+
+Each builder normalises strikes / expiries so the test surface is
+deterministic. Validation lives in :func:`OptionLeg.__post_init__` —
+strike > 0, qty > 0, side ∈ Tradier's ``buy_to_open``/``sell_to_open``/
+``buy_to_close``/``sell_to_close``, option_type ∈ {"call", "put"}.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+_VALID_SIDES = ("buy_to_open", "sell_to_open", "buy_to_close", "sell_to_close")
+_VALID_OPTION_TYPES = ("call", "put")
+
+
+@dataclass(frozen=True)
+class OptionLeg:
+    """One leg of a multi-leg options order."""
+
+    underlying: str
+    expiry: str               # ISO date string YYYY-MM-DD
+    strike: float
+    option_type: str          # "call" | "put"
+    side: str                 # buy_to_open | sell_to_open | buy_to_close | sell_to_close
+    qty: int                  # contracts (always positive — direction encoded by side)
+    option_symbol: str | None = None  # OCC symbol; populated by adapter when None
+
+    def __post_init__(self) -> None:
+        if not self.underlying or not self.underlying.strip():
+            raise ValueError("underlying must be a non-empty ticker")
+        if not self.expiry or len(self.expiry) != 10:
+            raise ValueError(
+                f"expiry must be ISO 'YYYY-MM-DD', got {self.expiry!r}",
+            )
+        if self.strike <= 0:
+            raise ValueError(f"strike must be > 0, got {self.strike}")
+        if self.option_type.lower() not in _VALID_OPTION_TYPES:
+            raise ValueError(
+                f"option_type must be 'call' or 'put', got {self.option_type!r}",
+            )
+        if self.side.lower() not in _VALID_SIDES:
+            raise ValueError(
+                f"side must be one of {_VALID_SIDES}, got {self.side!r}",
+            )
+        if self.qty <= 0:
+            raise ValueError(f"qty must be > 0, got {self.qty}")
+
+    @property
+    def is_long(self) -> bool:
+        return self.side.lower().startswith("buy")
+
+    @property
+    def signed_qty(self) -> int:
+        """Contract count signed by direction (long positive, short negative)."""
+        return self.qty if self.is_long else -self.qty
+
+
+# ── Vertical spread ──────────────────────────────────────────────────────────
+
+def vertical_spread(
+    underlying: str,
+    expiry: str,
+    long_strike: float,
+    short_strike: float,
+    *,
+    option_type: str = "call",
+    qty: int = 1,
+) -> list[OptionLeg]:
+    """Long vertical spread (debit when call & long_strike < short_strike)."""
+    if long_strike == short_strike:
+        raise ValueError("long_strike and short_strike must differ")
+    return [
+        OptionLeg(
+            underlying=underlying, expiry=expiry,
+            strike=float(long_strike), option_type=option_type,
+            side="buy_to_open", qty=qty,
+        ),
+        OptionLeg(
+            underlying=underlying, expiry=expiry,
+            strike=float(short_strike), option_type=option_type,
+            side="sell_to_open", qty=qty,
+        ),
+    ]
+
+
+# ── Iron condor ─────────────────────────────────────────────────────────────
+
+def iron_condor(
+    underlying: str,
+    expiry: str,
+    *,
+    put_long_strike: float,
+    put_short_strike: float,
+    call_short_strike: float,
+    call_long_strike: float,
+    qty: int = 1,
+) -> list[OptionLeg]:
+    """Iron condor — short the inner strikes, long the wings.
+
+    Strike order must be: ``put_long < put_short < call_short < call_long``.
+    The structure is credit at open and defined-risk in both wings.
+    """
+    if not (put_long_strike < put_short_strike < call_short_strike < call_long_strike):
+        raise ValueError(
+            "iron condor strikes must satisfy "
+            "put_long < put_short < call_short < call_long, got "
+            f"{put_long_strike}, {put_short_strike}, "
+            f"{call_short_strike}, {call_long_strike}",
+        )
+    return [
+        OptionLeg(
+            underlying=underlying, expiry=expiry,
+            strike=float(put_long_strike), option_type="put",
+            side="buy_to_open", qty=qty,
+        ),
+        OptionLeg(
+            underlying=underlying, expiry=expiry,
+            strike=float(put_short_strike), option_type="put",
+            side="sell_to_open", qty=qty,
+        ),
+        OptionLeg(
+            underlying=underlying, expiry=expiry,
+            strike=float(call_short_strike), option_type="call",
+            side="sell_to_open", qty=qty,
+        ),
+        OptionLeg(
+            underlying=underlying, expiry=expiry,
+            strike=float(call_long_strike), option_type="call",
+            side="buy_to_open", qty=qty,
+        ),
+    ]
+
+
+# ── Straddle ────────────────────────────────────────────────────────────────
+
+def straddle(
+    underlying: str,
+    expiry: str,
+    strike: float,
+    *,
+    long: bool = True,
+    qty: int = 1,
+) -> list[OptionLeg]:
+    """Long straddle (volatility play) or short straddle (premium harvest)."""
+    side = "buy_to_open" if long else "sell_to_open"
+    return [
+        OptionLeg(
+            underlying=underlying, expiry=expiry,
+            strike=float(strike), option_type="call",
+            side=side, qty=qty,
+        ),
+        OptionLeg(
+            underlying=underlying, expiry=expiry,
+            strike=float(strike), option_type="put",
+            side=side, qty=qty,
+        ),
+    ]
+
+
+# ── Calendar spread ─────────────────────────────────────────────────────────
+
+def calendar(
+    underlying: str,
+    near_expiry: str,
+    far_expiry: str,
+    strike: float,
+    *,
+    option_type: str = "call",
+    qty: int = 1,
+) -> list[OptionLeg]:
+    """Calendar spread — short the near-dated leg, long the far-dated."""
+    if near_expiry >= far_expiry:
+        raise ValueError(
+            f"near_expiry must be earlier than far_expiry "
+            f"(got {near_expiry!r} vs {far_expiry!r})",
+        )
+    return [
+        OptionLeg(
+            underlying=underlying, expiry=near_expiry,
+            strike=float(strike), option_type=option_type,
+            side="sell_to_open", qty=qty,
+        ),
+        OptionLeg(
+            underlying=underlying, expiry=far_expiry,
+            strike=float(strike), option_type=option_type,
+            side="buy_to_open", qty=qty,
+        ),
+    ]
+
+
+def closing_legs(legs: list[OptionLeg]) -> list[OptionLeg]:
+    """Return the closing-side mirror of an open multi-leg structure.
+
+    Each ``buy_to_open`` becomes ``sell_to_close``; each ``sell_to_open``
+    becomes ``buy_to_close``. Useful for one-click "close the condor"
+    flows in the Streamlit UI.
+    """
+    pair = {
+        "buy_to_open":  "sell_to_close",
+        "sell_to_open": "buy_to_close",
+    }
+    out: list[OptionLeg] = []
+    for leg in legs:
+        side_lower = leg.side.lower()
+        if side_lower not in pair:
+            raise ValueError(
+                f"closing_legs only accepts opening sides, got {leg.side!r}",
+            )
+        out.append(
+            OptionLeg(
+                underlying=leg.underlying, expiry=leg.expiry,
+                strike=leg.strike, option_type=leg.option_type,
+                side=pair[side_lower], qty=leg.qty,
+                option_symbol=leg.option_symbol,
+            )
+        )
+    return out

--- a/tests/test_options_legs.py
+++ b/tests/test_options_legs.py
@@ -1,0 +1,178 @@
+"""
+tests/test_options_legs.py — multi-leg builder validation.
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from strategies.options_legs import (
+    OptionLeg,
+    calendar,
+    closing_legs,
+    iron_condor,
+    straddle,
+    vertical_spread,
+)
+
+# ── OptionLeg validation ─────────────────────────────────────────────────────
+
+def test_option_leg_validates_strike():
+    with pytest.raises(ValueError, match="strike"):
+        OptionLeg(
+            underlying="SPY", expiry="2026-06-19", strike=0,
+            option_type="call", side="buy_to_open", qty=1,
+        )
+
+
+def test_option_leg_validates_qty():
+    with pytest.raises(ValueError, match="qty"):
+        OptionLeg(
+            underlying="SPY", expiry="2026-06-19", strike=100,
+            option_type="call", side="buy_to_open", qty=0,
+        )
+
+
+def test_option_leg_validates_side():
+    with pytest.raises(ValueError, match="side"):
+        OptionLeg(
+            underlying="SPY", expiry="2026-06-19", strike=100,
+            option_type="call", side="long", qty=1,
+        )
+
+
+def test_option_leg_validates_option_type():
+    with pytest.raises(ValueError, match="option_type"):
+        OptionLeg(
+            underlying="SPY", expiry="2026-06-19", strike=100,
+            option_type="future", side="buy_to_open", qty=1,
+        )
+
+
+def test_option_leg_validates_expiry_format():
+    with pytest.raises(ValueError, match="expiry"):
+        OptionLeg(
+            underlying="SPY", expiry="june", strike=100,
+            option_type="call", side="buy_to_open", qty=1,
+        )
+
+
+def test_signed_qty_long_short():
+    long_leg = OptionLeg(
+        underlying="SPY", expiry="2026-06-19", strike=100,
+        option_type="call", side="buy_to_open", qty=3,
+    )
+    short_leg = OptionLeg(
+        underlying="SPY", expiry="2026-06-19", strike=100,
+        option_type="call", side="sell_to_open", qty=3,
+    )
+    assert long_leg.signed_qty == 3
+    assert long_leg.is_long is True
+    assert short_leg.signed_qty == -3
+    assert short_leg.is_long is False
+
+
+# ── Vertical spread ──────────────────────────────────────────────────────────
+
+def test_vertical_spread_two_legs_opposite_sides():
+    legs = vertical_spread(
+        "SPY", "2026-06-19",
+        long_strike=450.0, short_strike=455.0,
+    )
+    assert len(legs) == 2
+    assert legs[0].side == "buy_to_open"
+    assert legs[0].strike == 450.0
+    assert legs[1].side == "sell_to_open"
+    assert legs[1].strike == 455.0
+    assert {leg.option_type for leg in legs} == {"call"}
+
+
+def test_vertical_spread_rejects_equal_strikes():
+    with pytest.raises(ValueError, match="differ"):
+        vertical_spread("SPY", "2026-06-19", 450, 450)
+
+
+# ── Iron condor ──────────────────────────────────────────────────────────────
+
+def test_iron_condor_four_legs_correct_sides():
+    legs = iron_condor(
+        "SPY", "2026-06-19",
+        put_long_strike=440, put_short_strike=445,
+        call_short_strike=455, call_long_strike=460,
+        qty=2,
+    )
+    assert len(legs) == 4
+    assert all(leg.qty == 2 for leg in legs)
+
+    # Legs in canonical order: long put, short put, short call, long call.
+    assert legs[0].option_type == "put"  and legs[0].side == "buy_to_open"
+    assert legs[1].option_type == "put"  and legs[1].side == "sell_to_open"
+    assert legs[2].option_type == "call" and legs[2].side == "sell_to_open"
+    assert legs[3].option_type == "call" and legs[3].side == "buy_to_open"
+
+    # Net signed_qty should be zero (two long, two short).
+    assert sum(leg.signed_qty for leg in legs) == 0
+
+
+def test_iron_condor_rejects_misordered_strikes():
+    with pytest.raises(ValueError, match="strikes must satisfy"):
+        iron_condor(
+            "SPY", "2026-06-19",
+            put_long_strike=445, put_short_strike=440,  # swapped
+            call_short_strike=455, call_long_strike=460,
+        )
+
+
+# ── Straddle ─────────────────────────────────────────────────────────────────
+
+def test_long_straddle_two_legs_buy_to_open():
+    legs = straddle("SPY", "2026-06-19", strike=450, long=True)
+    assert len(legs) == 2
+    assert {leg.option_type for leg in legs} == {"call", "put"}
+    assert all(leg.side == "buy_to_open" for leg in legs)
+
+
+def test_short_straddle_two_legs_sell_to_open():
+    legs = straddle("SPY", "2026-06-19", strike=450, long=False)
+    assert all(leg.side == "sell_to_open" for leg in legs)
+
+
+# ── Calendar ─────────────────────────────────────────────────────────────────
+
+def test_calendar_two_legs_short_near_long_far():
+    legs = calendar("SPY", "2026-06-19", "2026-09-18", strike=450)
+    assert len(legs) == 2
+    assert legs[0].expiry == "2026-06-19" and legs[0].side == "sell_to_open"
+    assert legs[1].expiry == "2026-09-18" and legs[1].side == "buy_to_open"
+
+
+def test_calendar_rejects_inverted_expiry():
+    with pytest.raises(ValueError, match="earlier than"):
+        calendar("SPY", "2026-09-18", "2026-06-19", strike=450)
+
+
+# ── closing_legs ─────────────────────────────────────────────────────────────
+
+def test_closing_legs_mirrors_open_sides():
+    open_legs = vertical_spread("SPY", "2026-06-19", 450, 455)
+    closes = closing_legs(open_legs)
+    assert closes[0].side == "sell_to_close"
+    assert closes[1].side == "buy_to_close"
+    # Strikes / expiries / qtys preserved.
+    for o, c in zip(open_legs, closes):
+        assert o.strike == c.strike
+        assert o.expiry == c.expiry
+        assert o.qty == c.qty
+
+
+def test_closing_legs_rejects_already_closed():
+    leg = OptionLeg(
+        underlying="SPY", expiry="2026-06-19", strike=450,
+        option_type="call", side="sell_to_close", qty=1,
+    )
+    with pytest.raises(ValueError, match="opening sides"):
+        closing_legs([leg])

--- a/tests/test_options_sizing.py
+++ b/tests/test_options_sizing.py
@@ -1,0 +1,135 @@
+"""
+tests/test_options_sizing.py — delta-neutral / max-vega sizing.
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from risk.options_sizing import (
+    LegMarket,
+    cap_by_max_vega,
+    delta_neutral_qty,
+    scale_legs,
+)
+from strategies.options_legs import iron_condor, straddle
+
+# ── delta_neutral_qty ────────────────────────────────────────────────────────
+
+def test_delta_neutral_caps_directional_long_call():
+    """A standalone long call is highly directional — large delta. The
+    sizer truncates the multiplier so |delta × m × 100| stays under cap."""
+    legs = straddle("SPY", "2026-06-19", strike=450, long=True)
+    # Both legs at-the-money: delta is roughly +0.5 call, -0.5 put — net flat.
+    # Substitute a clearly directional structure: just the long call leg.
+    legs = [legs[0]]  # one buy_to_open call
+    market = {0: LegMarket(S=450.0, T=0.25, sigma=0.20)}
+    qty = delta_neutral_qty(legs, market, max_abs_delta_shares=100)
+    assert qty >= 1
+    # With ~50 share-deltas per contract, qty=2 gives ~100 — at the cap.
+    assert qty <= 2
+
+
+def test_delta_neutral_returns_zero_when_one_contract_breaches():
+    """Strict caps below one contract's delta are honoured by truncation
+    to zero — caller must not place the order."""
+    from strategies.options_legs import OptionLeg
+
+    legs = [
+        OptionLeg(
+            underlying="SPY", expiry="2026-06-19", strike=450,
+            option_type="call", side="buy_to_open", qty=1,
+        ),
+    ]
+    market = {0: LegMarket(S=450.0, T=0.25, sigma=0.20)}
+    # 10 share-deltas cap is below the ~50-delta of an ATM call → 0.
+    qty = delta_neutral_qty(legs, market, max_abs_delta_shares=10)
+    assert qty == 0
+
+
+def test_delta_neutral_handles_neutral_structure():
+    """A balanced long straddle is delta-near-zero — sizer returns the
+    base qty without dividing by ~zero."""
+    legs = straddle("SPY", "2026-06-19", strike=450, long=True, qty=1)
+    market = {
+        0: LegMarket(S=450.0, T=0.25, sigma=0.20),
+        1: LegMarket(S=450.0, T=0.25, sigma=0.20),
+    }
+    qty = delta_neutral_qty(legs, market, max_abs_delta_shares=50)
+    # Net delta ≈ 0 → sizer falls back to the base leg qty (1).
+    assert qty >= 1
+
+
+def test_delta_neutral_rejects_non_positive_cap():
+    legs = straddle("SPY", "2026-06-19", strike=450)
+    market = {
+        0: LegMarket(S=450.0, T=0.25, sigma=0.20),
+        1: LegMarket(S=450.0, T=0.25, sigma=0.20),
+    }
+    with pytest.raises(ValueError, match="max_abs_delta"):
+        delta_neutral_qty(legs, market, max_abs_delta_shares=0)
+
+
+# ── cap_by_max_vega ──────────────────────────────────────────────────────────
+
+def test_cap_by_max_vega_truncates_to_cap():
+    """An iron condor is short vega; cap_by_max_vega picks the largest m."""
+    legs = iron_condor(
+        "SPY", "2026-06-19",
+        put_long_strike=440, put_short_strike=445,
+        call_short_strike=455, call_long_strike=460,
+    )
+    market = {
+        i: LegMarket(S=450.0, T=0.25, sigma=0.20)
+        for i in range(len(legs))
+    }
+    qty = cap_by_max_vega(legs, market, max_vega_dollars=200.0)
+    assert qty >= 1
+
+
+def test_cap_by_max_vega_zero_when_one_contract_breaches():
+    legs = iron_condor(
+        "SPY", "2026-06-19",
+        put_long_strike=440, put_short_strike=445,
+        call_short_strike=455, call_long_strike=460,
+    )
+    market = {
+        i: LegMarket(S=450.0, T=0.25, sigma=0.20)
+        for i in range(len(legs))
+    }
+    qty = cap_by_max_vega(legs, market, max_vega_dollars=0.001)
+    assert qty == 0
+
+
+def test_cap_by_max_vega_rejects_non_positive_cap():
+    legs = iron_condor(
+        "SPY", "2026-06-19",
+        put_long_strike=440, put_short_strike=445,
+        call_short_strike=455, call_long_strike=460,
+    )
+    market = {
+        i: LegMarket(S=450.0, T=0.25, sigma=0.20)
+        for i in range(len(legs))
+    }
+    with pytest.raises(ValueError, match="max_vega"):
+        cap_by_max_vega(legs, market, max_vega_dollars=0)
+
+
+# ── scale_legs ───────────────────────────────────────────────────────────────
+
+def test_scale_legs_multiplies_qty():
+    legs = straddle("SPY", "2026-06-19", strike=450, qty=1)
+    scaled = scale_legs(legs, multiplier=4)
+    assert all(leg.qty == 4 for leg in scaled)
+    # Original leg list is untouched.
+    assert all(leg.qty == 1 for leg in legs)
+
+
+def test_scale_legs_zero_returns_empty():
+    legs = straddle("SPY", "2026-06-19", strike=450, qty=1)
+    assert scale_legs(legs, multiplier=0) == []
+    assert scale_legs(legs, multiplier=-3) == []

--- a/tests/test_tradier_multi_leg.py
+++ b/tests/test_tradier_multi_leg.py
@@ -1,0 +1,145 @@
+"""
+tests/test_tradier_multi_leg.py — tradier_bridge.place_multi_leg payload.
+
+Mocks ``requests.post`` so no HTTP fires and asserts the multileg payload
+matches Tradier's documented form.
+"""
+from __future__ import annotations
+
+import os
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+import broker.tradier_bridge as tb
+from strategies.options_legs import iron_condor, vertical_spread
+
+
+@pytest.fixture
+def configured_tradier(monkeypatch):
+    """Inject sentinel credentials so _is_configured() returns True."""
+    monkeypatch.setattr(tb, "TRADIER_API_KEY", "test-key")
+    monkeypatch.setattr(tb, "TRADIER_ACCOUNT_ID", "test-acct")
+    monkeypatch.setattr(tb, "TRADIER_SANDBOX", True)
+    monkeypatch.setattr(tb, "BASE_URL", "https://sandbox.example/v1")
+
+
+def _install_fake_post(monkeypatch, captured: dict, payload_json: dict | None = None):
+    class _Resp:
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return payload_json or {"order": {"id": "abc-123", "status": "ok"}}
+
+    def _fake_post(url, headers=None, data=None, timeout=None):
+        captured["url"] = url
+        captured["headers"] = headers
+        captured["data"] = data
+        return _Resp()
+
+    monkeypatch.setitem(sys.modules, "requests", SimpleNamespace(post=_fake_post))
+
+
+# ── OCC symbol helper ────────────────────────────────────────────────────────
+
+def test_occ_symbol_format():
+    sym = tb._occ_symbol("SPY", "2026-06-19", "call", 450.0)
+    assert sym == "SPY260619C00450000"
+
+    sym_put = tb._occ_symbol("AAPL", "2026-12-18", "put", 175.5)
+    assert sym_put == "AAPL261218P00175500"
+
+
+# ── place_multi_leg payload shape ────────────────────────────────────────────
+
+def test_place_multi_leg_builds_iron_condor_payload(configured_tradier, monkeypatch):
+    legs = iron_condor(
+        "SPY", "2026-06-19",
+        put_long_strike=440, put_short_strike=445,
+        call_short_strike=455, call_long_strike=460,
+        qty=2,
+    )
+    captured: dict = {}
+    _install_fake_post(monkeypatch, captured)
+
+    result = tb.place_multi_leg(legs, order_type="credit")
+    assert result is not None
+    assert result["order_id"] == "abc-123"
+    assert result["legs"] == 4
+    assert result["underlying"] == "SPY"
+    assert result["order_type"] == "credit"
+
+    data = captured["data"]
+    assert data["class"] == "multileg"
+    assert data["symbol"] == "SPY"
+    assert data["type"] == "credit"
+    assert data["duration"] == "day"
+    # Four indexed legs.
+    assert data["option_symbol[0]"] == "SPY260619P00440000"
+    assert data["side[0]"] == "buy_to_open"
+    assert data["quantity[0]"] == "2"
+    assert data["option_symbol[3]"] == "SPY260619C00460000"
+    assert data["side[3]"] == "buy_to_open"
+
+
+def test_place_multi_leg_uses_provided_option_symbol(configured_tradier, monkeypatch):
+    """Pre-resolved OCC symbols on the leg take precedence over the
+    OCC builder so callers can paste in venue-specific identifiers."""
+    legs = vertical_spread("SPY", "2026-06-19", 450, 455)
+    legs = [
+        type(legs[0])(
+            underlying=legs[0].underlying, expiry=legs[0].expiry,
+            strike=legs[0].strike, option_type=legs[0].option_type,
+            side=legs[0].side, qty=legs[0].qty,
+            option_symbol="CUSTOM_LONG",
+        ),
+        legs[1],  # second leg auto-derives OCC
+    ]
+    captured: dict = {}
+    _install_fake_post(monkeypatch, captured)
+
+    tb.place_multi_leg(legs)
+    data = captured["data"]
+    assert data["option_symbol[0]"] == "CUSTOM_LONG"
+    assert data["option_symbol[1]"] == "SPY260619C00455000"
+
+
+def test_place_multi_leg_rejects_empty_legs():
+    with pytest.raises(ValueError, match="at least one leg"):
+        tb.place_multi_leg([])
+
+
+def test_place_multi_leg_rejects_mixed_underlyings(configured_tradier):
+    spy = vertical_spread("SPY", "2026-06-19", 450, 455)
+    qqq = vertical_spread("QQQ", "2026-06-19", 350, 355)
+    with pytest.raises(ValueError, match="same underlying"):
+        tb.place_multi_leg(spy + qqq)
+
+
+def test_place_multi_leg_returns_none_when_unconfigured(monkeypatch):
+    monkeypatch.setattr(tb, "TRADIER_API_KEY", "")
+    monkeypatch.setattr(tb, "TRADIER_ACCOUNT_ID", "")
+    legs = vertical_spread("SPY", "2026-06-19", 450, 455)
+    assert tb.place_multi_leg(legs) is None
+
+
+def test_place_multi_leg_swallows_http_failure(configured_tradier, monkeypatch):
+    """A 5xx from Tradier returns None instead of raising — matches the
+    project convention used by place_option_order."""
+    class _BoomResp:
+        def raise_for_status(self):
+            raise RuntimeError("503")
+
+        def json(self):
+            return {}
+
+    monkeypatch.setitem(
+        sys.modules, "requests",
+        SimpleNamespace(post=lambda *a, **kw: _BoomResp()),
+    )
+    legs = vertical_spread("SPY", "2026-06-19", 450, 455)
+    assert tb.place_multi_leg(legs) is None


### PR DESCRIPTION
Closes #145.

## Summary

P1.7 of the indie-quant roadmap. Promotes Tradier's options support from single-leg to first-class multi-leg structures.

- **`strategies/options_legs.py`** — new `OptionLeg` dataclass + four builders:
  - `vertical_spread(underlying, expiry, long_strike, short_strike)` (call by default)
  - `iron_condor(underlying, expiry, *, put_long, put_short, call_short, call_long)` — 4-leg credit structure with strike-order validation
  - `straddle(underlying, expiry, strike, *, long=True)`
  - `calendar(underlying, near_expiry, far_expiry, strike)` — short near, long far
  - `closing_legs(open_legs)` — mirror open structure into the matching close sides
- **`risk/options_sizing.py`** — Greeks-aware sizing using the canonical `analysis/greeks.compute_greeks`:
  - `delta_neutral_qty(legs, market, max_abs_delta_shares)` — caps total share-equivalent delta
  - `cap_by_max_vega(legs, market, max_vega_dollars)` — caps total vega exposure
  - `scale_legs(legs, multiplier)` — apply the sizer multiplier
- **`broker/tradier_bridge.py`** — new `place_multi_leg(legs, order_type, duration)` that builds OCC symbols (`_occ_symbol`) and POSTs the `class=multileg` payload Tradier expects. Mixed underlyings / empty leg lists rejected. HTTP failures swallowed to match the existing `place_option_order` convention.

## Test plan

- [x] `pytest tests/test_options_legs.py tests/test_options_sizing.py tests/test_tradier_multi_leg.py -v` — 32/32 pass
- [x] `pytest tests/ -m "not integration" --cov=. --cov-fail-under=76` — 1486 pass, 1 xfail, coverage 77.76%
- [x] `ruff check .` — clean
- [x] `bandit -r . -ll` — 0 HIGH severity
- [x] `pip-audit` — no known vulns
- [ ] Manual: paper-trade an iron condor on SPY in Tradier sandbox; confirm 4 legs in the order book and journal exit.

https://claude.ai/code/session_01WmG6mAtgV1nr1c9NPxBAD8

---
_Generated by [Claude Code](https://claude.ai/code/session_01WmG6mAtgV1nr1c9NPxBAD8)_