### PR TITLE
P1.9: Redis Streams event bus with in-memory fallback (#147)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -127,3 +127,10 @@ LOG_LEVEL=INFO
 # RISK_EXPORTER_ENABLED=1              # opt-in; scheduler skips the tick when 0/false
 # RISK_EXPORTER_INTERVAL_SECONDS=60    # gauge refresh cadence
 # RISK_ALERT_COOLDOWN=3600             # seconds between consecutive drawdown alerts
+
+# Event bus (#147) — Redis Streams pub/sub fan-out for cron + scheduler events.
+# When EVENT_BUS_ENABLED=0 (default) every publish() call is a no-op so existing
+# setups pay zero cost. Flip to 1 to activate Redis Streams.
+# EVENT_BUS_ENABLED=0                  # 1 → real Redis backend; 0 → in-memory no-op
+# REDIS_URL=redis://localhost:6379/0   # backing Redis instance
+# EVENT_BUS_MAX_LEN=100000             # XADD MAXLEN approximate trim per stream

--- a/bus/__init__.py
+++ b/bus/__init__.py
@@ -1,0 +1,1 @@
+"""bus — Redis-Streams event bus for the platform."""

--- a/bus/event_bus.py
+++ b/bus/event_bus.py
@@ -1,0 +1,248 @@
+"""
+bus/event_bus.py — Redis Streams (with in-memory fallback).
+
+Activation is opt-in: ``EVENT_BUS_ENABLED=1`` flips publishers from no-op
+into a real ``redis.Redis().xadd()`` call. When the env var is unset,
+``publish()`` is silent so existing crons / scheduler ticks pay zero
+cost.
+
+Two backends share the same surface:
+
+* :class:`RedisEventBus` — production. Uses ``redis-py`` Streams
+  (``XADD`` for publish, ``XRANGE`` / ``XREAD`` for replay).
+* :class:`InMemoryEventBus` — fallback when the ``redis`` package is
+  missing or ``EVENT_BUS_ENABLED!=1``. Backed by a per-stream list so
+  unit tests can exercise the publish/replay surface without spinning
+  up Redis.
+
+Both implement the same protocol:
+
+    bus.publish(event: Event, stream: str | None = None) -> str
+        Returns a monotonic message-id (``"<timestamp>-<seq>"`` form).
+
+    bus.replay(stream: str, since: str = "0", limit: int = 1000)
+        Yields ``(message_id, Event)`` tuples in publish order.
+
+    bus.subscribe(stream: str, group: str, consumer: str, block_ms: int)
+        Generator over ``(message_id, Event)`` for blocking consumption
+        (Redis only — the in-memory fallback raises NotImplementedError).
+
+Public factory: :func:`get_event_bus()`. Threadsafe singleton; honours
+``EVENT_BUS_ENABLED`` and ``REDIS_URL`` env vars.
+"""
+from __future__ import annotations
+
+import json
+import os
+import threading
+import time
+from collections import defaultdict
+from typing import Iterator
+
+import structlog
+
+from bus.events import Event, EventType, Stream  # noqa: F401 — re-export
+
+logger = structlog.get_logger(__name__)
+
+try:
+    import redis as _redis
+except ImportError:
+    _redis = None  # type: ignore[assignment]
+
+
+def _is_enabled() -> bool:
+    raw = os.environ.get("EVENT_BUS_ENABLED", "0").strip().lower()
+    return raw in ("1", "true", "yes", "on")
+
+
+# ── Redis backend ───────────────────────────────────────────────────────────
+
+class RedisEventBus:
+    """Redis Streams implementation."""
+
+    def __init__(
+        self,
+        url: str | None = None,
+        *,
+        max_len: int | None = None,
+    ) -> None:
+        if _redis is None:
+            raise ImportError(
+                "redis package is required for RedisEventBus. "
+                "Install it with: pip install redis",
+            )
+        self._url = url or os.environ.get("REDIS_URL", "redis://localhost:6379/0")
+        self._max_len = max_len if max_len is not None else int(
+            os.environ.get("EVENT_BUS_MAX_LEN", "100000"),
+        )
+        self._client = _redis.from_url(self._url, decode_responses=True)
+
+    def publish(self, event: Event, stream: str | None = None) -> str:
+        target = stream or Stream.for_event(event.event_type)
+        fields = {
+            "event_type": event.event_type,
+            "ts": event.ts,
+            "payload": json.dumps(event.payload),
+        }
+        kwargs: dict = {}
+        if self._max_len:
+            kwargs["maxlen"] = self._max_len
+            kwargs["approximate"] = True
+        return self._client.xadd(target, fields, **kwargs)
+
+    def replay(
+        self,
+        stream: str,
+        since: str = "0",
+        limit: int = 1000,
+    ) -> Iterator[tuple[str, Event]]:
+        rows = self._client.xrange(stream, min=since, count=limit)
+        for msg_id, fields in rows:
+            yield msg_id, _decode_event(fields)
+
+    def subscribe(
+        self,
+        stream: str,
+        group: str,
+        consumer: str,
+        block_ms: int = 5000,
+    ) -> Iterator[tuple[str, Event]]:
+        # Best-effort group create — ignore BUSYGROUP if it already exists.
+        try:
+            self._client.xgroup_create(stream, group, id="0", mkstream=True)
+        except Exception as exc:  # pragma: no cover — group already exists
+            if "BUSYGROUP" not in str(exc):
+                raise
+        while True:
+            response = self._client.xreadgroup(
+                group, consumer, {stream: ">"}, count=10, block=block_ms,
+            )
+            if not response:
+                continue
+            for _stream, messages in response:
+                for msg_id, fields in messages:
+                    yield msg_id, _decode_event(fields)
+
+
+# ── In-memory backend ───────────────────────────────────────────────────────
+
+class InMemoryEventBus:
+    """List-backed fallback. Not thread-safe across processes — single-process
+    only. Useful for unit tests and offline dev runs."""
+
+    def __init__(self) -> None:
+        self._streams: dict[str, list[tuple[str, dict]]] = defaultdict(list)
+        self._seq = 0
+        self._lock = threading.Lock()
+
+    def _next_id(self) -> str:
+        with self._lock:
+            self._seq += 1
+            return f"{int(time.time() * 1000)}-{self._seq}"
+
+    def publish(self, event: Event, stream: str | None = None) -> str:
+        target = stream or Stream.for_event(event.event_type)
+        fields = {
+            "event_type": event.event_type,
+            "ts": event.ts,
+            "payload": json.dumps(event.payload),
+        }
+        msg_id = self._next_id()
+        with self._lock:
+            self._streams[target].append((msg_id, fields))
+        return msg_id
+
+    def replay(
+        self,
+        stream: str,
+        since: str = "0",
+        limit: int = 1000,
+    ) -> Iterator[tuple[str, Event]]:
+        with self._lock:
+            rows = list(self._streams.get(stream, []))
+        out: list[tuple[str, Event]] = []
+        for msg_id, fields in rows:
+            if since != "0" and msg_id < since:
+                continue
+            out.append((msg_id, _decode_event(fields)))
+            if len(out) >= limit:
+                break
+        yield from out
+
+    def subscribe(self, *args, **kwargs):
+        raise NotImplementedError(
+            "InMemoryEventBus does not support blocking subscribe; "
+            "use a real Redis instance via EVENT_BUS_ENABLED=1.",
+        )
+
+
+def _decode_event(fields: dict) -> Event:
+    payload_raw = fields.get("payload", "{}")
+    try:
+        payload = json.loads(payload_raw)
+    except (TypeError, json.JSONDecodeError):
+        payload = {"raw": payload_raw}
+    return Event(
+        event_type=fields.get("event_type", ""),
+        payload=payload,
+        ts=fields.get("ts", ""),
+    )
+
+
+# ── Singleton factory ───────────────────────────────────────────────────────
+
+_bus_lock = threading.Lock()
+_bus_instance: RedisEventBus | InMemoryEventBus | None = None
+
+
+def get_event_bus() -> RedisEventBus | InMemoryEventBus:
+    """Return the configured singleton bus.
+
+    Picks Redis when ``EVENT_BUS_ENABLED=1`` and the ``redis`` package
+    is importable; otherwise falls back to the in-memory backend so
+    callers never crash on a missing dependency.
+    """
+    global _bus_instance
+    if _bus_instance is not None:
+        return _bus_instance
+    with _bus_lock:
+        if _bus_instance is not None:
+            return _bus_instance
+        if _is_enabled() and _redis is not None:
+            try:
+                _bus_instance = RedisEventBus()
+                logger.info("event_bus: Redis backend active")
+            except Exception as exc:
+                logger.warning(
+                    "event_bus: Redis init failed, falling back to memory",
+                    error=str(exc),
+                )
+                _bus_instance = InMemoryEventBus()
+        else:
+            _bus_instance = InMemoryEventBus()
+    return _bus_instance
+
+
+def reset_event_bus() -> None:
+    """Reset the singleton — intended for tests."""
+    global _bus_instance
+    with _bus_lock:
+        _bus_instance = None
+
+
+# ── Publish helper (best-effort, never raises) ──────────────────────────────
+
+def publish(event_type: str, payload: dict, stream: str | None = None) -> str | None:
+    """Convenience wrapper used by cron / scheduler / agent code.
+
+    Failures are swallowed with a structured-log warning — the bus must
+    never bring down the calling cron when Redis is unreachable.
+    """
+    try:
+        evt = Event(event_type=event_type, payload=payload)
+        return get_event_bus().publish(evt, stream=stream)
+    except Exception as exc:
+        logger.warning("event_bus: publish failed",
+                       event_type=event_type, error=str(exc))
+        return None

--- a/bus/events.py
+++ b/bus/events.py
@@ -1,0 +1,75 @@
+"""
+bus/events.py — typed event constants + Event dataclass for the bus.
+
+Event types are namespaced ``<domain>.<verb>`` strings so consumers can
+filter with simple prefix matching. The set is intentionally small;
+publishers stick to this enumeration so dashboards and the replay tool
+can rely on stable identifiers.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any
+
+# ── Event-type constants ────────────────────────────────────────────────────
+
+class EventType:
+    SIGNAL_GENERATED = "signal.generated"
+    ORDER_PLACED     = "order.placed"
+    ORDER_REJECTED   = "order.rejected"
+    ORDER_FILLED     = "order.filled"
+    RISK_BREACH      = "risk.breach"
+    KILLSWITCH       = "kill.switch"
+
+    @classmethod
+    def all(cls) -> tuple[str, ...]:
+        return (
+            cls.SIGNAL_GENERATED,
+            cls.ORDER_PLACED,
+            cls.ORDER_REJECTED,
+            cls.ORDER_FILLED,
+            cls.RISK_BREACH,
+            cls.KILLSWITCH,
+        )
+
+
+# ── Stream constants ────────────────────────────────────────────────────────
+
+class Stream:
+    """Default stream names. Operators may override per-call."""
+
+    SIGNALS  = "signals"
+    ORDERS   = "orders"
+    RISK     = "risk"
+
+    @classmethod
+    def for_event(cls, event_type: str) -> str:
+        if event_type.startswith("signal."):
+            return cls.SIGNALS
+        if event_type.startswith("order.") or event_type.startswith("kill."):
+            return cls.ORDERS
+        if event_type.startswith("risk."):
+            return cls.RISK
+        return "events"  # generic fallback
+
+
+# ── Event dataclass ─────────────────────────────────────────────────────────
+
+@dataclass(frozen=True)
+class Event:
+    """Single bus payload."""
+
+    event_type: str
+    payload: dict[str, Any]
+    ts: str = field(
+        default_factory=lambda: datetime.now(timezone.utc).isoformat(),
+    )
+
+    def __post_init__(self) -> None:
+        if not self.event_type or not isinstance(self.event_type, str):
+            raise ValueError("event_type must be a non-empty string")
+        if not isinstance(self.payload, dict):
+            raise ValueError(
+                f"payload must be a dict, got {type(self.payload).__name__}",
+            )

--- a/risk/metrics_exporter.py
+++ b/risk/metrics_exporter.py
@@ -312,6 +312,24 @@ def maybe_alert_drawdown(
         threshold=-threshold,
         equity=snapshot.equity,
     )
+
+    # Best-effort bus publish (#147). Silently no-ops when EVENT_BUS_ENABLED!=1.
+    try:
+        from bus.event_bus import publish as _bus_publish
+        from bus.events import EventType
+
+        _bus_publish(
+            EventType.RISK_BREACH,
+            {
+                "drawdown": snapshot.drawdown,
+                "threshold": -threshold,
+                "equity": snapshot.equity,
+                "daily_pnl": snapshot.daily_pnl,
+            },
+        )
+    except Exception as exc:  # pragma: no cover — bus is best-effort
+        logger.debug("risk_exporter: bus publish failed", error=str(exc))
+
     return True
 
 

--- a/scripts/replay_events.py
+++ b/scripts/replay_events.py
@@ -1,0 +1,68 @@
+"""
+scripts/replay_events.py — read back the bus stream and print each event.
+
+Usage
+-----
+    python scripts/replay_events.py [--stream signals] [--since 0]
+                                    [--limit 1000] [--format json|pretty]
+
+When ``EVENT_BUS_ENABLED=0`` the in-memory backend is used; the replay
+tool is then only meaningful inside a single live process. With
+``EVENT_BUS_ENABLED=1`` the tool reads from Redis Streams.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from bus.event_bus import get_event_bus  # noqa: E402
+from bus.events import Stream  # noqa: E402
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="scripts.replay_events",
+        description="Replay events from the bus.",
+    )
+    parser.add_argument("--stream", default=Stream.SIGNALS)
+    parser.add_argument("--since", default="0")
+    parser.add_argument("--limit", type=int, default=1000)
+    parser.add_argument(
+        "--format", choices=("json", "pretty"), default="pretty",
+    )
+    return parser
+
+
+def replay(stream: str, since: str, limit: int, fmt: str) -> int:
+    bus = get_event_bus()
+    count = 0
+    for msg_id, event in bus.replay(stream, since=since, limit=limit):
+        if fmt == "json":
+            line = json.dumps(
+                {
+                    "msg_id": msg_id,
+                    "event_type": event.event_type,
+                    "ts": event.ts,
+                    "payload": event.payload,
+                }
+            )
+            print(line)
+        else:
+            print(f"{msg_id}  {event.ts}  {event.event_type}  {event.payload}")
+        count += 1
+    if count == 0:
+        print(f"# no events on stream {stream!r}", file=sys.stderr)
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_arg_parser().parse_args(argv)
+    return replay(args.stream, args.since, args.limit, args.format)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_e2e_risk_exporter_tick_to_alert.py
+++ b/tests/test_e2e_risk_exporter_tick_to_alert.py
@@ -104,6 +104,16 @@ def test_drawdown_breach_fires_alert_then_cooldown(monkeypatch, journal_db):
     assert refired is True
     assert len(received) == 2
 
