### PR TITLE
P1.11: paper-to-live promotion guard (#149)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -128,6 +128,15 @@ LOG_LEVEL=INFO
 # RISK_EXPORTER_INTERVAL_SECONDS=60    # gauge refresh cadence
 # RISK_ALERT_COOLDOWN=3600             # seconds between consecutive drawdown alerts
 
+# Paper-to-live promotion guard (#149) — every live broker
+# (alpaca / ibkr / schwab) refuses to instantiate unless BOTH conditions
+# below are met. Prevents accidentally flipping into real-money trading
+# with one env-var flick.
+# LIVE_TRADING_CONFIRMED=false         # set to "true" only after reviewing the paper run
+# LIVE_PROMOTION_MIN_DAYS=30           # paper journal must show ≥ this many distinct days
+# LIVE_PROMOTION_MIN_SHARPE=0.5        # daily-PnL Sharpe over the paper run
+# LIVE_PROMOTION_BYPASS=0              # 1 → skip both checks (emergency only — logged)
+
 # Event bus (#147) — Redis Streams pub/sub fan-out for cron + scheduler events.
 # When EVENT_BUS_ENABLED=0 (default) every publish() call is a no-op so existing
 # setups pay zero cost. Flip to 1 to activate Redis Streams.

--- a/pages/shared.py
+++ b/pages/shared.py
@@ -62,6 +62,21 @@ def render_sidebar() -> dict:
     # ── Sidebar ───────────────────────────────────────────────────────────────
     st.sidebar.title("📈 Quant Platform")
     st.sidebar.markdown("*Personal Trading Dashboard*")
+
+    # P1.11 — paper / live mode banner. Live mode goes through the promotion
+    # gate; the banner is the visual confirmation operators get before they
+    # see real money on the line.
+    try:
+        from providers.broker import is_live_mode
+
+        if is_live_mode():
+            st.sidebar.error("🔴 LIVE TRADING — real money at risk", icon="🚨")
+        else:
+            st.sidebar.success("🟢 Paper mode — no real orders sent")
+    except Exception:
+        # Never let the banner break the sidebar; the gate enforces safety.
+        pass
+
     st.sidebar.divider()
 
     # ── Section: Chart Controls ───────────────────────────────────────────────

--- a/providers/broker.py
+++ b/providers/broker.py
@@ -113,6 +113,109 @@ class BrokerProvider(Protocol):
         ...
 
 
+_LIVE_PROVIDERS = ("alpaca", "ibkr", "schwab")
+
+
+class LivePromotionRefused(RuntimeError):
+    """Raised by ``get_broker`` when the paper→live promotion guard refuses.
+
+    The exception message names the failing precondition so operators can
+    fix the missing env var or extend the paper track record before
+    flipping ``BROKER_PROVIDER`` to a real venue.
+    """
+
+
+def _live_promotion_check(name: str) -> None:
+    """Refuse to instantiate a live broker without explicit confirmation
+    AND a minimum paper track record.
+
+    Two preconditions must both hold:
+
+    * ``LIVE_TRADING_CONFIRMED=true`` — explicit operator opt-in. Set
+      after reviewing the paper track record + risk limits.
+    * Journal shows ≥ ``LIVE_PROMOTION_MIN_DAYS`` (default 30) of distinct
+      paper-trading days with realised PnL Sharpe ≥
+      ``LIVE_PROMOTION_MIN_SHARPE`` (default 0.5).
+
+    The Sharpe gate is a coarse "did the paper run produce something?"
+    check, not a guarantee of profitability. Operators are still
+    responsible for the strategy review.
+
+    Bypassed entirely when ``LIVE_PROMOTION_BYPASS=1`` — for emergency
+    re-enablement after a kill-switch event. Use sparingly; the bypass
+    is logged at error level so audit trails surface it.
+    """
+    if name not in _LIVE_PROVIDERS:
+        return
+    if os.environ.get("LIVE_PROMOTION_BYPASS", "").strip().lower() in ("1", "true", "yes"):
+        import structlog
+        log = structlog.get_logger(__name__)
+        log.error(
+            "live_promotion: bypass active — skipping confirmation + track-record gate",
+            provider=name,
+        )
+        return
+
+    confirmed = os.environ.get("LIVE_TRADING_CONFIRMED", "").strip().lower() in (
+        "1", "true", "yes",
+    )
+    if not confirmed:
+        raise LivePromotionRefused(
+            f"refusing to instantiate live broker {name!r}: "
+            "LIVE_TRADING_CONFIRMED is not set. Set it to 'true' only "
+            "after reviewing the paper track record + risk limits.",
+        )
+
+    min_days = int(os.environ.get("LIVE_PROMOTION_MIN_DAYS", "30"))
+    min_sharpe = float(os.environ.get("LIVE_PROMOTION_MIN_SHARPE", "0.5"))
+    days, sharpe = _paper_track_record()
+    if days < min_days:
+        raise LivePromotionRefused(
+            f"refusing to instantiate live broker {name!r}: paper journal "
+            f"only has {days} distinct trading days, need ≥ {min_days}. "
+            "Continue paper trading or override with LIVE_PROMOTION_MIN_DAYS.",
+        )
+    if sharpe < min_sharpe:
+        raise LivePromotionRefused(
+            f"refusing to instantiate live broker {name!r}: paper Sharpe "
+            f"{sharpe:.2f} < required {min_sharpe:.2f}. Iterate on the "
+            "strategy or relax LIVE_PROMOTION_MIN_SHARPE if intentional.",
+        )
+
+
+def _paper_track_record() -> tuple[int, float]:
+    """Return ``(distinct_paper_days, daily_pnl_sharpe)`` from the journal.
+
+    Sharpe = mean(daily PnL %) / std(daily PnL %) over the realised exits
+    in ``journal_trades.db``. Returns ``(0, 0.0)`` if the journal is
+    empty / unreadable so a fresh install never accidentally passes.
+    """
+    try:
+        from journal.trading_journal import get_journal
+    except Exception:
+        return 0, 0.0
+    try:
+        df = get_journal()
+    except Exception:
+        return 0, 0.0
+    if df is None or df.empty or "pnl" not in df.columns:
+        return 0, 0.0
+    closed = df.dropna(subset=["pnl", "exit_time"])
+    if closed.empty:
+        return 0, 0.0
+
+    import pandas as pd  # local import — keeps the import cost off cold paths
+
+    days = pd.to_datetime(closed["exit_time"]).dt.date
+    pnl_per_day = closed.groupby(days)["pnl"].sum()
+    if len(pnl_per_day) == 0:
+        return 0, 0.0
+    if len(pnl_per_day) == 1 or pnl_per_day.std() == 0:
+        return int(len(pnl_per_day)), 0.0
+    sharpe = float(pnl_per_day.mean() / pnl_per_day.std())
+    return int(len(pnl_per_day)), sharpe
+
+
 def get_broker(provider: Optional[str] = None) -> BrokerProvider:
     """
     Return a configured BrokerProvider adapter.
@@ -127,8 +230,13 @@ def get_broker(provider: Optional[str] = None) -> BrokerProvider:
     ------
     ValueError
         If the provider name is not recognised.
+    LivePromotionRefused
+        If the resolved provider is a live venue (alpaca / ibkr / schwab)
+        and the operator has not satisfied the P1.11 promotion gate
+        (``LIVE_TRADING_CONFIRMED`` + paper track record).
     """
     name = (provider or os.environ.get("BROKER_PROVIDER", "paper")).lower().strip()
+    _live_promotion_check(name)
     if name == "alpaca":
         from adapters.broker.alpaca_adapter import AlpacaBrokerAdapter
         return AlpacaBrokerAdapter()
@@ -145,3 +253,13 @@ def get_broker(provider: Optional[str] = None) -> BrokerProvider:
         f"Unknown broker provider: {name!r}. "
         "Valid options: alpaca, ibkr, schwab, paper"
     )
