### PR TITLE
test-quality: extend mutmut to e2e chain modules (#223)

### DIFF
--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -46,21 +46,26 @@ jobs:
           pip install -r requirements.txt
           pip install -r requirements-dev.txt
 
-      # Verify the unit suite is green before we start mutating — a
-      # pre-existing failure would make every mutant "killed" by that
-      # same failure, polluting the survival statistics.
-      - name: Smoke test (suite must be green)
-        run: pytest tests/ -m "not integration and not e2e" -q --tb=line
+      # Verify the unit AND e2e suites are green before we start
+      # mutating — a pre-existing failure would make every mutant
+      # "killed" by that same failure, polluting the survival
+      # statistics. e2e is included because #223 added e2e chain
+      # modules to the mutation surface.
+      - name: Smoke test (unit + e2e must be green)
+        run: pytest tests/ -m "not integration" -q --tb=line
 
       - name: Run mutmut
         # mutmut returns non-zero when there are surviving mutants —
         # which is information, not a CI failure on this advisory job.
+        # Path / runner config lives in setup.cfg [mutmut]; the CLI
+        # flags here are kept in sync with that file so a manual
+        # ``workflow_dispatch`` run uses the same surface.
         continue-on-error: true
         run: |
           mutmut run \
-            --paths-to-mutate "risk/,analysis/,strategies/indicators.py" \
+            --paths-to-mutate "risk/,analysis/,strategies/indicators.py,broker/paper_trader.py,journal/trading_journal.py,bus/event_bus.py,audit/" \
             --tests-dir tests/ \
-            --runner 'python -m pytest -x -q -m "not integration and not e2e" --no-header --tb=no' \
+            --runner 'python -m pytest -x -q -m "not integration" --no-header --tb=no' \
             --use-coverage
 
       - name: Generate HTML report

--- a/docs/ci_pipeline.md
+++ b/docs/ci_pipeline.md
@@ -126,14 +126,24 @@ For each new e2e file:
 - [ ] Schema invariant: lock the output dict keys downstream consumers
   read (regression net for refactors).
 
-## Off-cycle: weekly mutation testing (#204)
+## Off-cycle: weekly mutation testing (#204, extended #223)
 
 A separate workflow `.github/workflows/mutation.yml` runs `mutmut`
-against the math-heavy modules — `risk/`, `analysis/`,
-`strategies/indicators.py` — every Monday at 06:00 UTC. Mutation
-testing flips operators and constants in source and re-runs the
-suite; tests that still pass mean the original line was exercised
-but the assertions don't actually catch the bug.
+every Monday at 06:00 UTC. Mutation testing flips operators and
+constants in source and re-runs the suite; tests that still pass
+mean the original line was exercised but the assertions don't
+actually catch the bug.
+
+**Mutation surface** (path groups in `setup.cfg [mutmut]`):
+
+| Group | Modules | Killed mostly by |
+|---|---|---|
+| Math (#204) | `risk/`, `analysis/`, `strategies/indicators.py` | unit + property tests (greeks parity, kelly bounds, var fallback, hrp, markowitz) |
+| E2E chain (#223) | `broker/paper_trader.py`, `journal/trading_journal.py`, `bus/event_bus.py`, `audit/` | e2e suite (bracket lifecycle, ml execute → journal, audit log lifecycle, event-bus publish/consume) |
+
+The runner uses the `not integration` selector — both unit AND e2e
+tests participate, so a sign-flip in `broker/paper_trader.py` is
+caught by either layer rather than only the unit slice.
 
 It is **not** a PR gate (each run is ≥ 30 min and the survival rate
 is advisory, not pass/fail). The HTML report is uploaded as an

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,11 +1,28 @@
 ; setup.cfg — tool configurations that don't have a dedicated file.
 ;
-; Mutation testing (#204): mutmut reads its config from this section.
-; Targets the math-heavy modules where line coverage is least
-; informative — risk/, analysis/, strategies/indicators.py. Mutation
-; runs weekly via .github/workflows/mutation.yml; not in the PR gate.
+; Mutation testing (#204, extended in #223): mutmut reads its config
+; from this section. Targets the math-heavy modules where line
+; coverage is least informative AND the e2e chain modules where
+; trade-correctness depends on the multi-module flow being right.
+;
+; Path groups:
+;   * risk/, analysis/, strategies/indicators.py (#204) — pure math.
+;     Killed mostly by unit tests (greeks property tests, var, kelly,
+;     hrp, markowitz).
+;   * broker/paper_trader.py, journal/trading_journal.py,
+;     bus/event_bus.py, audit/ (#223) — chain modules that the e2e
+;     suite exercises end-to-end. Killed mostly by e2e tests, so the
+;     runner below includes the e2e marker.
+;
+; Mutation runs weekly via .github/workflows/mutation.yml; not in
+; the PR gate. Each weekly run produces an HTML report whose
+; survival rate per module is the right "are our tests effective"
+; signal.
 
 [mutmut]
-paths_to_mutate = risk/,analysis/,strategies/indicators.py
+paths_to_mutate = risk/,analysis/,strategies/indicators.py,broker/paper_trader.py,journal/trading_journal.py,bus/event_bus.py,audit/
 tests_dir = tests/
-runner = python -m pytest -x -q -m "not integration and not e2e" --no-header --tb=no
+; Runner now drops the e2e exclusion so mutmut validates against the
+; full unit + e2e surface. The integration marker stays excluded
+; (those tests need live credentials).
+runner = python -m pytest -x -q -m "not integration" --no-header --tb=no


### PR DESCRIPTION
Closes #223.

**Phase 3** of the e2e excellence enhancement. Today's mutmut config covers the math-heavy modules only (`risk/`, `analysis/`, `strategies/indicators.py`) and runs against the unit suite alone, so the weekly run can't tell us whether the e2e suite would actually catch a sign-flip in `broker/paper_trader.py`, `journal/trading_journal.py`, `bus/event_bus.py`, or `audit/`.

## What lands

| Group | Modules | Killed mostly by |
|---|---|---|
| Math (existing #204) | `risk/`, `analysis/`, `strategies/indicators.py` | unit + property tests (greeks parity, kelly bounds, var fallback, hrp, markowitz) |
| **E2E chain (NEW #223)** | `broker/paper_trader.py`, `journal/trading_journal.py`, `bus/event_bus.py`, `audit/` | e2e suite (bracket lifecycle, ml execute → journal, audit log lifecycle, event-bus publish/consume) |

## Files

- `setup.cfg` — `[mutmut].paths_to_mutate` gains 4 chain modules; `[mutmut].runner` drops the e2e exclusion (`-m "not integration"`) so unit + e2e both participate in killing mutants
- `.github/workflows/mutation.yml` — inline CLI flags kept in sync with `setup.cfg`; pre-mutation smoke test now runs unit + e2e so a pre-existing failure surfaces before mutmut starts
- `docs/ci_pipeline.md` — table of the two path groups and which test layer kills each

## Test plan

- [x] `ruff check .` clean
- [x] Excellent-test PR gate (#215) self-checks: `setup.cfg` + workflow + docs only — no `.py` source diffs, gate exits 0
- [ ] CI green on all 5 jobs
- [ ] Manual `workflow_dispatch` of `Mutation Testing` after merge — verify the HTML report covers the 4 new chain modules
- [ ] Sign-flip experiment on a throwaway branch (e.g. break a sign in `broker/paper_trader.py:_close_bracket`) → killed by `tests/test_e2e_bracket_lifecycle.py` on next run

## Why this completes the e2e excellence bundle

| Phase | What | Status |
|---|---|---|
| 1 (#221) | Perf gate, cleanup invariant, injection fixtures | merged via PR #224 |
| 2 (#222) | 5 missing chain tests | merged via PR #225 |
| **3 (#223)** | **Extend mutmut to chain modules** | **this PR** |

After this lands, the e2e suite has: completeness (every chain has a test), per-test perf budget, cleanup invariants, failure-injection coverage, AND mutation-survival evidence that the chain tests actually catch bugs. That's the "excellent" bar.

https://claude.ai/code/session_01WmG6mAtgV1nr1c9NPxBAD8

---
_Generated by [Claude Code](https://claude.ai/code/session_01WmG6mAtgV1nr1c9NPxBAD8)_