### PR TITLE
test-infra: enable branch coverage in pytest gate (#200)

### DIFF
--- a/.claude/skills/pre-push/SKILL.md
+++ b/.claude/skills/pre-push/SKILL.md
@@ -19,13 +19,15 @@ ruff check .
 
 Source: `.github/workflows/ci.yml:22-23`. Fails CI on any violation. On failure, suggest `ruff check . --fix` and show the first 10 lines of the diagnostic.
 
-### 2. Unit tests + coverage (76% gate)
+### 2. Unit tests + coverage (76% combined line+branch gate)
 
 ```
 pytest tests/ -m "not integration" --cov=. --cov-fail-under=76 --cov-report=term-missing
 ```
 
 Source: `.github/workflows/ci.yml:73-79`. On failure, report which tests failed (first 5) and, if the failure is coverage-only, print the files with the lowest coverage from the term-missing report.
+
+**Branch coverage is on** (`.coveragerc:branch = True`, #200) so the term-missing report shows partial branches with `1->2` notation — those are conditionals where one arm is unexercised. The `Missing` column lists them; pick a few with the lowest impact before pushing.
 
 ### 3. Bandit (HIGH severity only)
 

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,4 +1,12 @@
 [run]
+# Branch coverage (#200) — line coverage marks
+#   if x: return None
+#   return _compute(x)
+# 100 % covered if any test calls the function with truthy x. Branch
+# coverage flips that: each conditional must be exercised through both
+# arms before the file is "fully covered". Strictly more rigorous;
+# coverage.py supports it natively, no extra deps.
+branch = True
 omit =
     venv/*
     .venv/*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,10 @@ jobs:
       # Unit tests — excludes integration AND e2e so the unit feedback
       # loop stays tight. The e2e suite runs in parallel via the `e2e`
       # job below; integration runs on demand once tests are added.
+      #
+      # Coverage uses branch coverage (#200) configured in .coveragerc.
+      # The 76 % floor is now line + branch combined, so it's strictly
+      # more rigorous than the historical line-only floor.
       - name: Run unit tests
         continue-on-error: false
         run: |

--- a/docs/ci_pipeline.md
+++ b/docs/ci_pipeline.md
@@ -9,7 +9,7 @@ the **only** required check on `main`.
 |---|---|---|
 | `lint` | `ruff check .` | n/a |
 | `security` | `bandit -ll` (HIGH-only) + `pip-audit` | n/a |
-| `Test (Python 3.11)` | unit tests (`-m "not integration and not e2e"`) + integration scaffold | 76% global line floor — **gates merges** |
+| `Test (Python 3.11)` | unit tests (`-m "not integration and not e2e"`) + integration scaffold | 76% combined line+branch floor (#200) — **gates merges** |
 | `E2E (Python 3.11)` | end-to-end regression suite (`-m e2e`) | per-module floor via `scripts/check_e2e_coverage.py` (each cross-module file ≥ 40 %, with hand-tightened bumps) — **gates merges** |
 | `Merge gate` | depends on all four above; verifies `needs.*.result` for every parent | n/a — pure dependency aggregator |
 


### PR DESCRIPTION
Closes #200.

## Summary

Flips `branch = True` in `.coveragerc` so `pytest --cov` measures both line and branch coverage. The metric becomes strictly more rigorous (each conditional now needs both arms exercised before the file is "fully covered").

## Floor

Existing CI floor is 76 %. Locally the combined number drops from 78.1 % (line) to 77.06 % (line + branch), so the 76 % gate still passes — no floor change needed. The ticket suggested lowering the floor to ~70 %; measurement showed that's not necessary.

## Files

- `.coveragerc` — `branch = True` under `[run]`
- `.github/workflows/ci.yml` — comment clarifies the floor is now line + branch combined
- `.claude/skills/pre-push/SKILL.md` — same wording + tip on reading partial-branch `1->2` notation
- `docs/ci_pipeline.md` — table updated

## Test plan

- [x] `ruff check .` clean
- [x] `pytest tests/ -m "not integration" --cov=. --cov-fail-under=76` — 1590 passed, combined 77.06 %
- [ ] CI green (lint + security + test + e2e + merge-gate)

Recommended landing order: this PR first (B), then #199 (silent-skip), then #201 (warnings-as-errors). The trio is the test-infrastructure foundation everything else builds on.

https://claude.ai/code/session_01WmG6mAtgV1nr1c9NPxBAD8

---
_Generated by [Claude Code](https://claude.ai/code/session_01WmG6mAtgV1nr1c9NPxBAD8)_