### PR TITLE
ci: split e2e suite into a parallel pipeline job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,11 +67,13 @@ jobs:
           pip install -r requirements.txt
           pip install pytest-cov
 
-      # Unit tests — excludes anything marked @pytest.mark.integration
+      # Unit tests — excludes integration AND e2e so the unit feedback
+      # loop stays tight. The e2e suite runs in parallel via the `e2e`
+      # job below; integration runs on demand once tests are added.
       - name: Run unit tests
         continue-on-error: false
         run: |
-          pytest tests/ -v -m "not integration" \
+          pytest tests/ -v -m "not integration and not e2e" \
             --cov=. \
             --cov-report=xml:coverage.xml \
             --cov-report=term-missing \
@@ -109,10 +111,82 @@ jobs:
         with:
           pytest-xml-coverage-path: ./coverage.xml
           junitxml-path: ./test-results-unit.xml
-          title: "Coverage Report"
-          badge-title: "Coverage"
+          title: "Coverage Report (unit)"
+          badge-title: "Unit Coverage"
           hide-badge: false
           hide-report: false
           create-new-comment: false
           hide-comment: false
           report-only-changed-files: false
+          unique-id-for-comment: unit-coverage
+
+  e2e:
+    name: E2E (Python 3.11)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Cache pip dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pytest-cov
+
+      # End-to-end suite — exercises the broker ↔ guard ↔ journal ↔
+      # scheduler ↔ cache chain on a real SQLite + paper trader. Network
+      # boundaries (Polygon, MLflow, alert channels) are mocked at the
+      # adapter; nothing else is.
+      #
+      # Coverage is reported but NOT gated on the 76% floor: the e2e
+      # suite intentionally exercises a small slice of the codebase
+      # (the cross-module paths) and would otherwise need the unit
+      # suite running alongside to clear the gate. The unit job owns
+      # the coverage gate; this job's job is "did the chain break?"
+      - name: Run end-to-end tests
+        continue-on-error: false
+        run: |
+          pytest tests/ -v -m "e2e" \
+            --cov=. \
+            --cov-report=xml:coverage-e2e.xml \
+            --cov-report=term \
+            --junitxml=test-results-e2e.xml
+
+      - name: Upload e2e coverage and test results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: e2e-report
+          path: |
+            coverage-e2e.xml
+            test-results-e2e.xml
+
+      - name: Post e2e summary comment
+        uses: MishaKav/pytest-coverage-comment@main
+        if: github.event_name == 'pull_request'
+        with:
+          pytest-xml-coverage-path: ./coverage-e2e.xml
+          junitxml-path: ./test-results-e2e.xml
+          title: "E2E Report"
+          badge-title: "E2E Tests"
+          hide-badge: false
+          hide-report: false
+          create-new-comment: false
+          hide-comment: false
+          report-only-changed-files: false
+          unique-id-for-comment: e2e-report