+    # Bus publish (P1.9) — every breach must also land on the risk stream.
+    from bus.event_bus import get_event_bus, reset_event_bus
+    from bus.events import EventType, Stream
+
+    bus_rows = list(get_event_bus().replay(Stream.RISK))
+    assert len(bus_rows) >= 2
+    assert all(evt.event_type == EventType.RISK_BREACH for _, evt in bus_rows)
+    assert bus_rows[0][1].payload["drawdown"] == pytest.approx(-1 / 6)
+    reset_event_bus()
+
 
 def test_no_alert_when_within_threshold(monkeypatch, journal_db):
     """Drawdown above the threshold (e.g. -3%) does not broadcast."""

--- a/tests/test_event_bus.py
+++ b/tests/test_event_bus.py
@@ -1,0 +1,192 @@
+"""
+tests/test_event_bus.py — bus.event_bus + bus.events round-trip.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from bus import event_bus
+from bus.event_bus import (
+    InMemoryEventBus,
+    Stream,
+    get_event_bus,
+    publish,
+    reset_event_bus,
+)
+from bus.events import Event, EventType
+
+
+@pytest.fixture(autouse=True)
+def _reset_bus():
+    reset_event_bus()
+    yield
+    reset_event_bus()
+
+
+# ── Event dataclass ──────────────────────────────────────────────────────────
+
+def test_event_validates_event_type():
+    with pytest.raises(ValueError, match="event_type"):
+        Event(event_type="", payload={})
+
+
+def test_event_validates_payload_type():
+    with pytest.raises(ValueError, match="payload"):
+        Event(event_type=EventType.SIGNAL_GENERATED, payload="not-a-dict")
+
+
+def test_event_default_ts_is_set():
+    e = Event(EventType.SIGNAL_GENERATED, {"ticker": "AAPL"})
+    assert e.ts  # ISO 8601 string
+
+
+def test_event_type_constants():
+    expected = {
+        "signal.generated", "order.placed", "order.rejected",
+        "order.filled", "risk.breach", "kill.switch",
+    }
+    assert set(EventType.all()) == expected
+
+
+def test_stream_routing_by_event_type():
+    assert Stream.for_event(EventType.SIGNAL_GENERATED) == Stream.SIGNALS
+    assert Stream.for_event(EventType.ORDER_PLACED)     == Stream.ORDERS
+    assert Stream.for_event(EventType.ORDER_REJECTED)   == Stream.ORDERS
+    assert Stream.for_event(EventType.RISK_BREACH)      == Stream.RISK
+    assert Stream.for_event(EventType.KILLSWITCH)       == Stream.ORDERS
+    assert Stream.for_event("unknown.event")            == "events"
+
+
+# ── In-memory backend ───────────────────────────────────────────────────────
+
+def test_inmemory_publish_and_replay_round_trip():
+    bus = InMemoryEventBus()
+    bus.publish(Event(EventType.SIGNAL_GENERATED, {"ticker": "AAPL", "score": 0.4}))
+    bus.publish(Event(EventType.ORDER_PLACED,    {"ticker": "AAPL", "qty": 10}))
+
+    sigs = list(bus.replay(Stream.SIGNALS))
+    orders = list(bus.replay(Stream.ORDERS))
+
+    assert len(sigs)   == 1
+    assert len(orders) == 1
+    assert sigs[0][1].event_type   == EventType.SIGNAL_GENERATED
+    assert sigs[0][1].payload      == {"ticker": "AAPL", "score": 0.4}
+    assert orders[0][1].event_type == EventType.ORDER_PLACED
+
+
+def test_inmemory_replay_with_limit():
+    bus = InMemoryEventBus()
+    for i in range(5):
+        bus.publish(Event(EventType.SIGNAL_GENERATED, {"i": i}))
+    rows = list(bus.replay(Stream.SIGNALS, limit=3))
+    assert len(rows) == 3
+
+
+def test_inmemory_replay_since_filter():
+    bus = InMemoryEventBus()
+    ids: list[str] = []
+    for i in range(3):
+        ids.append(bus.publish(Event(EventType.SIGNAL_GENERATED, {"i": i})))
+    rows = list(bus.replay(Stream.SIGNALS, since=ids[1]))
+    assert len(rows) == 2  # rows >= ids[1]
+
+
+def test_inmemory_subscribe_raises():
+    bus = InMemoryEventBus()
+    with pytest.raises(NotImplementedError):
+        next(bus.subscribe("signals", "g", "c"))
+
+
+# ── publish() helper + factory selection ────────────────────────────────────
+
+def test_publish_helper_uses_inmemory_when_disabled(monkeypatch):
+    monkeypatch.delenv("EVENT_BUS_ENABLED", raising=False)
+    bus = get_event_bus()
+    assert isinstance(bus, InMemoryEventBus)
+
+    msg_id = publish(EventType.RISK_BREACH, {"drawdown": -0.15})
+    assert msg_id is not None
+    rows = list(bus.replay(Stream.RISK))
+    assert len(rows) == 1
+    assert rows[0][1].payload == {"drawdown": -0.15}
+
+
+def test_factory_falls_back_to_memory_when_redis_init_fails(monkeypatch):
+    monkeypatch.setenv("EVENT_BUS_ENABLED", "1")
+
+    def _broken_init(*args, **kwargs):
+        raise RuntimeError("redis unreachable")
+
+    monkeypatch.setattr(event_bus, "RedisEventBus", _broken_init)
+
+    bus = get_event_bus()
+    assert isinstance(bus, InMemoryEventBus)
+
+
+def test_publish_helper_swallows_event_validation_errors(monkeypatch):
+    """An invalid event payload shape must not crash the cron — the
+    helper logs and returns None."""
+    monkeypatch.delenv("EVENT_BUS_ENABLED", raising=False)
+    msg_id = publish("", {"bad": "type"})
+    assert msg_id is None
+
+
+def test_factory_singleton_returns_same_instance(monkeypatch):
+    monkeypatch.delenv("EVENT_BUS_ENABLED", raising=False)
+    bus1 = get_event_bus()
+    bus2 = get_event_bus()
+    assert bus1 is bus2
+
+
+def test_reset_event_bus_clears_singleton(monkeypatch):
+    monkeypatch.delenv("EVENT_BUS_ENABLED", raising=False)
+    bus1 = get_event_bus()
+    reset_event_bus()
+    bus2 = get_event_bus()
+    assert bus1 is not bus2
+
+
+# ── Decode round-trip ───────────────────────────────────────────────────────
+
+def test_decode_event_handles_dict_payload():
+    bus = InMemoryEventBus()
+    bus.publish(Event(EventType.ORDER_FILLED, {"id": "abc", "qty": 5}))
+    rows = list(bus.replay(Stream.ORDERS))
+    assert rows[0][1].payload == {"id": "abc", "qty": 5}
+
+
+def test_decode_event_falls_back_when_payload_unparseable():
+    """The decoder defends against non-JSON strings landing on a stream."""
+    bus = InMemoryEventBus()
+    bus._streams[Stream.SIGNALS].append(
+        ("123-1", {"event_type": "signal.generated", "ts": "now", "payload": "not-json"}),
+    )
+    rows = list(bus.replay(Stream.SIGNALS))
+    assert rows[0][1].payload == {"raw": "not-json"}
+
+
+# ── Stream override ─────────────────────────────────────────────────────────
+
+def test_publish_respects_explicit_stream(monkeypatch):
+    monkeypatch.delenv("EVENT_BUS_ENABLED", raising=False)
+    publish(EventType.SIGNAL_GENERATED, {"ticker": "AAPL"}, stream="custom")
+    bus = get_event_bus()
+    rows = list(bus.replay("custom"))
+    assert len(rows) == 1
+
+
+# ── JSON serialisation of the bus message ────────────────────────────────────
+
+def test_publish_serialises_payload_as_json():
+    bus = InMemoryEventBus()
+    bus.publish(Event(EventType.ORDER_FILLED, {"id": 1, "filled": True}))
+    fields = bus._streams[Stream.ORDERS][0][1]
+    # Stored as JSON string under the "payload" field.
+    assert isinstance(fields["payload"], str)
+    assert json.loads(fields["payload"]) == {"id": 1, "filled": True}


### PR DESCRIPTION
Closes #147.

## Summary

P1.9 of the indie-quant roadmap. Adds a Redis-Streams event bus with an in-memory fallback so cron / scheduler / agent code can fan-out structured events without crashing on hosts without Redis.

- **`bus/event_bus.py`** — `RedisEventBus` (XADD/XRANGE/XREADGROUP) and `InMemoryEventBus` (per-stream list). `get_event_bus()` picks Redis when `EVENT_BUS_ENABLED=1` and the `redis` package is importable; otherwise falls back to the in-memory backend. Best-effort `publish(event_type, payload, stream=None)` helper that swallows exceptions with a structured-log warning.
- **`bus/events.py`** — `Event` dataclass + `EventType` constants (`signal.generated`, `order.placed`, `order.rejected`, `order.filled`, `risk.breach`, `kill.switch`) + `Stream` router so publishers don't pick names by hand.
- **`scripts/replay_events.py`** — replay CLI over `bus.replay()` for the audit trail.
- **`risk/metrics_exporter.py`** — `maybe_alert_drawdown` now publishes a `risk.breach` event after broadcasting an alert. Integration is best-effort.
- **`.env.example`** — documents `EVENT_BUS_ENABLED`, `REDIS_URL`, `EVENT_BUS_MAX_LEN`.

## Test plan

- [x] `pytest tests/test_event_bus.py -v` — 18/18 pass
- [x] `pytest tests/test_e2e_risk_exporter_tick_to_alert.py -v` — 3/3 pass (extends drawdown e2e to assert bus.publish is exercised)
- [x] `pytest tests/ -m "not integration" --cov=. --cov-fail-under=76` — 1530 pass, 1 xfail, coverage 77.67%
- [x] `ruff check .` — clean
- [x] `bandit -r . -ll` — 0 HIGH severity
- [x] `pip-audit` — no known vulns
- [ ] Manual: `EVENT_BUS_ENABLED=1 python scripts/replay_events.py --stream risk` after a drawdown breach lands.

https://claude.ai/code/session_01WmG6mAtgV1nr1c9NPxBAD8

---
_Generated by [Claude Code](https://claude.ai/code/session_01WmG6mAtgV1nr1c9NPxBAD8)_