### PR TITLE
P1.12: walk-forward executor selection (auto/ray/mp/serial) (#150)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -137,6 +137,11 @@ LOG_LEVEL=INFO
 # LIVE_PROMOTION_MIN_SHARPE=0.5        # daily-PnL Sharpe over the paper run
 # LIVE_PROMOTION_BYPASS=0              # 1 → skip both checks (emergency only — logged)
 
+# Walk-forward executor (#150) — picks the per-segment parallelism backend.
+# 'auto' (default) prefers Ray when importable, otherwise multiprocessing.
+# WF_EXECUTOR=auto                     # auto | ray | mp | serial
+# RAY_ENABLED=0                        # legacy alias — when 1 forces Ray
+
 # Event bus (#147) — Redis Streams pub/sub fan-out for cron + scheduler events.
 # When EVENT_BUS_ENABLED=0 (default) every publish() call is a no-op so existing
 # setups pay zero cost. Flip to 1 to activate Redis Streams.

--- a/backtester/walk_forward.py
+++ b/backtester/walk_forward.py
@@ -3,11 +3,18 @@ backtester/walk_forward.py — Walk-forward backtesting with optional parallelis
 
 Rolling train/test windows over the full price series. The standard
 `walk_forward()` is single-threaded. `walk_forward_parallel()` distributes
-segments across CPU cores (multiprocessing) or a Ray cluster when available.
+segments across executors:
+
+* ``auto`` (default — P1.12) — prefer Ray when importable, otherwise
+  ``ProcessPoolExecutor``. Single-process serial when only one segment.
+* ``ray`` — force the Ray path (raises if ``ray`` is not installed).
+* ``mp``  — force ``ProcessPoolExecutor``.
+* ``serial`` — single-threaded (useful for debugging).
 
 ENV vars
 --------
-    RAY_ENABLED   '1' to use Ray cluster for segment parallelism (default: 0)
+    WF_EXECUTOR   auto | ray | mp | serial  (default: auto)
+    RAY_ENABLED   legacy alias — when '1' it forces ``ray`` if WF_EXECUTOR is unset
 """
 from __future__ import annotations
 
@@ -100,6 +107,32 @@ def _run_segment(args: tuple) -> Optional[BacktestResult]:
         return None
 
 
+_VALID_EXECUTORS = ("auto", "ray", "mp", "serial")
+
+
+def _resolve_executor(executor: Optional[str]) -> str:
+    """Pick the concrete executor name based on the request and the environment.
+
+    ``executor`` argument takes precedence over the ``WF_EXECUTOR`` env var,
+    which takes precedence over the legacy ``RAY_ENABLED`` flag.
+    """
+    requested = (executor or os.environ.get("WF_EXECUTOR", "auto")).lower().strip()
+    if requested not in _VALID_EXECUTORS:
+        raise ValueError(
+            f"executor must be one of {_VALID_EXECUTORS}, got {requested!r}",
+        )
+    if requested == "auto":
+        # Honour the legacy env-var if the operator hasn't picked WF_EXECUTOR.
+        if os.environ.get("RAY_ENABLED", "0") == "1":
+            return "ray"
+        try:
+            import ray  # noqa: F401
+            return "ray"
+        except ImportError:
+            return "mp"
+    return requested
+
+
 def walk_forward_parallel(
     df: pd.DataFrame,
     strategy: str = "sma_crossover",
@@ -108,13 +141,13 @@ def walk_forward_parallel(
     test_periods: int = 60,
     step: int = 30,
     n_workers: Optional[int] = None,
+    executor: Optional[str] = None,
 ) -> WalkForwardResult:
-    """
-    Parallelised walk-forward backtest using multiprocessing.
+    """Parallelised walk-forward backtest.
 
-    When RAY_ENABLED=1 and ray is installed, uses a Ray cluster instead of
-    multiprocessing.Pool.  Falls back to single-threaded walk_forward() if
-    parallelism is unavailable.
+    When ``executor`` is unset / ``"auto"`` the function prefers Ray (if
+    importable) and otherwise falls back to ``ProcessPoolExecutor``. Pass
+    ``executor="serial"`` for deterministic single-threaded debugging.
 
     Parameters
     ----------
@@ -124,7 +157,9 @@ def walk_forward_parallel(
     train_periods : bars reserved for training (skipped)
     test_periods  : bars per test segment
     step          : slide step between windows
-    n_workers     : number of parallel workers (default: os.cpu_count())
+    n_workers     : number of parallel workers (default: ``os.cpu_count()``)
+    executor      : ``auto | ray | mp | serial`` — override the env-var
+                    selection.
 
     Returns
     -------
@@ -143,9 +178,10 @@ def walk_forward_parallel(
     if not segments:
         return WalkForwardResult()
 
+    chosen = _resolve_executor(executor)
+
     # Ray path
-    use_ray = os.environ.get("RAY_ENABLED", "0") == "1"
-    if use_ray:
+    if chosen == "ray":
         try:
             import ray  # type: ignore[import]
             if not ray.is_initialized():
@@ -160,13 +196,13 @@ def walk_forward_parallel(
             results = [r for r in raw_results if r is not None]
         except ImportError:
             logger.info("ray not installed; falling back to multiprocessing")
-            use_ray = False
+            chosen = "mp"
         except Exception as exc:
             logger.warning("Ray execution failed (%s); falling back to multiprocessing", exc)
-            use_ray = False
+            chosen = "mp"
 
     # Multiprocessing path
-    if not use_ray:
+    if chosen == "mp":
         workers = n_workers or min(os.cpu_count() or 1, len(segments))
         results: list[BacktestResult] = []
         with ProcessPoolExecutor(max_workers=workers) as pool:
@@ -175,6 +211,14 @@ def walk_forward_parallel(
                 result = future.result()
                 if result is not None:
                     results.append(result)
+
+    # Serial path
+    if chosen == "serial":
+        results = []
+        for seg in segments:
+            r = _run_segment(seg)
+            if r is not None:
+                results.append(r)
 
     if not results:
         return WalkForwardResult()

--- a/cron/monthly_wf.py
+++ b/cron/monthly_wf.py
@@ -1,11 +1,17 @@
 """
 Monthly walk-forward backtest runner.
-Run manually: python -m cron.monthly_wf
+Run manually: python -m cron.monthly_wf [--executor auto|ray|mp|serial]
 Schedule via cron: 0 6 1 * * /path/to/venv/bin/python -m cron.monthly_wf
 
 Results saved to: data/wf_history.db (SQLite)
 Table: wf_results (run_date, ticker, consistency_score, total_return, n_windows)
+
+ENV vars
+--------
+    WF_EXECUTOR  auto | ray | mp | serial  (default: auto — Ray when available)
+    WF_TICKERS   comma-separated ticker list (default: SPY,QQQ,AAPL,MSFT,TSLA)
 """
+import argparse
 import os
 import sqlite3
 import sys
@@ -15,13 +21,31 @@ from pathlib import Path
 import pandas as pd
 import yfinance as yf
 
-from backtester.walk_forward import walk_forward
+from backtester.walk_forward import walk_forward, walk_forward_parallel
 from utils.logger import get_logger
 
 logger = get_logger("cron.monthly_wf")
 
 DB_PATH = Path(__file__).parent.parent / "data" / "wf_history.db"
 DEFAULT_TICKERS = "SPY,QQQ,AAPL,MSFT,TSLA"
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="cron.monthly_wf",
+        description="Monthly walk-forward runner. Honours WF_EXECUTOR env var.",
+    )
+    parser.add_argument(
+        "--executor",
+        choices=("auto", "ray", "mp", "serial"),
+        default=None,
+        help=(
+            "Executor for the per-segment backtest. 'auto' (default) prefers "
+            "Ray when importable, else multiprocessing. 'serial' runs "
+            "single-threaded — useful for debugging."
+        ),
+    )
+    return parser
 
 
 def _init_db(conn: sqlite3.Connection) -> None:
@@ -61,7 +85,10 @@ def _upsert_result(
     conn.commit()
 
 
-def run() -> int:
+def run(argv: list[str] | None = None) -> int:
+    args = _build_arg_parser().parse_args(argv)
+    executor = args.executor or os.environ.get("WF_EXECUTOR")
+
     tickers = [
         t.strip().upper()
         for t in os.getenv("WF_TICKERS", DEFAULT_TICKERS).split(",")
@@ -84,8 +111,19 @@ def run() -> int:
                 raise ValueError(f"No data returned for {ticker}")
             df = df.rename(columns=str.lower)
 
-            logger.info("Running walk_forward for %s (%d bars)", ticker, len(df))
-            wf = walk_forward(df, ticker=ticker)
+            logger.info(
+                "Running walk_forward for %s (%d bars, executor=%s)",
+                ticker, len(df), executor or "single",
+            )
+            # Default (no --executor / WF_EXECUTOR) keeps the historical
+            # single-threaded path. Operators opt into parallelism by
+            # passing an explicit executor.
+            if executor in (None, "single", "serial"):
+                wf = walk_forward(df, ticker=ticker)
+            else:
+                wf = walk_forward_parallel(
+                    df, ticker=ticker, executor=executor,
+                )
 
             n_windows = len(wf.windows)
             _upsert_result(

--- a/tests/test_monthly_wf.py
+++ b/tests/test_monthly_wf.py
@@ -93,7 +93,7 @@ class TestDbInit:
         monkeypatch.setenv("WF_TICKERS", "SPY")
 
         from cron import monthly_wf
-        monthly_wf.run()
+        monthly_wf.run([])
 
         assert tmp_db.exists(), "DB file should be created"
 
@@ -107,7 +107,7 @@ class TestDbInit:
         monkeypatch.setenv("WF_TICKERS", "SPY")
 
         from cron import monthly_wf
-        monthly_wf.run()
+        monthly_wf.run([])
 
         conn = sqlite3.connect(tmp_db)
         cols = {row[1] for row in conn.execute("PRAGMA table_info(wf_results)").fetchall()}
@@ -121,7 +121,7 @@ class TestPersistence:
         monkeypatch.setenv("WF_TICKERS", "SPY")
 
         from cron import monthly_wf
-        rc = monthly_wf.run()
+        rc = monthly_wf.run([])
 
         assert rc == 0
 
@@ -140,7 +140,7 @@ class TestPersistence:
         monkeypatch.setenv("WF_TICKERS", "SPY,QQQ")
 
         from cron import monthly_wf
-        monthly_wf.run()
+        monthly_wf.run([])
 
         conn = sqlite3.connect(tmp_db)
         tickers = {r[0] for r in conn.execute("SELECT ticker FROM wf_results").fetchall()}
@@ -156,8 +156,8 @@ class TestUpsertBehavior:
 
         from cron import monthly_wf
 
-        monthly_wf.run()
-        monthly_wf.run()  # second run on same date
+        monthly_wf.run([])
+        monthly_wf.run([])  # second run on same date
 
         conn = sqlite3.connect(tmp_db)
         count = conn.execute("SELECT COUNT(*) FROM wf_results WHERE ticker='SPY'").fetchone()[0]
@@ -183,10 +183,10 @@ class TestUpsertBehavior:
         )
 
         with patch("cron.monthly_wf.walk_forward", return_value=wf_first):
-            monthly_wf.run()
+            monthly_wf.run([])
 
         with patch("cron.monthly_wf.walk_forward", return_value=wf_second):
-            monthly_wf.run()
+            monthly_wf.run([])
 
         conn = sqlite3.connect(tmp_db)
         row = conn.execute(
@@ -204,7 +204,7 @@ class TestFailureHandling:
 
         with patch("cron.monthly_wf.yf.download", side_effect=RuntimeError("network error")):
             from cron import monthly_wf
-            rc = monthly_wf.run()
+            rc = monthly_wf.run([])
 
         assert rc == 1
 
@@ -222,7 +222,7 @@ class TestFailureHandling:
         with patch("cron.monthly_wf.yf.download", side_effect=fake_download), \
              patch("cron.monthly_wf.walk_forward", return_value=wf):
             from cron import monthly_wf
-            rc = monthly_wf.run()
+            rc = monthly_wf.run([])
 
         assert rc == 1
 

--- a/tests/test_walk_forward_executor.py
+++ b/tests/test_walk_forward_executor.py
@@ -1,0 +1,128 @@
+"""
+tests/test_walk_forward_executor.py — executor selection in walk_forward_parallel.
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from backtester.walk_forward import _resolve_executor
+
+# ── _resolve_executor — argument vs env var precedence ──────────────────────
+
+def test_resolve_explicit_argument_wins(monkeypatch):
+    monkeypatch.setenv("WF_EXECUTOR", "ray")
+    assert _resolve_executor("serial") == "serial"
+
+
+def test_resolve_env_var_used_when_no_argument(monkeypatch):
+    monkeypatch.setenv("WF_EXECUTOR", "mp")
+    assert _resolve_executor(None) == "mp"
+
+
+def test_resolve_default_auto_picks_ray_when_importable(monkeypatch):
+    monkeypatch.delenv("WF_EXECUTOR", raising=False)
+    monkeypatch.delenv("RAY_ENABLED", raising=False)
+
+    # Pretend ray is importable.
+    import importlib
+
+    real_import = importlib.import_module
+
+    def _fake_import(name, *args, **kwargs):
+        if name == "ray":
+            return type("ray_stub", (), {})()
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(importlib, "import_module", _fake_import)
+    # Module doesn't actually use importlib — it uses ``import ray``.
+    # Provide it via sys.modules for the duration of the test.
+    monkeypatch.setitem(sys.modules, "ray", type("_M", (), {})())
+    assert _resolve_executor(None) == "ray"
+
+
+def test_resolve_default_auto_falls_back_to_mp_without_ray(monkeypatch):
+    monkeypatch.delenv("WF_EXECUTOR", raising=False)
+    monkeypatch.delenv("RAY_ENABLED", raising=False)
+    monkeypatch.setitem(sys.modules, "ray", None)
+    # The bare ``import ray`` resolves to None which raises ImportError on
+    # attribute access; force a clean ImportError by removing the entry.
+    sys.modules.pop("ray", None)
+
+    # Patch builtins.__import__ to raise on "ray" so the auto branch falls
+    # back to multiprocessing.
+    import builtins
+
+    real_import = builtins.__import__
+
+    def _fake_import(name, *args, **kwargs):
+        if name == "ray":
+            raise ImportError("test-fake")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _fake_import)
+    assert _resolve_executor(None) == "mp"
+
+
+def test_resolve_legacy_ray_enabled_flag(monkeypatch):
+    """Operators on the old RAY_ENABLED=1 flag still get Ray."""
+    monkeypatch.delenv("WF_EXECUTOR", raising=False)
+    monkeypatch.setenv("RAY_ENABLED", "1")
+    assert _resolve_executor(None) == "ray"
+
+
+def test_resolve_explicit_serial(monkeypatch):
+    monkeypatch.setenv("RAY_ENABLED", "1")
+    assert _resolve_executor("serial") == "serial"
+
+
+def test_resolve_rejects_unknown_executor():
+    with pytest.raises(ValueError, match="executor"):
+        _resolve_executor("dask")
+
+
+# ── walk_forward_parallel serial path round-trip ─────────────────────────────
+
+def _toy_df(n=300):
+    import numpy as np
+    import pandas as pd
+
+    rng = np.random.default_rng(42)
+    idx = pd.date_range("2024-01-01", periods=n, freq="D")
+    closes = 100 + rng.normal(0, 1, n).cumsum()
+    highs = closes + 0.5
+    lows  = closes - 0.5
+    opens = closes - 0.1
+    vols  = rng.integers(1_000, 10_000, n)
+    # Backtester engine expects capitalised OHLCV columns.
+    return pd.DataFrame(
+        {
+            "Open": opens, "High": highs, "Low": lows, "Close": closes,
+            "Volume": vols,
+        },
+        index=idx,
+    )
+
+
+def test_serial_executor_returns_results(monkeypatch):
+    """The serial path runs every segment in-process — useful for debugging."""
+    from backtester.walk_forward import walk_forward_parallel
+
+    df = _toy_df(300)
+    monkeypatch.delenv("WF_EXECUTOR", raising=False)
+    monkeypatch.delenv("RAY_ENABLED", raising=False)
+    wf = walk_forward_parallel(df, executor="serial", ticker="TST")
+    assert wf.windows  # at least one segment ran
+    assert wf.consistency_score >= 0
+
+
+def test_parallel_executor_invalid_choice():
+    from backtester.walk_forward import walk_forward_parallel
+
+    df = _toy_df(300)
+    with pytest.raises(ValueError, match="executor"):
+        walk_forward_parallel(df, executor="dask")


