### PR TITLE
test-infra: detect silent test skips from missing required deps (#199)

### DIFF
--- a/.claude/skills/pre-push/SKILL.md
+++ b/.claude/skills/pre-push/SKILL.md
@@ -22,12 +22,22 @@ Source: `.github/workflows/ci.yml:22-23`. Fails CI on any violation. On failure,
 ### 2. Unit tests + coverage (76% combined line+branch gate)
 
 ```
-pytest tests/ -m "not integration" --cov=. --cov-fail-under=76 --cov-report=term-missing
+pytest tests/ -m "not integration" --cov=. --cov-fail-under=76 --cov-report=term-missing --junitxml=/tmp/pre-push-junit.xml
 ```
 
 Source: `.github/workflows/ci.yml:73-79`. On failure, report which tests failed (first 5) and, if the failure is coverage-only, print the files with the lowest coverage from the term-missing report.
 
 **Branch coverage is on** (`.coveragerc:branch = True`, #200) so the term-missing report shows partial branches with `1->2` notation — those are conditionals where one arm is unexercised. The `Missing` column lists them; pick a few with the lowest impact before pushing.
+
+The `--junitxml` flag is needed by stage 2b below.
+
+### 2b. Silent-skip guard (#199)
+
+```
+python scripts/check_no_silent_skips.py /tmp/pre-push-junit.xml requirements.txt
+```
+
+Source: `.github/workflows/ci.yml`. Fails if any test was skipped because a package pinned in `requirements.txt` failed to import — the regression mode where a removed pin or a broken wheel silently lowers coverage with no failing test. On failure, the script names the offending package and the affected test; the fix is almost always `pip install -r requirements.txt` (or restoring the dropped pin in source).
 
 ### 3. Bandit (HIGH severity only)
 
@@ -55,6 +65,7 @@ Stage                    | Result
 -------------------------+--------
 1. ruff                  | PASS
 2. pytest (cov >= 76%)   | PASS
+2b. silent-skip guard    | PASS
 3. bandit HIGH           | PASS
 4. pip-audit             | PASS
 ```

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,13 @@ jobs:
             --cov-fail-under=76 \
             --junitxml=test-results-unit.xml
 
+      # Silent-skip guard (#199) — fails the job if any test was skipped
+      # because a package pinned in requirements.txt failed to import.
+      # Catches the regression where a removed pin or broken wheel lowers
+      # coverage with no failing test.
+      - name: Detect silent skips from missing required deps
+        run: python scripts/check_no_silent_skips.py test-results-unit.xml requirements.txt
+
       # Integration tests — runs tests marked @pytest.mark.integration
       # Currently 0 tests are marked; this step scaffolds the split for future use.
       # Exit code 5 means "no tests collected", which is expected until integration

--- a/docs/ci_pipeline.md
+++ b/docs/ci_pipeline.md
@@ -9,7 +9,7 @@ the **only** required check on `main`.
 |---|---|---|
 | `lint` | `ruff check .` | n/a |
 | `security` | `bandit -ll` (HIGH-only) + `pip-audit` | n/a |
-| `Test (Python 3.11)` | unit tests (`-m "not integration and not e2e"`) + integration scaffold | 76% combined line+branch floor (#200) — **gates merges** |
+| `Test (Python 3.11)` | unit tests (`-m "not integration and not e2e"`) + integration scaffold + silent-skip guard (`scripts/check_no_silent_skips.py`, #199) | 76% combined line+branch floor (#200) — **gates merges** |
 | `E2E (Python 3.11)` | end-to-end regression suite (`-m e2e`) | per-module floor via `scripts/check_e2e_coverage.py` (each cross-module file ≥ 40 %, with hand-tightened bumps) — **gates merges** |
 | `Merge gate` | depends on all four above; verifies `needs.*.result` for every parent | n/a — pure dependency aggregator |
 
@@ -70,9 +70,13 @@ the merge button only listens to `Merge gate`.
 The `/pre-push` skill runs the same gates locally:
 
 - `ruff check .`
-- `pytest tests/ -m "not integration" --cov=. --cov-fail-under=76` —
+- `pytest tests/ -m "not integration" --cov=. --cov-fail-under=76 --junitxml=/tmp/pre-push-junit.xml` —
   this still includes e2e tests; the local pass is intentionally
   broader than the CI unit job to catch e2e breakage before push.
+- `python scripts/check_no_silent_skips.py /tmp/pre-push-junit.xml requirements.txt` —
+  silent-skip guard (#199); fails if any test was skipped because a
+  package pinned in `requirements.txt` couldn't import. The fix is
+  almost always `pip install -r requirements.txt`.
 - `bandit -r . -ll`
 - `pip-audit -r requirements.txt`
 

--- a/scripts/check_no_silent_skips.py
+++ b/scripts/check_no_silent_skips.py
@@ -1,0 +1,166 @@
+"""
+scripts/check_no_silent_skips.py — fail if a test was skipped because a
+package pinned in ``requirements.txt`` failed to import.
+
+Closes #199.
+
+The local 78% coverage hides ~150 statements that are silently skipped
+when an optional dep can't import — e.g. ``ta`` wheel-build failures
+mute every test in ``tests/test_strategies_indicators.py`` and
+``strategies/indicators.py`` shows 0 % line coverage with no failing
+test. CI installs the deps so the published number is higher, but a
+future regression — a removed pin, a broken wheel, a Python-version
+bump that drops a dep — would silently lower coverage with no failing
+test.
+
+This checker reads the JUnit XML produced by ``pytest --junitxml=...``,
+extracts every ``<skipped/>`` reason, and fails if any reason names a
+package that's pinned in ``requirements.txt``.
+
+Usage::
+
+    python scripts/check_no_silent_skips.py test-results-unit.xml
+
+Exit codes:
+    0 — no silent skips against required deps
+    1 — at least one skip references a required package
+    2 — usage / parse error
+"""
+from __future__ import annotations
+
+import re
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+# Map distribution name (as it appears in ``requirements.txt``) to the
+# *import* name(s) it provides. We only need entries for packages whose
+# distribution name differs from their import name. Lower-case throughout.
+_DIST_TO_IMPORTS: dict[str, set[str]] = {
+    "scikit-learn":    {"sklearn"},
+    "python-dateutil": {"dateutil"},
+    "python-dotenv":   {"dotenv"},
+    "gitpython":       {"git"},
+    "pillow":          {"pil"},
+    "pyyaml":          {"yaml"},
+    "beautifulsoup4":  {"bs4"},
+    "ib-insync":       {"ib_insync"},
+    "curl-cffi":       {"curl_cffi"},
+    "streamlit-autorefresh": {"streamlit_autorefresh"},
+}
+
+# Patterns that extract an import name from a pytest skip message.
+# - importorskip default:   "could not import 'X': ..."
+# - generic skipif message: "X not installed"
+# - bare ImportError text:  "No module named 'X'"
+_PATTERNS = [
+    re.compile(r"could not import ['\"]([\w.\-]+)['\"]"),
+    re.compile(r"^([\w.\-]+) not installed", re.IGNORECASE),
+    re.compile(r"No module named ['\"]([\w.\-]+)['\"]"),
+]
+
+# Strip extras and version specifiers to recover the bare distribution name.
+# Examples:  "ccxt>=4.0.0" -> "ccxt"
+#            "uvicorn[standard]==0.30.0" -> "uvicorn"
+_REQ_LINE_RE = re.compile(r"^([A-Za-z0-9_.\-]+)")
+
+
+def _required_imports(requirements_path: Path) -> set[str]:
+    """Return the set of import names that are pinned in requirements.txt.
+
+    Each distribution contributes its lower-cased name *plus* any aliases
+    declared in :data:`_DIST_TO_IMPORTS`.
+    """
+    imports: set[str] = set()
+    if not requirements_path.exists():
+        return imports
+    for raw in requirements_path.read_text().splitlines():
+        line = raw.split("#", 1)[0].strip()
+        if not line:
+            continue
+        match = _REQ_LINE_RE.match(line)
+        if not match:
+            continue
+        dist = match.group(1).lower()
+        imports.add(dist)
+        imports.update(_DIST_TO_IMPORTS.get(dist, set()))
+    return imports
+
+
+def _extract_import_name(message: str) -> str | None:
+    """Return the import name a skip message blames, or ``None``."""
+    for pat in _PATTERNS:
+        m = pat.search(message)
+        if m:
+            return m.group(1).lower()
+    return None
+
+
+def _scan_junit(xml_path: Path) -> list[tuple[str, str, str]]:
+    """Return list of (classname, testname, message) for every skipped test.
+
+    Module-level ``pytest.importorskip`` reports the reason in the
+    element *text*, not the ``message`` attribute (which is just
+    ``"collection skipped"``); we concatenate both so a single regex
+    pass catches every variant.
+    """
+    tree = ET.parse(xml_path)
+    skipped: list[tuple[str, str, str]] = []
+    for case in tree.iter("testcase"):
+        for skip in case.findall("skipped"):
+            attr_msg = skip.attrib.get("message", "") or ""
+            text_msg = skip.text or ""
+            combined = (attr_msg + " | " + text_msg).strip(" |")
+            skipped.append(
+                (
+                    case.attrib.get("classname", ""),
+                    case.attrib.get("name", ""),
+                    combined,
+                )
+            )
+    return skipped
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = argv if argv is not None else sys.argv[1:]
+    if not args:
+        print(
+            "usage: check_no_silent_skips.py <junit-xml> [requirements.txt]",
+            file=sys.stderr,
+        )
+        return 2
+
+    xml_path = Path(args[0])
+    req_path = Path(args[1]) if len(args) > 1 else Path("requirements.txt")
+
+    try:
+        skipped = _scan_junit(xml_path)
+    except (FileNotFoundError, ET.ParseError) as exc:
+        print(f"::error::cannot read {xml_path}: {exc}", file=sys.stderr)
+        return 2
+
+    required = _required_imports(req_path)
+    offenders: list[tuple[str, str, str, str]] = []
+    for classname, testname, message in skipped:
+        pkg = _extract_import_name(message)
+        if pkg and pkg in required:
+            offenders.append((classname, testname, pkg, message))
+
+    print(f"silent-skip check: scanned {len(skipped)} skip(s) in {xml_path}")
+    if not offenders:
+        print("  no skips reference packages pinned in requirements.txt")
+        return 0
+
+    print(
+        f"::error::{len(offenders)} test(s) silently skipped because a "
+        "required package failed to import:",
+    )
+    for classname, testname, pkg, message in offenders:
+        print(f"  {classname}::{testname}")
+        print(f"    package: {pkg}  (pinned in {req_path})")
+        print(f"    reason : {message}")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_check_no_silent_skips.py
+++ b/tests/test_check_no_silent_skips.py
@@ -1,0 +1,244 @@
+"""Tests for ``scripts/check_no_silent_skips.py`` — the silent-skip CI guard."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scripts.check_no_silent_skips import (
+    _DIST_TO_IMPORTS,
+    _extract_import_name,
+    _required_imports,
+    main,
+)
+
+
+def _write_junit(
+    path: Path,
+    skips: list[tuple[str, str, str]],
+    *,
+    text_skips: list[tuple[str, str, str, str]] | None = None,
+) -> Path:
+    """Write a minimal JUnit XML with skipped testcases.
+
+    ``skips`` carry the reason in the ``message`` attribute (per-test
+    skipif). ``text_skips`` carry it in the element text with a generic
+    ``message`` attribute (module-level importorskip). Both shapes are
+    emitted by pytest in real life.
+    """
+    blocks: list[str] = []
+    for cls, name, msg in skips:
+        blocks.append(
+            f'    <testcase classname="{cls}" name="{name}">\n'
+            f'      <skipped message="{msg}"/>\n'
+            f"    </testcase>"
+        )
+    for cls, name, attr_msg, text_msg in text_skips or []:
+        blocks.append(
+            f'    <testcase classname="{cls}" name="{name}">\n'
+            f'      <skipped message="{attr_msg}">{text_msg}</skipped>\n'
+            f"    </testcase>"
+        )
+    body = "\n".join(blocks)
+    total = len(skips) + len(text_skips or [])
+    path.write_text(
+        f'<?xml version="1.0" encoding="utf-8"?>\n'
+        f'<testsuites>\n'
+        f'  <testsuite name="pytest" tests="{total}" skipped="{total}">\n'
+        f"{body}\n"
+        f"  </testsuite>\n"
+        f"</testsuites>\n"
+    )
+    return path
+
+
+def _write_requirements(path: Path, lines: list[str]) -> Path:
+    path.write_text("\n".join(lines) + "\n")
+    return path
+
+
+# ── _extract_import_name ──────────────────────────────────────────────────────
+
+@pytest.mark.parametrize(
+    "message, expected",
+    [
+        ("could not import 'ta': No module named 'ta'", "ta"),
+        ("could not import 'duckdb'", "duckdb"),
+        ("gensim not installed", "gensim"),
+        ("torch not installed", "torch"),
+        ("No module named 'ta'", "ta"),
+        ("network unreachable", None),
+        ("", None),
+        # double-quote variant of importorskip
+        ('could not import "ta"', "ta"),
+        # mixed case in custom skipif
+        ("LightGBM not installed", "lightgbm"),
+    ],
+)
+def test_extract_import_name(message: str, expected: str | None) -> None:
+    assert _extract_import_name(message) == expected
+
+
+# ── _required_imports ────────────────────────────────────────────────────────
+
+def test_required_imports_strips_versions(tmp_path: Path) -> None:
+    req = _write_requirements(
+        tmp_path / "requirements.txt",
+        [
+            "ta==0.11.0",
+            "ccxt>=4.0.0",
+            "lightgbm>=4.0.0",
+            "uvicorn[standard]==0.30.0",
+            "# a comment",
+            "",
+        ],
+    )
+    out = _required_imports(req)
+    assert {"ta", "ccxt", "lightgbm", "uvicorn"} <= out
+
+
+def test_required_imports_expands_aliases(tmp_path: Path) -> None:
+    req = _write_requirements(
+        tmp_path / "requirements.txt",
+        ["scikit-learn>=1.3.0", "python-dateutil==2.9.0"],
+    )
+    out = _required_imports(req)
+    assert "scikit-learn" in out and "sklearn" in out
+    assert "python-dateutil" in out and "dateutil" in out
+
+
+def test_required_imports_missing_file_returns_empty(tmp_path: Path) -> None:
+    assert _required_imports(tmp_path / "nope.txt") == set()
+
+
+# ── main ─────────────────────────────────────────────────────────────────────
+
+def test_main_clean_when_no_skips(tmp_path: Path, capsys) -> None:
+    junit = _write_junit(tmp_path / "junit.xml", [])
+    req = _write_requirements(tmp_path / "requirements.txt", ["ta==0.11.0"])
+    rc = main([str(junit), str(req)])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "scanned 0 skip(s)" in out
+
+
+def test_main_clean_when_skip_is_optional_dep(tmp_path: Path, capsys) -> None:
+    """``torch`` is NOT in requirements.txt so a torch skip is allowed."""
+    junit = _write_junit(
+        tmp_path / "junit.xml",
+        [("tests.test_torch", "test_x", "torch not installed")],
+    )
+    req = _write_requirements(tmp_path / "requirements.txt", ["pandas==3.0.2"])
+    rc = main([str(junit), str(req)])
+    assert rc == 0
+    assert "no skips reference packages pinned" in capsys.readouterr().out
+
+
+def test_main_fails_when_required_pkg_skipped(tmp_path: Path, capsys) -> None:
+    junit = _write_junit(
+        tmp_path / "junit.xml",
+        [
+            (
+                "tests.test_strategies_indicators",
+                "test_add_rsi",
+                "could not import 'ta': No module named 'ta'",
+            )
+        ],
+    )
+    req = _write_requirements(tmp_path / "requirements.txt", ["ta==0.11.0"])
+    rc = main([str(junit), str(req)])
+    assert rc == 1
+    out = capsys.readouterr().out
+    assert "silently skipped" in out
+    assert "ta" in out
+    assert "test_add_rsi" in out
+
+
+def test_main_fails_for_alias_skip(tmp_path: Path, capsys) -> None:
+    """A skip naming ``sklearn`` should fail when ``scikit-learn`` is pinned."""
+    junit = _write_junit(
+        tmp_path / "junit.xml",
+        [("tests.t", "test_x", "could not import 'sklearn'")],
+    )
+    req = _write_requirements(
+        tmp_path / "requirements.txt", ["scikit-learn>=1.3.0"]
+    )
+    rc = main([str(junit), str(req)])
+    assert rc == 1
+    assert "sklearn" in capsys.readouterr().out
+
+
+def test_main_returns_2_on_missing_xml(tmp_path: Path, capsys) -> None:
+    rc = main([str(tmp_path / "does-not-exist.xml")])
+    assert rc == 2
+    assert "cannot read" in capsys.readouterr().err
+
+
+def test_main_returns_2_on_no_args(capsys) -> None:
+    rc = main([])
+    assert rc == 2
+    assert "usage:" in capsys.readouterr().err
+
+
+def test_main_returns_2_on_malformed_xml(tmp_path: Path, capsys) -> None:
+    bad = tmp_path / "bad.xml"
+    bad.write_text("<not-valid")
+    rc = main([str(bad)])
+    assert rc == 2
+
+
+# ── alias map sanity ─────────────────────────────────────────────────────────
+
+def test_alias_map_keys_are_lowercase() -> None:
+    """Distribution-name keys are matched case-insensitively after lower()."""
+    for k in _DIST_TO_IMPORTS:
+        assert k == k.lower(), f"alias key not lowercase: {k}"
+
+
+def test_main_fails_for_module_level_importorskip(
+    tmp_path: Path, capsys
+) -> None:
+    """Module-level ``pytest.importorskip`` puts the reason in the
+    element *text* with ``message="collection skipped"`` — verify we
+    still detect it."""
+    junit = _write_junit(
+        tmp_path / "junit.xml",
+        skips=[],
+        text_skips=[
+            (
+                "",
+                "tests.test_strategies_indicators",
+                "collection skipped",
+                "Skipped: could not import 'ta': No module named 'ta'",
+            )
+        ],
+    )
+    req = _write_requirements(tmp_path / "requirements.txt", ["ta==0.11.0"])
+    rc = main([str(junit), str(req)])
+    assert rc == 1
+    out = capsys.readouterr().out
+    assert "ta" in out
+    assert "test_strategies_indicators" in out
+
+
+def test_main_handles_multiple_skips_some_offending(
+    tmp_path: Path, capsys
+) -> None:
+    junit = _write_junit(
+        tmp_path / "junit.xml",
+        [
+            ("tests.t1", "ok", "torch not installed"),  # optional, allowed
+            ("tests.t2", "bad", "could not import 'ta'"),  # required, fail
+            ("tests.t3", "bad2", "gensim not installed"),  # required, fail
+        ],
+    )
+    req = _write_requirements(
+        tmp_path / "requirements.txt",
+        ["ta==0.11.0", "gensim>=4.3.0"],
+    )
+    rc = main([str(junit), str(req)])
+    assert rc == 1
+    out = capsys.readouterr().out
+    assert "2 test(s) silently skipped" in out
+    assert "test_x" not in out  # sanity — different name
+    assert "torch" not in out  # optional dep is not flagged


### PR DESCRIPTION
Closes #199.

## Summary

Adds `scripts/check_no_silent_skips.py`, which parses the JUnit XML pytest already emits and fails if any `<skipped/>` reason names a package pinned in `requirements.txt`. Catches the regression mode where a removed pin or a broken wheel silently lowers coverage with no failing test — today the 76 % CI floor is a rubber yardstick because four entire test files (~150 statements) silently skip on missing optional deps.

## Files

- `scripts/check_no_silent_skips.py` (new) — JUnit parser + alias map (sklearn ↔ scikit-learn, etc)
- `tests/test_check_no_silent_skips.py` (new) — **22 unit tests** covering attribute-message and module-level collection-skip variants, alias mapping, version-spec stripping, and exit-code behaviour
- `.github/workflows/ci.yml` — new step in the test job, immediately after pytest
- `.claude/skills/pre-push/SKILL.md` — stage 2b uses the same junit XML
- `docs/ci_pipeline.md` — documents the gate

## Caveat for local reviewers

Running `/pre-push` on a dev workstation that's missing `ta` or `gensim` (which can fail to wheel-build on Python 3.11) will trip this very gate. **That's the gate doing its job** — fix is `pip install -r requirements.txt`. CI installs all deps cleanly, so the CI run will be green.

## Test plan

- [x] `ruff check .` clean
- [x] `pytest tests/test_check_no_silent_skips.py` — 22 passed
- [x] Locally the script flags `ta` (collection-level skip) + `gensim` (per-test skip) correctly when those deps aren't installed
- [ ] CI green (where all deps install)

Recommended landing order: after #200 (branch coverage), before #201 (warnings-as-errors).

https://claude.ai/code/session_01WmG6mAtgV1nr1c9NPxBAD8

---
_Generated by [Claude Code](https://claude.ai/code/session_01WmG6mAtgV1nr1c9NPxBAD8)_