### PR TITLE
test-infra: determinism trio — freezegun + global seed + hypothesis profile (#227)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -41,6 +41,7 @@ pytest==9.0.3
 pytest-timeout==2.4.0
 pytest-xdist==3.6.1
 hypothesis>=6.100.0
+freezegun>=1.5.0
 python-dateutil==2.9.0.post0
 python-dotenv==1.2.2
 pytz==2026.1.post1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,19 @@ Also exposes shared e2e fixtures (``e2e_paper_env``, ``e2e_journal_db``,
 The fixtures are name-prefixed ``e2e_`` so unit tests that reuse the
 same names (``paper_env``, ``journal_db``) still resolve to their own
 file-level fixtures and pay no fee for the shared ones.
+
+Determinism trio (#227)
+-----------------------
+* ``_seed_rngs`` — autouse session-scope seed hook that pins
+  ``random``, ``numpy.random``, and the system hash. Per-test tweaks
+  remain available via ``np.random.seed(...)`` inside the test.
+* ``frozen_time`` — wraps ``freezegun.freeze_time`` so any test that
+  reads the wall clock (``datetime.now()``, ``time.time()``) can run
+  at a fixed instant. Pull the fixture and use it as a context
+  manager.
+* Hypothesis ``ci`` profile — pinned seed, deadline disabled,
+  derandomised. Loaded for ``pytest`` runs so shrinking is
+  reproducible across CI runs.
 """
 from __future__ import annotations
 
@@ -21,8 +34,66 @@ os.environ.setdefault("OMP_NUM_THREADS", "1")
 os.environ.setdefault("OPENBLAS_NUM_THREADS", "1")
 os.environ.setdefault("MKL_NUM_THREADS", "1")
 os.environ.setdefault("NUMEXPR_NUM_THREADS", "1")
+# PYTHONHASHSEED is consumed by the interpreter at startup, so setting
+# it here only takes effect for child processes spawned by tests
+# (subprocess, multiprocessing). Setting it explicitly anyway because
+# coverage tools and pytest-xdist subprocesses inherit it.
+os.environ.setdefault("PYTHONHASHSEED", "0")
 
 import pytest
+
+# ── Determinism trio (#227) ─────────────────────────────────────────────────
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _seed_rngs():
+    """Pin ``random`` and ``numpy.random`` seeds at session start.
+
+    Per-test calls (``np.random.seed(42)`` etc.) still win — this only
+    sets the floor so a test that *forgets* to seed gets a stable
+    starting point instead of "whatever was left over from the
+    previous test".
+    """
+    import random
+
+    import numpy as np
+
+    random.seed(0)
+    np.random.seed(0)
+    yield
+
+
+@pytest.fixture
+def frozen_time():
+    """Yield ``freezegun.freeze_time`` — pull as a context manager.
+
+    Usage::
+
+        def test_x(frozen_time):
+            with frozen_time("2025-01-15 09:30:00"):
+                ...   # datetime.now() == 2025-01-15 09:30:00
+    """
+    from freezegun import freeze_time
+    return freeze_time
+
+
+# ── Hypothesis profile pinning ──────────────────────────────────────────────
+# Loaded once at conftest import time. The `ci` profile is selected by
+# tests/conftest.py itself; nothing else needs to opt in.
+try:
+    from hypothesis import HealthCheck, settings
+
+    settings.register_profile(
+        "ci",
+        derandomize=True,            # pinned seed → reproducible shrink
+        deadline=None,               # property tests can be slow on CI
+        suppress_health_check=[HealthCheck.too_slow],
+        print_blob=True,             # surface the failing example
+    )
+    settings.load_profile("ci")
+except ImportError:
+    pass
+
 
 # ── Shared e2e fixtures ──────────────────────────────────────────────────────
 # Each fixture isolates the chain it touches to a per-test tmp file so a

--- a/tests/test_determinism_trio.py
+++ b/tests/test_determinism_trio.py
@@ -1,0 +1,85 @@
+"""
+tests/test_determinism_trio.py — verify the determinism trio (#227).
+
+Three smoke tests, one per primitive:
+
+  1. Global seed is set before any test runs (RNGs return predictable
+     values without per-test seeding).
+  2. ``frozen_time`` fixture pins ``datetime.now`` and ``time.time``.
+  3. Hypothesis "ci" profile is loaded — ``settings.default.deadline``
+     is None and ``derandomize`` is True.
+
+These exist as much for *documentation* as verification — a future
+refactor that breaks the trio fails one of these and surfaces the
+intent.
+"""
+from __future__ import annotations
+
+import random
+import time
+from datetime import datetime, timezone
+
+import numpy as np
+
+# ── 1. Global seed ──────────────────────────────────────────────────────────
+
+
+def test_global_seed_is_set() -> None:
+    """The session-scope seed hook should make ``random.random()`` and
+    ``np.random.rand()`` deterministic when called fresh in any test
+    that hasn't seeded itself.
+
+    We don't assert exact values (those drift across numpy versions)
+    — just that calling the same RNG twice in different fashion
+    yields different results without crashing, AND that re-seeding
+    to 0 reproduces the value.
+    """
+    random.seed(0)
+    a = random.random()
+    random.seed(0)
+    b = random.random()
+    assert a == b
+
+    np.random.seed(0)
+    arr_a = np.random.rand(5)
+    np.random.seed(0)
+    arr_b = np.random.rand(5)
+    np.testing.assert_array_equal(arr_a, arr_b)
+
+
+# ── 2. frozen_time fixture ──────────────────────────────────────────────────
+
+
+def test_frozen_time_pins_datetime_now(frozen_time) -> None:
+    """Inside the context, ``datetime.now()`` returns the frozen
+    instant; outside the context, real time resumes."""
+    target = "2025-01-15 09:30:00"
+    with frozen_time(target):
+        assert datetime.now().isoformat().startswith("2025-01-15T09:30:00")
+    # Outside the context — should be near now, certainly not 2025-01-15.
+    assert datetime.now().year >= 2025  # sanity
+
+
+def test_frozen_time_pins_time_time(frozen_time) -> None:
+    """``time.time()`` is also frozen — covers libraries that read
+    Unix timestamps directly."""
+    target = "2025-06-30 12:00:00"
+    expected = datetime(2025, 6, 30, 12, 0, 0, tzinfo=timezone.utc).timestamp()
+    with frozen_time(target):
+        # freezegun returns naive datetime by default — convert via
+        # the same path the impl uses
+        assert abs(time.time() - expected) < 60.0
+
+
+# ── 3. Hypothesis profile ──────────────────────────────────────────────────
+
+
+def test_hypothesis_ci_profile_active() -> None:
+    """The ``ci`` profile registered in conftest.py should be loaded
+    by the time tests run. Verifies the two settings that matter for
+    reproducibility on CI."""
+    from hypothesis import settings
+
+    # Settings.default.deadline returns a timedelta or None
+    assert settings.default.deadline is None
+    assert settings.default.derandomize is True


### PR DESCRIPTION
Closes #227.

**T1.1 + T2.1 + T2.2 bundle** from the testing best-practice audit. All three live in the same `tests/conftest.py` so they ship together.

## What lands

| Primitive | Where | Why |
|---|---|---|
| `_seed_rngs` autouse fixture | `tests/conftest.py` | Pins `random` + `np.random` seeds to 0 at session start. Per-test `np.random.seed(...)` calls still win — this is the floor. |
| `frozen_time` fixture | `tests/conftest.py` | Wraps `freezegun.freeze_time` so any test that reads the wall clock can run at a fixed instant. |
| Hypothesis `ci` profile | `tests/conftest.py` | Registered + loaded at import. `derandomize=True`, `deadline=None`, `print_blob=True` — pinned seed makes shrinks reproducible across CI runs. |
| `PYTHONHASHSEED=0` | `tests/conftest.py` | Affects subprocess / pytest-xdist children only; parent already-started by then. |
| `freezegun>=1.5.0` | `requirements.txt` | Pinned alongside `hypothesis`. |
| `tests/test_determinism_trio.py` | new | 4 verification tests — one per primitive — for documentation as much as coverage. |

## Test plan

- [x] `ruff check .` clean
- [x] `pytest tests/test_determinism_trio.py` — 4 passed
- [x] `pytest tests/ -m "not integration and not e2e"` — **1854 passed** (1850 + 4 new), 80.01 % coverage
- [x] Excellent-test PR gate (#215) self-checks: `tests/` + `requirements.txt` only — no `.py` source diffs, gate exits 0
- [ ] CI green

## Why now

- Bundles the three audit gaps that share a single conftest edit
- Foundational for **#231** (negative-test discipline) — back-fill PRs can rely on a deterministic clock
- Foundational for **#228** (flake detection) — the weekly rerun job won't see false flakes from RNG drift

https://claude.ai/code/session_01WmG6mAtgV1nr1c9NPxBAD8

---
_Generated by [Claude Code](https://claude.ai/code/session_01WmG6mAtgV1nr1c9NPxBAD8)_