### PR DESCRIPTION
Closes #150.

## Summary

P1.12 — last Phase-1 ticket. Promotes walk-forward parallelism from an opt-in `RAY_ENABLED=1` env var to a typed executor selector with sensible auto-detection.

- **`backtester/walk_forward.py`**
  - `walk_forward_parallel(..., executor=None)` — new kwarg with values `auto | ray | mp | serial`. Defaults to `auto` which tries Ray first and falls back to multiprocessing.
  - `_resolve_executor(executor)` — argument > `WF_EXECUTOR` env var > legacy `RAY_ENABLED=1` alias > Ray-if-importable > mp.
  - New `serial` path runs every segment in-process — useful for debugging without spawning workers.
- **`cron/monthly_wf.py`**
  - New `--executor {auto,ray,mp,serial}` CLI flag. The cron's default stays single-threaded so its resource footprint is predictable; operators opt into parallelism explicitly.
- **`.env.example`** — documents `WF_EXECUTOR` and notes `RAY_ENABLED=1` is now a legacy alias.

## Test plan

- [x] `pytest tests/test_walk_forward_executor.py -v` — 9/9 pass (precedence, fallback, serial round-trip, validation)
- [x] `pytest tests/test_monthly_wf.py -v` — 17/17 pass (updated to pass `argv=[]` now that `run()` accepts CLI flags)
- [x] `pytest tests/ -m "not integration" --cov=. --cov-fail-under=76` — 1572 pass, 1 xfail, coverage 78.30%
- [x] `ruff check .` — clean
- [x] `bandit -r . -ll` — 0 HIGH severity
- [x] `pip-audit` — no known vulns
- [ ] Manual: `python -m cron.monthly_wf --executor ray` on a multi-ticker run; expect ≥5× wall-clock vs `--executor serial` on an 8-core laptop.

## Phase 1 complete

This closes the last Phase-1 ticket. All twelve indie-quant features (#139 guard → #150 Ray WF) are now on `main` with an e2e regression suite (#185) and one resolved bug fast-follow (#186).

https://claude.ai/code/session_01WmG6mAtgV1nr1c9NPxBAD8

---
_Generated by [Claude Code](https://claude.ai/code/session_01WmG6mAtgV1nr1c9NPxBAD8)_