+
+
+def is_live_mode(provider: Optional[str] = None) -> bool:
+    """Return ``True`` when the configured broker is a live venue.
+
+    Used by the Streamlit sidebar banner to render the live/paper indicator
+    in the right colour.
+    """
+    name = (provider or os.environ.get("BROKER_PROVIDER", "paper")).lower().strip()
+    return name in _LIVE_PROVIDERS

--- a/tests/test_live_promotion_guard.py
+++ b/tests/test_live_promotion_guard.py
@@ -1,0 +1,228 @@
+"""
+tests/test_live_promotion_guard.py — paper→live promotion gate (#149).
+
+Each case isolates the journal under JOURNAL_DB_PATH so the guard's
+track-record probe runs against a deterministic fixture. The Alpaca /
+IBKR / Schwab adapter classes are monkeypatched to a sentinel so we
+exercise the gate without a real SDK.
+"""
+from __future__ import annotations
+
+import os
+import sys
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+import journal.trading_journal as jt
+from providers.broker import (
+    LivePromotionRefused,
+    _live_promotion_check,
+    _paper_track_record,
+    get_broker,
+    is_live_mode,
+)
+
+# ── Helpers ─────────────────────────────────────────────────────────────────
+
+def _seed_paper_run(days: int, daily_pnl: float = 100.0) -> None:
+    """Seed the journal with one closed trade per day for ``days`` days."""
+    start = datetime.now(timezone.utc) - timedelta(days=days)
+    for i in range(days):
+        ts = (start + timedelta(days=i)).isoformat()
+        # Cheat: drive entry_time + exit_time directly via a manual insert
+        # so we don't have to wait for real-clock days to elapse.
+        from journal.trading_journal import _get_connection
+
+        conn = _get_connection()
+        try:
+            with conn:
+                conn.execute(
+                    """
+                    INSERT INTO trades
+                        (ticker, side, qty, entry_price, entry_time,
+                         signal_source, regime, entry_notes,
+                         exit_price, exit_time, pnl, exit_reason)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        "TEST", "BUY", 1, 100.0, ts,
+                        "test", "", "",
+                        100.0 + (daily_pnl / 100), ts,
+                        daily_pnl + (i * 0.1),  # tiny variance for non-zero std
+                        "target",
+                    ),
+                )
+        finally:
+            conn.close()
+
+
+@pytest.fixture
+def journal_db(tmp_path, monkeypatch):
+    monkeypatch.setenv("JOURNAL_DB_PATH", str(tmp_path / "journal.db"))
+    jt.init_journal_table()
+    return tmp_path
+
+
+@pytest.fixture
+def fake_adapters(monkeypatch):
+    """Replace each live adapter class with a constructor that records the call."""
+    captured = {"alpaca": 0, "ibkr": 0, "schwab": 0}
+
+    class _FakeAlpaca:
+        def __init__(self):
+            captured["alpaca"] += 1
+
+    class _FakeIBKR:
+        def __init__(self):
+            captured["ibkr"] += 1
+
+    class _FakeSchwab:
+        def __init__(self):
+            captured["schwab"] += 1
+
+    monkeypatch.setattr(
+        "adapters.broker.alpaca_adapter.AlpacaBrokerAdapter", _FakeAlpaca,
+    )
+    monkeypatch.setattr(
+        "adapters.broker.ibkr_adapter.IBKRAdapter", _FakeIBKR,
+    )
+    monkeypatch.setattr(
+        "adapters.broker.schwab_adapter.SchwabAdapter", _FakeSchwab,
+    )
+    return captured
+
+
+# ── Track-record helper ─────────────────────────────────────────────────────
+
+def test_track_record_empty_journal(journal_db):
+    assert _paper_track_record() == (0, 0.0)
+
+
+def test_track_record_counts_distinct_days_and_sharpe(journal_db):
+    _seed_paper_run(days=20, daily_pnl=50.0)
+    days, sharpe = _paper_track_record()
+    assert days == 20
+    assert sharpe > 0
+
+
+def test_track_record_zero_std_returns_zero_sharpe(journal_db):
+    _seed_paper_run(days=10, daily_pnl=100.0)
+    # Patch out the variance so std == 0 → sharpe == 0 short-circuit.
+    from journal.trading_journal import _get_connection
+
+    conn = _get_connection()
+    with conn:
+        conn.execute("UPDATE trades SET pnl = 100.0")
+    conn.close()
+    days, sharpe = _paper_track_record()
+    assert days == 10
+    assert sharpe == 0.0
+
+
+# ── Paper passes through unchanged ──────────────────────────────────────────
+
+def test_paper_provider_never_gated(monkeypatch, journal_db):
+    """The paper broker is exempt from the promotion gate by design."""
+    monkeypatch.setenv("BROKER_PROVIDER", "paper")
+    monkeypatch.delenv("LIVE_TRADING_CONFIRMED", raising=False)
+    # Should not raise.
+    broker = get_broker()
+    assert broker is not None
+
+
+def test_is_live_mode_reflects_provider(monkeypatch):
+    monkeypatch.setenv("BROKER_PROVIDER", "paper")
+    assert is_live_mode() is False
+    monkeypatch.setenv("BROKER_PROVIDER", "alpaca")
+    assert is_live_mode() is True
+
+
+# ── Live providers are gated ────────────────────────────────────────────────
+
+@pytest.mark.parametrize("name", ["alpaca", "ibkr", "schwab"])
+def test_live_provider_refused_without_confirmation(
+    monkeypatch, journal_db, fake_adapters, name,
+):
+    monkeypatch.setenv("BROKER_PROVIDER", name)
+    monkeypatch.delenv("LIVE_TRADING_CONFIRMED", raising=False)
+    with pytest.raises(LivePromotionRefused, match="LIVE_TRADING_CONFIRMED"):
+        get_broker()
+    # No adapter was ever instantiated.
+    assert sum(fake_adapters.values()) == 0
+
+
+def test_live_provider_refused_with_short_track_record(
+    monkeypatch, journal_db, fake_adapters,
+):
+    _seed_paper_run(days=5, daily_pnl=50.0)  # <30 day default
+    monkeypatch.setenv("BROKER_PROVIDER", "alpaca")
+    monkeypatch.setenv("LIVE_TRADING_CONFIRMED", "true")
+    with pytest.raises(LivePromotionRefused, match="distinct trading days"):
+        get_broker()
+
+
+def test_live_provider_refused_with_low_sharpe(
+    monkeypatch, journal_db, fake_adapters,
+):
+    """Negative-PnL paper run produces sharpe < 0.5 — gate refuses."""
+    _seed_paper_run(days=30, daily_pnl=-100.0)
+    monkeypatch.setenv("BROKER_PROVIDER", "alpaca")
+    monkeypatch.setenv("LIVE_TRADING_CONFIRMED", "true")
+    monkeypatch.setenv("LIVE_PROMOTION_MIN_SHARPE", "0.5")
+    with pytest.raises(LivePromotionRefused, match="Sharpe"):
+        get_broker()
+
+
+def test_live_provider_admitted_with_track_record(
+    monkeypatch, journal_db, fake_adapters,
+):
+    _seed_paper_run(days=30, daily_pnl=100.0)
+    monkeypatch.setenv("BROKER_PROVIDER", "alpaca")
+    monkeypatch.setenv("LIVE_TRADING_CONFIRMED", "true")
+    monkeypatch.setenv("LIVE_PROMOTION_MIN_SHARPE", "0.0")
+    broker = get_broker()
+    assert broker is not None
+    assert fake_adapters["alpaca"] == 1
+
+
+def test_live_provider_can_relax_min_days(
+    monkeypatch, journal_db, fake_adapters,
+):
+    _seed_paper_run(days=3, daily_pnl=100.0)
+    monkeypatch.setenv("BROKER_PROVIDER", "alpaca")
+    monkeypatch.setenv("LIVE_TRADING_CONFIRMED", "true")
+    monkeypatch.setenv("LIVE_PROMOTION_MIN_DAYS", "2")
+    monkeypatch.setenv("LIVE_PROMOTION_MIN_SHARPE", "0.0")
+    broker = get_broker()
+    assert broker is not None
+
+
+# ── Bypass ──────────────────────────────────────────────────────────────────
+
+def test_live_provider_bypass_skips_both_checks(
+    monkeypatch, journal_db, fake_adapters,
+):
+    monkeypatch.setenv("BROKER_PROVIDER", "alpaca")
+    monkeypatch.delenv("LIVE_TRADING_CONFIRMED", raising=False)
+    monkeypatch.setenv("LIVE_PROMOTION_BYPASS", "1")
+    broker = get_broker()
+    assert broker is not None
+    assert fake_adapters["alpaca"] == 1
+
+
+# ── Unknown provider still raises ValueError ────────────────────────────────
+
+def test_unknown_provider_raises_value_error(monkeypatch):
+    monkeypatch.setenv("BROKER_PROVIDER", "fakebroker")
+    with pytest.raises(ValueError, match="Unknown broker provider"):
+        get_broker()
+
+
+# ── Direct guard call ───────────────────────────────────────────────────────
+
+def test_live_promotion_check_no_op_for_paper():
+    # Should never raise, regardless of env state.
+    _live_promotion_check("paper")


### PR DESCRIPTION
Closes #149.

## Summary

P1.11 of the indie-quant roadmap. Paper-to-live promotion guard: every live broker (`alpaca` / `ibkr` / `schwab`) now refuses to instantiate unless **both** of these preconditions hold:

1. `LIVE_TRADING_CONFIRMED=true` — explicit operator opt-in.
2. Paper journal shows ≥ `LIVE_PROMOTION_MIN_DAYS` distinct trading days (default 30) **and** a daily-PnL Sharpe ≥ `LIVE_PROMOTION_MIN_SHARPE` (default 0.5).

`LivePromotionRefused` is a typed exception so callers can distinguish the gate from generic broker errors. The guard is bypassable via `LIVE_PROMOTION_BYPASS=1` for emergency re-enablement; bypass is logged at error level so audit trails surface it.

`is_live_mode(provider)` returns `True` for the live venues; `pages/shared.py` uses it to render a red `LIVE TRADING — real money at risk` banner in the sidebar when active and a green paper-mode pill otherwise.

## Test plan

- [x] `pytest tests/test_live_promotion_guard.py -v` — 15/15 pass
- [x] `pytest tests/ -m "not integration" --cov=. --cov-fail-under=76` — 1563 pass, 1 xfail, coverage 78.09%
- [x] `ruff check .` — clean
- [x] `bandit -r . -ll` — 0 HIGH severity
- [x] `pip-audit` — no known vulns
- [ ] Manual: `BROKER_PROVIDER=alpaca python -c "from providers.broker import get_broker; get_broker()"` → expect `LivePromotionRefused`. Set `LIVE_TRADING_CONFIRMED=true` + seed 30 paper days → succeeds.

https://claude.ai/code/session_01WmG6mAtgV1nr1c9NPxBAD8

---
_Generated by [Claude Code](https://claude.ai/code/session_01WmG6mAtgV1nr1c9NPxBAD8)_