### PR TITLE
P1.10: append-only audit log + CSV blotter exporter (#148)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,6 @@ htmlcov/
 
 # Pre-trade kill-switch flag (#139) — never commit; operator-local state
 .killswitch
+
+# Audit log records (#148) — operator-local; rotated via audit.logger.rotate
+audit/log/

--- a/audit/__init__.py
+++ b/audit/__init__.py
@@ -1,0 +1,1 @@
+"""audit — append-only JSONL audit log + trade-blotter export (#148)."""

--- a/audit/logger.py
+++ b/audit/logger.py
@@ -1,0 +1,193 @@
+"""
+audit/logger.py — append-only JSONL audit logger.
+
+Every meaningful order-lifecycle event lands as a single JSON line on
+``audit/<run_id>.jsonl``. The format is intentionally trivial so an
+operator can ``grep`` / ``jq`` the log without needing the platform
+running. Each record carries:
+
+    {
+      "ts":       "2026-04-27T03:14:15+00:00",
+      "run_id":   "<8-char>",
+      "kind":     "decision" | "order" | "fill" | "pnl",
+      "ticker":   "AAPL",
+      "details":  { ... arbitrary JSON ... }
+    }
+
+The default log path is the ``audit/`` directory at the repo root. Set
+``AUDIT_LOG_DIR`` to override (e.g. for tests).
+
+Public API
+----------
+    log_decision(run_id, ticker, details)
+    log_order(run_id, ticker, details)
+    log_fill(run_id, ticker, details)
+    log_pnl(run_id, ticker, details)
+    iter_records(start: str | None, end: str | None) -> list[dict]
+    rotate(max_age_days: int) -> int   compress + delete old logs
+"""
+from __future__ import annotations
+
+import gzip
+import json
+import os
+import shutil
+import threading
+import uuid
+from collections.abc import Iterable
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import structlog
+
+logger = structlog.get_logger(__name__)
+
+_DEFAULT_DIR = Path(os.environ.get("AUDIT_LOG_DIR", "audit/log"))
+_LOCK = threading.Lock()
+_VALID_KINDS = ("decision", "order", "fill", "pnl")
+
+
+def new_run_id() -> str:
+    """Return a fresh 8-character hex run id (UUID4 prefix)."""
+    return uuid.uuid4().hex[:8]
+
+
+def _log_dir() -> Path:
+    raw = os.environ.get("AUDIT_LOG_DIR")
+    return Path(raw) if raw else _DEFAULT_DIR
+
+
+def _today_path() -> Path:
+    today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    return _log_dir() / f"{today}.jsonl"
+
+
+def _write_record(record: dict) -> None:
+    path = _today_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    line = json.dumps(record, separators=(",", ":"), sort_keys=True)
+    with _LOCK:
+        with path.open("a", encoding="utf-8") as f:
+            f.write(line)
+            f.write("\n")
+
+
+def _log(kind: str, run_id: str, ticker: str, details: dict) -> None:
+    if kind not in _VALID_KINDS:
+        raise ValueError(
+            f"kind must be one of {_VALID_KINDS}, got {kind!r}",
+        )
+    if not run_id:
+        raise ValueError("run_id must be non-empty")
+    record = {
+        "ts": datetime.now(timezone.utc).isoformat(),
+        "run_id": run_id,
+        "kind": kind,
+        "ticker": ticker.upper().strip() if ticker else "",
+        "details": dict(details or {}),
+    }
+    try:
+        _write_record(record)
+    except OSError as exc:  # pragma: no cover — disk full / permission denied
+        logger.warning("audit_log: write failed", error=str(exc))
+
+
+def log_decision(run_id: str, ticker: str, details: dict | None = None) -> None:
+    _log("decision", run_id, ticker, details or {})
+
+
+def log_order(run_id: str, ticker: str, details: dict | None = None) -> None:
+    _log("order", run_id, ticker, details or {})
+
+
+def log_fill(run_id: str, ticker: str, details: dict | None = None) -> None:
+    _log("fill", run_id, ticker, details or {})
+
+
+def log_pnl(run_id: str, ticker: str, details: dict | None = None) -> None:
+    _log("pnl", run_id, ticker, details or {})
+
+
+# ── Iteration / export ───────────────────────────────────────────────────────
+
+def _date_for_path(path: Path) -> str:
+    """Return the YYYY-MM-DD prefix for a known audit-log filename."""
+    name = path.name
+    if name.endswith(".jsonl"):
+        return name[:-len(".jsonl")]
+    if name.endswith(".jsonl.gz"):
+        return name[:-len(".jsonl.gz")]
+    return ""
+
+
+def iter_records(
+    start_date: str | None = None,
+    end_date: str | None = None,
+) -> Iterable[dict]:
+    """Yield records from every audit log between ``start_date`` and
+    ``end_date`` inclusive (ISO ``YYYY-MM-DD`` strings; both optional).
+
+    Reads ``.jsonl`` and ``.jsonl.gz`` files transparently so callers
+    don't need to know which dates have been rotated.
+    """
+    directory = _log_dir()
+    if not directory.exists():
+        return
+    files = sorted(directory.glob("*.jsonl*"))
+    for path in files:
+        date_str = _date_for_path(path)
+        if start_date and date_str < start_date:
+            continue
+        if end_date and date_str > end_date:
+            continue
+        opener = gzip.open if path.suffix == ".gz" else open
+        with opener(path, "rt", encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    yield json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+
+
+def rotate(max_age_days: int = 90, compress_after_days: int = 7) -> dict:
+    """Compress old logs (gzip) and delete logs past ``max_age_days``.
+
+    Returns a summary dict ``{"compressed": N, "deleted": M}``.
+    """
+    if max_age_days < compress_after_days:
+        raise ValueError(
+            "max_age_days must be >= compress_after_days "
+            f"({max_age_days} vs {compress_after_days})",
+        )
+    directory = _log_dir()
+    if not directory.exists():
+        return {"compressed": 0, "deleted": 0}
+
+    today = datetime.now(timezone.utc).date()
+    compress_cutoff = today - timedelta(days=compress_after_days)
+    delete_cutoff = today - timedelta(days=max_age_days)
+
+    compressed = 0
+    deleted = 0
+    for path in sorted(directory.glob("*.jsonl*")):
+        date_str = _date_for_path(path)
+        if not date_str:
+            continue
+        try:
+            file_date = datetime.strptime(date_str, "%Y-%m-%d").date()
+        except ValueError:
+            continue
+        if file_date < delete_cutoff:
+            path.unlink()
+            deleted += 1
+            continue
+        if path.suffix == ".jsonl" and file_date < compress_cutoff:
+            gz_path = path.with_suffix(".jsonl.gz")
+            with open(path, "rb") as src, gzip.open(gz_path, "wb") as dst:
+                shutil.copyfileobj(src, dst)
+            path.unlink()
+            compressed += 1
+    return {"compressed": compressed, "deleted": deleted}

--- a/scripts/export_blotter.py
+++ b/scripts/export_blotter.py
@@ -1,0 +1,84 @@
+"""
+scripts/export_blotter.py — export the trade blotter as CSV.
+
+Reads from :func:`journal.trading_journal.get_journal` (the canonical
+trade record) and emits a CSV row per trade. Filters by date range so
+operators can produce monthly / quarterly blotters for tax + compliance.
+
+Usage
+-----
+    python scripts/export_blotter.py [--from 2026-01-01] [--to 2026-12-31]
+                                     [--ticker AAPL] [--out blotter.csv]
+
+When ``--out`` is omitted the CSV is written to stdout.
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+_COLUMNS = (
+    "id", "ticker", "side", "qty",
+    "entry_price", "entry_time",
+    "exit_price",  "exit_time",
+    "pnl", "exit_reason",
+    "signal_source", "regime",
+)
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="scripts.export_blotter",
+        description="Export the trading journal as a CSV blotter.",
+    )
+    parser.add_argument("--from", dest="start_date", default=None,
+                        help="Inclusive lower bound on entry_time (ISO date).")
+    parser.add_argument("--to", dest="end_date", default=None,
+                        help="Inclusive upper bound on entry_time (ISO date).")
+    parser.add_argument("--ticker", default=None,
+                        help="Filter to a single ticker symbol.")
+    parser.add_argument("--out", default=None,
+                        help="Output CSV path. Default: stdout.")
+    return parser
+
+
+def _load_journal(start_date, end_date, ticker):
+    from journal.trading_journal import get_journal
+
+    return get_journal(start_date=start_date, end_date=end_date, ticker=ticker)
+
+
+def export(start_date, end_date, ticker, out_path) -> int:
+    df = _load_journal(start_date, end_date, ticker)
+    rows = df.to_dict(orient="records") if not df.empty else []
+
+    if out_path:
+        target = open(out_path, "w", encoding="utf-8", newline="")
+    else:
+        target = sys.stdout
+    try:
+        writer = csv.DictWriter(target, fieldnames=_COLUMNS,
+                                extrasaction="ignore")
+        writer.writeheader()
+        for row in rows:
+            writer.writerow(row)
+    finally:
+        if out_path:
+            target.close()
+    return len(rows)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_arg_parser().parse_args(argv)
+    n = export(args.start_date, args.end_date, args.ticker, args.out)
+    print(f"# exported {n} rows", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_audit_logger.py
+++ b/tests/test_audit_logger.py
@@ -1,0 +1,162 @@
+"""
+tests/test_audit_logger.py — append-only JSONL audit log + rotation.
+"""
+from __future__ import annotations
+
+import gzip
+import json
+import os
+import sys
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from audit import logger as audit
+
+
+@pytest.fixture
+def audit_dir(tmp_path, monkeypatch):
+    monkeypatch.setenv("AUDIT_LOG_DIR", str(tmp_path / "log"))
+    return tmp_path / "log"
+
+
+def _today() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%d")
+
+
+# ── Validation ──────────────────────────────────────────────────────────────
+
+def test_log_rejects_bad_kind(audit_dir):
+    with pytest.raises(ValueError, match="kind"):
+        audit._log("garbage", "rid", "AAPL", {})
+
+
+def test_log_rejects_empty_run_id(audit_dir):
+    with pytest.raises(ValueError, match="run_id"):
+        audit.log_decision("", "AAPL")
+
+
+def test_new_run_id_is_unique():
+    a = audit.new_run_id()
+    b = audit.new_run_id()
+    assert a != b
+    assert len(a) == 8
+
+
+# ── Append + read back ─────────────────────────────────────────────────────
+
+def test_log_decision_round_trip(audit_dir):
+    audit.log_decision("rid-1", "AAPL", {"score": 0.4})
+    audit.log_order("rid-1", "AAPL", {"qty": 10, "side": "buy"})
+    audit.log_fill("rid-1", "AAPL", {"price": 100.0})
+    audit.log_pnl("rid-1", "AAPL", {"pnl": 50.0})
+
+    today = _today()
+    path = audit_dir / f"{today}.jsonl"
+    assert path.exists()
+    lines = path.read_text(encoding="utf-8").strip().split("\n")
+    assert len(lines) == 4
+    parsed = [json.loads(line) for line in lines]
+    assert [r["kind"] for r in parsed] == ["decision", "order", "fill", "pnl"]
+    assert all(r["run_id"] == "rid-1" for r in parsed)
+    assert all(r["ticker"] == "AAPL" for r in parsed)
+
+
+def test_log_normalises_ticker_case(audit_dir):
+    audit.log_order("rid-1", "  aapl ", {"qty": 1})
+    rec = next(audit.iter_records())
+    assert rec["ticker"] == "AAPL"
+
+
+def test_iter_records_filters_by_date(audit_dir):
+    today = _today()
+    audit.log_decision("rid-1", "AAPL", {"i": 1})
+
+    # Manually create a record from yesterday and tomorrow.
+    yesterday = (datetime.now(timezone.utc) - timedelta(days=1)).strftime("%Y-%m-%d")
+    tomorrow  = (datetime.now(timezone.utc) + timedelta(days=1)).strftime("%Y-%m-%d")
+    for date_str, payload in [
+        (yesterday, {"i": "yesterday"}),
+        (tomorrow,  {"i": "tomorrow"}),
+    ]:
+        path = audit_dir / f"{date_str}.jsonl"
+        path.write_text(
+            json.dumps(
+                {"ts": "x", "run_id": "rid-2", "kind": "decision",
+                 "ticker": "T", "details": payload}
+            ) + "\n",
+            encoding="utf-8",
+        )
+
+    only_today = list(audit.iter_records(start_date=today, end_date=today))
+    assert len(only_today) == 1
+    assert only_today[0]["details"]["i"] == 1
+
+    everything = list(audit.iter_records())
+    assert len(everything) == 3
+
+
+def test_iter_records_handles_missing_dir(audit_dir, tmp_path, monkeypatch):
+    monkeypatch.setenv("AUDIT_LOG_DIR", str(tmp_path / "nope"))
+    assert list(audit.iter_records()) == []
+
+
+def test_iter_records_skips_malformed_json(audit_dir):
+    audit.log_order("rid-1", "AAPL", {"qty": 1})
+    path = audit_dir / f"{_today()}.jsonl"
+    with path.open("a", encoding="utf-8") as f:
+        f.write("\n")
+        f.write("not-json\n")
+        f.write("\n")
+    rows = list(audit.iter_records())
+    assert len(rows) == 1
+
+
+# ── Rotation ────────────────────────────────────────────────────────────────
+
+def test_rotate_compresses_old_jsonl(audit_dir):
+    today = datetime.now(timezone.utc).date()
+    old_date = (today - timedelta(days=10)).isoformat()
+    old_path = audit_dir / f"{old_date}.jsonl"
+    old_path.parent.mkdir(parents=True, exist_ok=True)
+    old_path.write_text("{\"x\":1}\n", encoding="utf-8")
+
+    summary = audit.rotate(max_age_days=90, compress_after_days=7)
+    assert summary["compressed"] == 1
+    assert not old_path.exists()
+    gz = audit_dir / f"{old_date}.jsonl.gz"
+    assert gz.exists()
+    assert gzip.decompress(gz.read_bytes()).decode() == "{\"x\":1}\n"
+
+
+def test_rotate_deletes_past_max_age(audit_dir):
+    today = datetime.now(timezone.utc).date()
+    very_old = (today - timedelta(days=120)).isoformat()
+    p = audit_dir / f"{very_old}.jsonl.gz"
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_bytes(gzip.compress(b"{}\n"))
+
+    summary = audit.rotate(max_age_days=90, compress_after_days=7)
+    assert summary["deleted"] == 1
+    assert not p.exists()
+
+
+def test_rotate_handles_missing_dir(tmp_path, monkeypatch):
+    monkeypatch.setenv("AUDIT_LOG_DIR", str(tmp_path / "nope"))
+    assert audit.rotate() == {"compressed": 0, "deleted": 0}
+
+
+def test_rotate_rejects_bad_args(audit_dir):
+    with pytest.raises(ValueError, match="max_age_days"):
+        audit.rotate(max_age_days=3, compress_after_days=7)
+
+
+def test_rotate_skips_unrelated_filenames(audit_dir):
+    audit_dir.mkdir(parents=True, exist_ok=True)
+    junk = audit_dir / "not-a-date.jsonl"
+    junk.write_text("noise\n")
+    # Should not delete or compress a non-dated file.
+    audit.rotate()
+    assert junk.exists()

--- a/tests/test_export_blotter.py
+++ b/tests/test_export_blotter.py
@@ -1,0 +1,103 @@
+"""
+tests/test_export_blotter.py — CSV blotter export from journal.
+"""
+from __future__ import annotations
+
+import csv
+import io
+import os
+import sys
+
+import pandas as pd
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+import scripts.export_blotter as eb
+
+
+@pytest.fixture
+def fake_journal(monkeypatch):
+    captured: dict = {}
+
+    def _fake_get_journal(start_date=None, end_date=None, ticker=None):
+        captured["args"] = (start_date, end_date, ticker)
+        return pd.DataFrame(
+            [
+                {
+                    "id": 1, "ticker": "AAPL", "side": "BUY", "qty": 10,
+                    "entry_price": 100.0, "entry_time": "2026-04-01T10:00",
+                    "exit_price": 110.0,  "exit_time":  "2026-04-15T10:00",
+                    "pnl": 100.0, "exit_reason": "target",
+                    "signal_source": "ml", "regime": "bull",
+                    "extra_field": "drop me",  # extrasaction=ignore drops this
+                },
+                {
+                    "id": 2, "ticker": "SPY", "side": "BUY", "qty": 5,
+                    "entry_price": 450.0, "entry_time": "2026-04-05T10:00",
+                    "exit_price": 445.0,  "exit_time":  "2026-04-09T10:00",
+                    "pnl": -25.0, "exit_reason": "stop",
+                    "signal_source": "test", "regime": "bear",
+                },
+            ]
+        )
+
+    monkeypatch.setattr(
+        "journal.trading_journal.get_journal", _fake_get_journal,
+    )
+    return captured
+
+
+def test_export_writes_csv_to_file(tmp_path, fake_journal):
+    out_path = tmp_path / "blotter.csv"
+    n = eb.export(
+        start_date="2026-04-01", end_date="2026-04-30",
+        ticker=None, out_path=str(out_path),
+    )
+    assert n == 2
+    rows = list(csv.DictReader(out_path.read_text(encoding="utf-8").splitlines()))
+    assert len(rows) == 2
+    assert rows[0]["ticker"] == "AAPL"
+    assert rows[1]["pnl"] == "-25.0"
+    assert "extra_field" not in rows[0]
+
+
+def test_export_writes_csv_to_stdout(monkeypatch, fake_journal):
+    captured = io.StringIO()
+    monkeypatch.setattr(sys, "stdout", captured)
+    n = eb.export(start_date=None, end_date=None, ticker=None, out_path=None)
+    assert n == 2
+    output = captured.getvalue()
+    assert "AAPL" in output
+    assert "SPY"  in output
+    assert "extra_field" not in output
+
+
+def test_export_handles_empty_journal(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        "journal.trading_journal.get_journal",
+        lambda **kw: pd.DataFrame(),
+    )
+    out_path = tmp_path / "empty.csv"
+    n = eb.export(None, None, None, str(out_path))
+    assert n == 0
+    # Even with no rows, the header should be present.
+    text = out_path.read_text(encoding="utf-8")
+    assert "ticker" in text
+
+
+def test_main_returns_zero(monkeypatch, fake_journal, tmp_path):
+    out = tmp_path / "blotter.csv"
+    rc = eb.main(["--from", "2026-04-01", "--to", "2026-04-30",
+                  "--out", str(out)])
+    assert rc == 0
+    assert out.exists()
+
+
+def test_main_passes_filters_to_get_journal(fake_journal, tmp_path):
+    out = tmp_path / "blotter.csv"
+    eb.main([
+        "--from", "2026-04-01", "--to", "2026-04-30",
+        "--ticker", "AAPL", "--out", str(out),
+    ])
+    assert fake_journal["args"] == ("2026-04-01", "2026-04-30", "AAPL")


### PR DESCRIPTION
Closes #148.

## Summary

P1.10 of the indie-quant roadmap. Adds an append-only JSONL audit log + a CSV blotter exporter so operators have a paper trail for every decision/order/fill/pnl event and can produce monthly / quarterly trade summaries for tax + compliance.

- **`audit/logger.py`** — single-source audit logger with `log_decision / log_order / log_fill / log_pnl` helpers. Records land on `audit/log/<YYYY-MM-DD>.jsonl` (override via `AUDIT_LOG_DIR`). `iter_records(start_date, end_date)` reads `.jsonl` + `.jsonl.gz` transparently; `rotate(max_age_days, compress_after_days)` gzips old logs and deletes anything past the retention horizon. `new_run_id()` produces an 8-char hex id so operators can correlate decision → order → fill → pnl across processes.
- **`scripts/export_blotter.py`** — CLI that reads from `journal.trading_journal.get_journal` and emits CSV rows. Filters `--from / --to / --ticker`; writes to `--out` or stdout. Stable column set; extra schema fields dropped via DictWriter `extrasaction='ignore'`.
- **`.gitignore`** — adds `audit/log/` (operator-local, never committed).

## Test plan

- [x] `pytest tests/test_audit_logger.py tests/test_export_blotter.py -v` — 18/18 pass
- [x] `pytest tests/ -m "not integration" --cov=. --cov-fail-under=76` — 1548 pass, 1 xfail, coverage 77.94%
- [x] `ruff check .` — clean
- [x] `bandit -r . -ll` — 0 HIGH severity
- [x] `pip-audit` — no known vulns
- [ ] Manual: trade a few rows in paper mode → `python scripts/export_blotter.py --from 2026-04-01 --out blotter.csv` → CSV diff against `journal_trades.db`.

https://claude.ai/code/session_01WmG6mAtgV1nr1c9NPxBAD8

---
_Generated by [Claude Code](https://claude.ai/code/session_01WmG6mAtgV1nr1c9NPxBAD8)_