### PR TITLE
test-infra: promote pytest warnings to errors with allow-list (#201)

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -4,6 +4,23 @@ python_files = test_*.py
 addopts = --strict-markers --strict-config --tb=short
 timeout = 60
 timeout_method = thread
+# Warnings-as-errors (#201). Anything not explicitly ignored below
+# fails the test that emitted it. New deprecations from sklearn /
+# pandas / numpy / lgbm regress loudly instead of rotting into the
+# warning summary at the bottom of CI logs. Keep the ignore list
+# tight: each entry must have a one-line comment explaining why we
+# accept it, so future cleanup PRs can prune any that are no longer
+# needed. New ignores require justification in PR review.
+filterwarnings =
+    error
+    # LGBMRegressor is fitted on a pandas DataFrame (with feature
+    # names) and predicts on a numpy ndarray (without) in the smoke
+    # tests. Inherent to the test scaffolding — fitting + predicting
+    # on a DataFrame would mask shape bugs we want the test to find.
+    ignore:X does not have valid feature names:UserWarning
+    # tests/test_mlp_signal.py uses max_iter=20 to keep runtime in the
+    # 60 s test budget. Convergence is not what the smoke test asserts.
+    ignore::sklearn.exceptions.ConvergenceWarning
 markers =
     integration: marks tests as integration tests requiring live services (deselect with '-m "not integration"')
     e2e: marks end-to-end tests that exercise the cross-module chain (broker ↔ guard ↔ journal ↔ scheduler ↔ cache). Run a fast unit pass with '-m "not integration and not e2e"' and the slower regression suite with '-m e2e'. Both gate the merge in CI; the split keeps the unit feedback loop tight while still exercising the end-to-end paths added in #185.


### PR DESCRIPTION
Closes #201.

## Summary

Flips `filterwarnings = error` in `pytest.ini` so warnings fail the test that emitted them. New `DeprecationWarning`s from future `pandas` / `sklearn` / `numpy` upgrades regress loudly instead of rotting at the bottom of the test log.

## Allow-list

Two `ignore::` entries cover every warning the suite currently emits, each with a one-line `#` justification:

| Warning | Reason |
|---|---|
| `UserWarning: X does not have valid feature names` | LGBM smoke tests fit on DataFrame, predict on ndarray. Inherent to the scaffolding. |
| `sklearn.exceptions.ConvergenceWarning` | MLP smoke test caps `max_iter=20` to fit the 60 s test budget. |

Going forward, every new `ignore::` entry needs a comment explaining why so a future cleanup PR can prune any that are no longer needed.

## Files

- `pytest.ini` — `filterwarnings` block added

## Test plan

- [x] `ruff check .` clean
- [x] `pytest tests/ -m "not integration and not e2e"` — 1574 passed, **0 unfiltered warnings** (down from 11)
- [x] Suite runtime ≈ 33 s (no regression)
- [ ] CI green

Recommended landing order: after #199 + #200, before #202 / #203 / #205. This is the third leg of the test-infra foundation.

https://claude.ai/code/session_01WmG6mAtgV1nr1c9NPxBAD8

---
_Generated by [Claude Code](https://claude.ai/code/session_01WmG6mAtgV1nr1c9NPxBAD8)_