### PR TITLE
fix: PreTradeGuard accepts paper-broker total_value as equity (#183)

### DIFF
--- a/risk/pretrade_guard.py
+++ b/risk/pretrade_guard.py
@@ -190,7 +190,16 @@ class PreTradeGuard:
             logger.warning("pretrade_guard: account snapshot failed", error=str(exc))
             return 0.0, []
 
-        equity_raw = account.get("equity") or account.get("portfolio_value") or 0.0
+        # Equity key varies by adapter — Alpaca uses ``equity``, the paper
+        # broker exposes ``total_value``, and a few legacy paths still
+        # return ``portfolio_value``. Try all three so the guard's
+        # dollar-sizing dimensions actually fire on every backend.
+        equity_raw = (
+            account.get("equity")
+            or account.get("portfolio_value")
+            or account.get("total_value")
+            or 0.0
+        )
         try:
             equity = float(equity_raw)
         except (TypeError, ValueError):

--- a/tests/test_e2e_pretrade_guard_rejects_oversized.py
+++ b/tests/test_e2e_pretrade_guard_rejects_oversized.py
@@ -35,14 +35,6 @@ def paper_env(tmp_path, monkeypatch):
     return tmp_path
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="https://github.com/ghostlobster/quant-platform/issues/183 — "
-           "PreTradeGuard reads `equity`/`portfolio_value` but the paper "
-           "broker returns `total_value`, so dollar-sizing limits silently "
-           "no-op. Fix lands separately; this test flips to PASS when the "
-           "guard's _account_snapshot also accepts `total_value`.",
-)
 def test_guard_rejects_oversized_then_accepts_relaxed(paper_env, monkeypatch):
     """Tightening MAX_POSITION_PCT rejects a $10k order against $100k equity;
     relaxing the env var lets the same order fill."""


### PR DESCRIPTION
Closes #183.

## Summary

`risk/pretrade_guard.py:_account_snapshot()` now also reads `total_value` from the broker's account dict. The paper broker (`broker/paper_trader.get_account`) returns its equity under that key — the previous fallback chain (`equity` → `portfolio_value` → `0.0`) collapsed to zero against the paper adapter, silently disabling `MAX_POSITION_PCT` / `MAX_GROSS_EXPOSURE` / `MAX_DAILY_LOSS_PCT`.

The Alpaca adapter still passes through Alpaca's native `equity` field, so this is purely additive — every existing live path keeps working unchanged.

## Test plan

- [x] `pytest tests/test_e2e_pretrade_guard_rejects_oversized.py tests/test_pretrade_guard.py -v` — 12/12 pass (the xfail flips to PASS)
- [x] `pytest tests/ -m "not integration" --cov=. --cov-fail-under=76` — 1573 pass, 0 xfail, coverage 78.30%
- [x] `ruff check .` — clean
- [x] `bandit -r . -ll` — 0 HIGH severity
- [x] `pip-audit` — no known vulns

Removes the `xfail(strict=True)` marker on `test_guard_rejects_oversized_then_accepts_relaxed` — the e2e regression that surfaced this bug now stays green permanently.

https://claude.ai/code/session_01WmG6mAtgV1nr1c9NPxBAD8

---
_Generated by [Claude Code](https://claude.ai/code/session_01WmG6mAtgV1nr1c9NPxBAD8)_