--- a/docs/ci_pipeline.md
+++ b/docs/ci_pipeline.md
@@ -1,0 +1,90 @@
+# CI Pipeline Layout
+
+The platform's GitHub Actions pipeline is split into four jobs that run
+in parallel on every push to `main` and every PR targeting `main`:
+
+| Job | Owns | Coverage gate |
+|---|---|---|
+| `lint` | `ruff check .` | n/a |
+| `security` | `bandit -ll` (HIGH-only) + `pip-audit` | n/a |
+| `Test (Python 3.11)` | unit tests (`-m "not integration and not e2e"`) + integration scaffold | 76% — **gates merges** |
+| `E2E (Python 3.11)` | end-to-end regression suite (`-m e2e`) | reported, **not gated** |
+
+Splitting unit and e2e into separate jobs follows three best practices:
+
+1. **Tight feedback loop** — unit tests stay fast (≤1 min) by excluding
+   the slower e2e cases. The e2e job runs in parallel, so total wall
+   clock doesn't grow.
+2. **Distinct failure signal** — when CI goes red, the failing job name
+   tells you whether a unit invariant or a cross-module integration
+   broke. No more digging through 1500-test logs to find which 16 cases
+   matter.
+3. **Independent retry** — flaky e2e cases (network mocks, real SQLite,
+   real journals) can be re-run without re-running 1500 unit tests.
+
+## Markers
+
+Tests opt into the right pipeline path via pytest markers declared in
+`pytest.ini`:
+
+| Marker | Selector | Where it runs |
+|---|---|---|
+| `@pytest.mark.integration` | `-m integration` | `Test` job, separate step (currently empty scaffold for future live-broker tests) |
+| `@pytest.mark.e2e` | `-m e2e` | `E2E` job |
+| _no marker_ | `-m "not integration and not e2e"` | `Test` job, unit step |
+
+E2E test files apply the marker module-wide via:
+
+```python
+pytestmark = pytest.mark.e2e
+```
+
+so every test in the file inherits it without per-function decoration.
+
+## Required checks (branch-protection update needed)
+
+After this PR merges, the branch-protection rule on `main` should be
+updated to require **both** of the following checks before a PR can
+merge:
+
+- `Test (Python 3.11)`
+- `E2E (Python 3.11)`
+
+Without that update, a PR that breaks the e2e chain could still merge
+on a green unit job. The CI itself emits both — branch protection just
+has to enforce both.
+
+GitHub UI path: **Settings → Branches → main → Edit → Require status
+checks to pass before merging → add `E2E (Python 3.11)`.**
+
+## Local mirror
+
+The `/pre-push` skill runs the same gates locally:
+
+- `ruff check .`
+- `pytest tests/ -m "not integration" --cov=. --cov-fail-under=76` —
+  this still includes e2e tests; the local pass is intentionally
+  broader than the CI unit job to catch e2e breakage before push.
+- `bandit -r . -ll`
+- `pip-audit -r requirements.txt`
+
+Running just the e2e suite locally:
+
+```bash
+pytest tests/ -m e2e -v
+```
+
+Running just the unit suite (matches CI's unit step):
+
+```bash
+pytest tests/ -m "not integration and not e2e"
+```
+
+## Adding a new e2e file
+
+1. Create `tests/test_e2e_<chain>.py`.
+2. Add `pytestmark = pytest.mark.e2e` immediately after the imports.
+3. Reuse fixtures that point `data.db._DB_PATH` / `JOURNAL_DB_PATH` /
+   `DUCKDB_PATH` at `tmp_path` so the test never touches operator state.
+4. Mock at the network boundary only (HTTP adapter, MLflow registry,
+   alert channels). Real SQLite, real journal, real paper trader.

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,3 +3,4 @@ testpaths = tests
 python_files = test_*.py
 markers =
     integration: marks tests as integration tests requiring live services (deselect with '-m "not integration"')
+    e2e: marks end-to-end tests that exercise the cross-module chain (broker ↔ guard ↔ journal ↔ scheduler ↔ cache). Run a fast unit pass with '-m "not integration and not e2e"' and the slower regression suite with '-m e2e'. Both gate the merge in CI; the split keeps the unit feedback loop tight while still exercising the end-to-end paths added in #185.

--- a/tests/test_e2e_bracket_lifecycle.py
+++ b/tests/test_e2e_bracket_lifecycle.py
@@ -18,6 +18,10 @@ import broker.paper_trader as pt
 import data.db as db_module
 from providers.broker import OrderIntent
 
+# Every test in this file is part of the e2e regression suite — runs in
+# the dedicated `e2e` CI job, deselected from the fast unit pass.
+pytestmark = pytest.mark.e2e
+
 
 @pytest.fixture
 def paper_env(tmp_path, monkeypatch):

--- a/tests/test_e2e_monthly_retrain_to_mlflow.py
+++ b/tests/test_e2e_monthly_retrain_to_mlflow.py
@@ -18,6 +18,8 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
 import cron.monthly_ml_retrain as retrain
 
+pytestmark = pytest.mark.e2e
+
 
 class _FakeRegistry:
     def __init__(self) -> None:

--- a/tests/test_e2e_polygon_backfill_to_fetch_ohlcv.py
+++ b/tests/test_e2e_polygon_backfill_to_fetch_ohlcv.py
@@ -24,6 +24,8 @@ import adapters.market_data.polygon_adapter as polymod
 import cron.polygon_backfill as backfill
 import data.db as db_module
 
+pytestmark = pytest.mark.e2e
+
 
 def _polygon_payload(rows: int) -> dict:
     base_t = 1_700_000_000_000  # ms

--- a/tests/test_e2e_pretrade_guard_rejects_oversized.py
+++ b/tests/test_e2e_pretrade_guard_rejects_oversized.py
@@ -20,6 +20,8 @@ import broker.paper_trader as pt
 import data.db as db_module
 import journal.trading_journal as jt
 
+pytestmark = pytest.mark.e2e
+
 
 @pytest.fixture
 def paper_env(tmp_path, monkeypatch):

--- a/tests/test_e2e_risk_exporter_tick_to_alert.py
+++ b/tests/test_e2e_risk_exporter_tick_to_alert.py
@@ -25,6 +25,8 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 import journal.trading_journal as jt
 from risk import metrics_exporter as me
 
+pytestmark = pytest.mark.e2e
+
 
 class FakeBroker:
     """Minimal BrokerProvider stand-in; only the methods the exporter calls."""


### PR DESCRIPTION
## Summary

Promotes the e2e regression suite (added in #185) from "runs inline with unit tests" to a dedicated GitHub Actions job that runs in parallel with the unit pass. Three best-practice motivations:

1. **Tight feedback** — the unit step now selects `-m "not integration and not e2e"` so the fast pass stays under a minute.
2. **Distinct failure signal** — when CI goes red, the failing job name tells you whether a unit invariant or a cross-module integration broke. No more scrolling 1500 cases to find which 16 matter.
3. **Independent retry** — the e2e job can be re-run on its own without re-running every unit test.

## Changes

- **`pytest.ini`** — new `e2e` marker with the deselect/select recipe in its description.
- **`tests/test_e2e_*.py`** — module-level `pytestmark = pytest.mark.e2e` in all five files (16 cases). No per-function decoration needed.
- **`.github/workflows/ci.yml`**
  - Unit step now runs `-m "not integration and not e2e"`.
  - New `E2E (Python 3.11)` job mirrors the unit job's setup and runs `-m e2e`. Uploads its own coverage + junit artifacts. Coverage is reported but NOT gated on the 76% floor — the unit job owns that gate; the e2e suite intentionally exercises a small slice of the codebase by design.
  - Separate coverage-comment widget for e2e via `unique-id-for-comment`.
- **`docs/ci_pipeline.md`** — full description of the four-job layout, marker-driven selection, and the branch-protection update needed (require both `Test (Python 3.11)` AND `E2E (Python 3.11)`).

Local `/pre-push` mirror is unchanged on purpose — running both unit and e2e in one command before push catches breakage that the CI split surfaces on separate workers.

## Required follow-up after merge

Update `main` branch protection to require **both** checks:
- `Test (Python 3.11)`
- `E2E (Python 3.11)`

Settings → Branches → `main` → "Require status checks to pass" → add `E2E (Python 3.11)`.

## Test plan

- [x] `pytest tests/ -m "not integration and not e2e" --cov-fail-under=76` — 1574 pass, 18 deselected, coverage 78.43%
- [x] `pytest tests/ -m e2e` — 16 pass, 1617 deselected, 7s
- [x] `ruff check .` — clean
- [x] `bandit -r . -ll` — 0 HIGH severity
- [x] `pip-audit -r requirements.txt --ignore-vuln PYSEC-2022-42969` — no known vulnerabilities
- [ ] After merge: branch-protection rule update per `docs/ci_pipeline.md`.

https://claude.ai/code/session_01WmG6mAtgV1nr1c9NPxBAD8

---
_Generated by [Claude Code](https://claude.ai/code/session_01WmG6mAtgV1nr1c9NPxBAD8)_