### PR TITLE
docs: bug-regression policy + negative-test discipline + PR template (#230)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,26 @@
+## Summary
+
+<!-- 1-3 bullets describing the change and the why -->
+
+-
+
+## Test plan
+
+<!-- Tick everything that ran clean. CI runs the same gates -->
+
+- [ ] `ruff check .` clean
+- [ ] `pytest tests/ -m "not integration"` passes (unit + e2e)
+- [ ] Coverage gate (76 % combined line+branch) green
+- [ ] If this PR fixes a bug: a regression test exists and carries
+      `# regression test for #NNN` (per `CLAUDE.md` § Testing
+      Conventions). If a regression test isn't possible, explain why.
+- [ ] If this PR touches a critical-path module
+      (`broker/` / `journal/` / `risk/` / `audit/` / `bus/`):
+      at least one happy-path test AND at least one failure-mode
+      test ship together (per `CLAUDE.md` § Negative-test
+      discipline).
+- [ ] If this PR adds an e2e file: it uses the shared fixtures in
+      `tests/conftest.py` and stays under the 3 s per-test budget
+      (per `docs/ci_pipeline.md` § Adding a new e2e file).
+
+<!-- Closes #NNN -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -319,6 +319,38 @@ Copy `.env.example` to `.env` and populate the relevant keys. Key variables:
 - Fixtures for DB setup should use in-memory SQLite (`:memory:`) or temp files
 - Aim to keep unit tests fast (< 1s each)
 
+### Bug-regression discipline (#230)
+
+Every fixed bug ships with a permanent regression test. Tag the test
+with the issue number using a `# regression test for #NNN` comment
+on the line above the test function so reviewers can find it during
+code review:
+
+```python
+# regression test for #183 — PreTradeGuard read `equity` only,
+# missing the paper broker's `total_value` key
+def test_guard_accepts_paper_broker_equity():
+    ...
+```
+
+The PR description must call out either the regression test OR (in
+rare cases — e.g. the bug is environmental and impossible to
+reproduce in a test) explicitly explain why a regression test
+isn't possible. The PR template at
+[`.github/PULL_REQUEST_TEMPLATE.md`](.github/PULL_REQUEST_TEMPLATE.md)
+carries the checkbox.
+
+### Negative-test discipline (#231)
+
+Every public function on a critical path (`broker/`, `journal/`,
+`risk/`, `audit/`, `bus/`) ships **at least one happy-path test
+AND at least one failure-mode test** (raise, return None, empty
+input, etc.). The Phase-1 e2e injection fixtures
+(`inject_broker_failure`, `inject_journal_failure`,
+`trip_killswitch` in `tests/conftest.py`) are the unit-suite
+equivalent — pull them in with the same fixture-based pattern
+where possible.
+
 ### Running a Specific Test
 
 ```bash


### PR DESCRIPTION
Closes #230.

**T1.4** from the testing best-practice audit. Documents two test-quality conventions that the audit flagged as undocumented despite being implicit in recent PRs.

## What lands

### `CLAUDE.md` § Testing Conventions

Two new sub-sections:

| Convention | Rule |
|---|---|
| **Bug-regression discipline** | Every fixed bug ships with a permanent regression test, tagged via `# regression test for #NNN`. Today only one example exists in the codebase — `tests/conftest.py:37` mentions #183 inline. |
| **Negative-test discipline** | Every public function on a critical path (`broker/`, `journal/`, `risk/`, `audit/`, `bus/`) ships at least one happy-path test AND at least one failure-mode test. Pull in the Phase-1 e2e injection fixtures (`inject_broker_failure`, `inject_journal_failure`, `trip_killswitch` in `tests/conftest.py`) rather than re-rolling new mocks. |

### `.github/PULL_REQUEST_TEMPLATE.md` (new)

Adds the standard test-plan checklist with two new boxes that encode the conventions above, plus the existing CI-mirror checks (ruff, pytest, coverage gate) and the e2e-file checklist.

## Why now

Doc-only, blocks nothing else. Establishes the conventions before #231 (back-fill negative tests on critical-path unit files) ships so that PR can reference the policy directly. Also unblocks T2.6 (issue-link convention) which is the same edit.

## Test plan

- [x] `ruff check .` clean (no Python changes)
- [x] `pytest tests/ -m "not integration and not e2e"` — 1850 passed, 80.01 % coverage
- [x] Excellent-test PR gate (#215) self-checks: `CLAUDE.md` + `.github/PULL_REQUEST_TEMPLATE.md` only — neither is a `.py` file, gate exits 0
- [ ] CI green
- [ ] Future bug-fix PRs ship the `# regression test for #NNN` comment (verify retrospectively)

https://claude.ai/code/session_01WmG6mAtgV1nr1c9NPxBAD8

---
_Generated by [Claude Code](https://claude.ai/code/session_01WmG6mAtgV1nr1c9NPxBAD8)_