### PR TITLE
test-infra: weekly flake-detection workflow (#228)

### DIFF
--- a/.github/workflows/flake_detection.yml
+++ b/.github/workflows/flake_detection.yml
@@ -1,0 +1,97 @@
+name: Flake Detection
+
+# Weekly flake-detection job (#228). Runs the unit suite N times in
+# independent pytest invocations and aggregates the per-test
+# pass/fail breakdown.
+#
+# Why N independent runs (not pytest-rerunfailures or pytest-repeat):
+# both plugins re-run failing tests within a single pytest process,
+# which obscures whether the failure is reproducible across fresh
+# interpreter invocations. Independent runs surface flake from RNG
+# drift, BLAS thread races, file-system ordering, etc.
+#
+# Cadence: weekly is the right balance — re-running 5x costs ~5x
+# the unit-job wall clock (~4 min) which is too much per PR but
+# fine once a week.
+#
+# Output: ``flake-report.md`` artefact uploaded for review. Operators
+# look at the GitHub-rendered table; tests with 0 < fails < runs are
+# the actual flakes.
+
+on:
+  schedule:
+    - cron: "30 6 * * 1"   # Mondays at 06:30 UTC, 30 min after mutmut
+  workflow_dispatch:        # allow manual runs from the Actions tab
+    inputs:
+      n_runs:
+        description: "Number of independent pytest runs to aggregate"
+        required: false
+        default: "5"
+
+permissions:
+  contents: read
+
+jobs:
+  detect-flakes:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Cache pip dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-flake-${{ hashFiles('requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-flake-
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pytest-cov
+
+      # N independent runs. Each invocation gets a fresh interpreter
+      # so RNG / BLAS thread / file-system race conditions surface.
+      # ``continue-on-error: true`` lets the loop complete even when
+      # individual runs fail — we WANT the failure data for the
+      # aggregator.
+      - name: Run pytest 5x
+        continue-on-error: true
+        run: |
+          n_runs="${{ github.event.inputs.n_runs || 5 }}"
+          for i in $(seq 1 "$n_runs"); do
+            echo "::group::Run $i / $n_runs"
+            pytest tests/ -m "not integration and not e2e" \
+              --junitxml=run-$i.xml \
+              -q --tb=no --no-header || true
+            echo "::endgroup::"
+          done
+
+      - name: Aggregate flake report
+        run: |
+          python scripts/aggregate_flake_runs.py run-*.xml
+
+      - name: Upload report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: flake-report
+          path: |
+            flake-report.md
+            run-*.xml
+
+      - name: Print report to job summary
+        if: always()
+        run: |
+          if [ -f flake-report.md ]; then
+            cat flake-report.md >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,9 @@ audit/log/
 .mutmut-cache
 html/
 mutation-summary.txt
+
+# Flake-detection artefacts (#228) — generated locally by
+# scripts/aggregate_flake_runs.py; the CI workflow uploads them as
+# artefacts. Never commit.
+flake-report.md
+run-*.xml

--- a/docs/ci_pipeline.md
+++ b/docs/ci_pipeline.md
@@ -155,6 +155,40 @@ Manual runs are available from the Actions tab via
 Dev-only deps live in `requirements-dev.txt`; runtime deps are
 unaffected.
 
+## Off-cycle: weekly flake detection (#228)
+
+A separate workflow `.github/workflows/flake_detection.yml` runs the
+unit suite **5 times in independent pytest invocations** every
+Monday at 06:30 UTC (30 min after mutmut). The aggregator at
+`scripts/aggregate_flake_runs.py` reads each run's junit XML and
+produces `flake-report.md` listing every test with a per-run
+pass/fail breakdown.
+
+**Why N independent runs** (not `pytest-rerunfailures` or
+`pytest-repeat`): both plugins re-run failing tests within a single
+pytest process, which obscures whether a failure is reproducible
+across fresh interpreter invocations. Independent runs surface flake
+from RNG drift, BLAS thread races, file-system ordering — exactly
+the failure modes a flake detector should catch.
+
+**What the report shows**:
+- Tests that always pass → not in the report (stable + green)
+- Tests that always fail → not in the report (broken, not flaky;
+  surfaced by the standard PR-gate run)
+- Tests with `0 < fails < runs` → the actual flakes, sorted by
+  fail count descending
+
+It is **not** a PR gate (running the suite 5x costs ~5x the unit
+job's wall clock — too much per PR, fine once a week). Review the
+artefact each Monday and either fix the flake at source or add it
+to a known-flake allowlist with a tracking ticket.
+
+Manual runs are available from the Actions tab via
+`workflow_dispatch` (with an optional `n_runs` input override).
+
+The flake-detection workflow uses the standard `requirements.txt`
+only — no dev deps required.
+
 ## Best-practice config
 
 | Setting | Value | Why |

--- a/scripts/aggregate_flake_runs.py
+++ b/scripts/aggregate_flake_runs.py
@@ -1,0 +1,162 @@
+"""
+scripts/aggregate_flake_runs.py — flake-rate aggregator for the
+weekly flake-detection workflow (#228).
+
+Reads N junit XMLs produced by N independent pytest runs of the same
+suite and reports each test's pass/fail breakdown. Tests that go red
+sometimes — but not always — are flaky; tests that always pass and
+always fail aren't (those are stable, just possibly broken).
+
+Usage::
+
+    python scripts/aggregate_flake_runs.py run-1.xml run-2.xml ...
+
+Output:
+
+  * Stdout — human-readable summary (count + flake rate per test).
+  * ``flake-report.md`` — markdown table sorted by failure count
+    descending. Suitable for a GitHub issue body or a CI artefact.
+  * Exit code 0 always — flakes are information, not a failure (the
+    workflow already runs as ``continue-on-error: true``).
+
+Why a separate script (instead of pytest-rerunfailures or
+pytest-repeat): both plugins re-run failing tests within a single
+pytest process, which obscures whether the failure is reproducible
+across fresh interpreter invocations. We want **independent** runs
+to detect flake from RNG drift, BLAS thread races, file-system
+ordering, etc. The bash loop in the workflow gives us that for free;
+this script just aggregates the resulting XMLs.
+"""
+from __future__ import annotations
+
+import sys
+import xml.etree.ElementTree as ET
+from collections import defaultdict
+from pathlib import Path
+
+
+def _scan_junit(xml_path: Path) -> dict[str, str]:
+    """Return ``{test_id: status}`` for every testcase in ``xml_path``.
+
+    ``status`` is one of: ``"pass"``, ``"fail"``, ``"error"``,
+    ``"skip"``. ``test_id`` is ``"classname::name"`` so it matches the
+    pytest -v output format that operators see in workflow logs.
+    """
+    tree = ET.parse(xml_path)
+    out: dict[str, str] = {}
+    for case in tree.iter("testcase"):
+        cls = case.attrib.get("classname", "")
+        name = case.attrib.get("name", "")
+        test_id = f"{cls}::{name}" if cls else name
+        if case.find("failure") is not None:
+            out[test_id] = "fail"
+        elif case.find("error") is not None:
+            out[test_id] = "error"
+        elif case.find("skipped") is not None:
+            out[test_id] = "skip"
+        else:
+            out[test_id] = "pass"
+    return out
+
+
+def _aggregate(xml_paths: list[Path]) -> dict[str, list[str]]:
+    """Merge per-run statuses into ``{test_id: [status_run_1, ...]}``.
+
+    Tests that appear in only some runs (collection-only changes) get
+    a ``"missing"`` entry for the runs they're absent from so the
+    flake-rate denominator stays consistent.
+    """
+    per_run: list[dict[str, str]] = [_scan_junit(p) for p in xml_paths]
+    all_ids: set[str] = set()
+    for r in per_run:
+        all_ids.update(r.keys())
+    merged: dict[str, list[str]] = defaultdict(list)
+    for r in per_run:
+        for tid in all_ids:
+            merged[tid].append(r.get(tid, "missing"))
+    return dict(merged)
+
+
+def _flake_rate(statuses: list[str]) -> tuple[int, int, float]:
+    """Return ``(fails, runs_excluding_skips_and_missing, flake_rate)``.
+
+    A test that's ``"skip"`` or ``"missing"`` in some runs has those
+    runs excluded from the denominator (it's not flake — the test
+    just didn't run).
+    """
+    runs = [s for s in statuses if s not in ("skip", "missing")]
+    fails = sum(1 for s in runs if s in ("fail", "error"))
+    total = len(runs)
+    rate = (fails / total) if total else 0.0
+    return fails, total, rate
+
+
+def _format_report(merged: dict[str, list[str]], n_runs: int) -> str:
+    """Build a markdown report sorted by fail count descending."""
+    rows: list[tuple[str, int, int, float, list[str]]] = []
+    for tid, statuses in merged.items():
+        fails, total, rate = _flake_rate(statuses)
+        if 0 < fails < total:
+            rows.append((tid, fails, total, rate, statuses))
+    rows.sort(key=lambda r: (-r[1], r[0]))
+
+    lines = [f"# Flake report ({n_runs} runs)\n"]
+    if not rows:
+        lines.append("✅ No flakes detected — every test that ran "
+                     "passed in every run.")
+        return "\n".join(lines)
+
+    lines.append(
+        f"⚠️  {len(rows)} flaky test(s) detected. Flake rate is "
+        "fails / (runs − skips − missing); 1.0 means always-fail "
+        "(broken, not flaky).\n"
+    )
+    lines.append("| Test | Fails | Runs | Rate | Per-run |")
+    lines.append("|---|---:|---:|---:|---|")
+    for tid, fails, total, rate, statuses in rows:
+        per_run = " ".join("✅" if s == "pass" else "❌" if s in
+                           ("fail", "error") else "⚪" for s in statuses)
+        lines.append(
+            f"| `{tid}` | {fails} | {total} | {rate:.0%} | {per_run} |"
+        )
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = argv if argv is not None else sys.argv[1:]
+    if not args:
+        print(
+            "usage: aggregate_flake_runs.py <junit-xml> [...]",
+            file=sys.stderr,
+        )
+        return 2
+
+    xml_paths = [Path(a) for a in args]
+    missing = [p for p in xml_paths if not p.exists()]
+    if missing:
+        print(
+            f"::warning::skipping {len(missing)} missing XML(s): "
+            + ", ".join(str(p) for p in missing),
+            file=sys.stderr,
+        )
+        xml_paths = [p for p in xml_paths if p.exists()]
+
+    if not xml_paths:
+        print("::error::no junit XMLs to aggregate", file=sys.stderr)
+        return 2
+
+    merged = _aggregate(xml_paths)
+    report = _format_report(merged, n_runs=len(xml_paths))
+    print(report)
+
+    out_path = Path("flake-report.md")
+    out_path.write_text(report)
+    print(f"\nReport written to {out_path.resolve()}", file=sys.stderr)
+
+    # Exit 0 always — flake reporting is advisory, not a failure
+    # signal. The workflow file decides whether to escalate.
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_aggregate_flake_runs.py
+++ b/tests/test_aggregate_flake_runs.py
@@ -1,0 +1,193 @@
+"""Tests for ``scripts/aggregate_flake_runs.py`` — flake-rate aggregator."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scripts.aggregate_flake_runs import (
+    _aggregate,
+    _flake_rate,
+    _format_report,
+    _scan_junit,
+    main,
+)
+
+
+def _write_junit(
+    path: Path,
+    cases: list[tuple[str, str, str]],  # (classname, name, status)
+) -> Path:
+    blocks: list[str] = []
+    for cls, name, status in cases:
+        body = ""
+        if status == "fail":
+            body = '\n      <failure message="x"/>'
+        elif status == "error":
+            body = '\n      <error message="x"/>'
+        elif status == "skip":
+            body = '\n      <skipped message="x"/>'
+        blocks.append(
+            f'    <testcase classname="{cls}" name="{name}">'
+            f'{body}\n    </testcase>'
+        )
+    path.write_text(
+        '<?xml version="1.0"?>\n'
+        '<testsuites><testsuite name="pytest" tests="'
+        f'{len(cases)}">\n'
+        + "\n".join(blocks)
+        + "\n</testsuite></testsuites>\n"
+    )
+    return path
+
+
+# ── _scan_junit ─────────────────────────────────────────────────────────────
+
+
+def test_scan_junit_classifies_pass_fail_error_skip(tmp_path: Path) -> None:
+    junit = _write_junit(
+        tmp_path / "j.xml",
+        [
+            ("c", "ok", "pass"),
+            ("c", "broken", "fail"),
+            ("c", "exploded", "error"),
+            ("c", "skipped_test", "skip"),
+        ],
+    )
+    statuses = _scan_junit(junit)
+    assert statuses["c::ok"] == "pass"
+    assert statuses["c::broken"] == "fail"
+    assert statuses["c::exploded"] == "error"
+    assert statuses["c::skipped_test"] == "skip"
+
+
+def test_scan_junit_uses_name_when_classname_empty(tmp_path: Path) -> None:
+    junit = _write_junit(
+        tmp_path / "j.xml",
+        [("", "module-level", "pass")],
+    )
+    statuses = _scan_junit(junit)
+    assert "module-level" in statuses
+
+
+# ── _aggregate ──────────────────────────────────────────────────────────────
+
+
+def test_aggregate_carries_status_per_run(tmp_path: Path) -> None:
+    """Same test, different statuses across runs → list reflects each."""
+    a = _write_junit(tmp_path / "a.xml", [("c", "t", "pass")])
+    b = _write_junit(tmp_path / "b.xml", [("c", "t", "fail")])
+    c = _write_junit(tmp_path / "c.xml", [("c", "t", "pass")])
+    merged = _aggregate([a, b, c])
+    assert merged["c::t"] == ["pass", "fail", "pass"]
+
+
+def test_aggregate_marks_missing_test_as_missing(tmp_path: Path) -> None:
+    """A test that only ran in some XMLs gets ``missing`` in the others."""
+    a = _write_junit(tmp_path / "a.xml", [("c", "t", "pass")])
+    b = _write_junit(tmp_path / "b.xml", [])
+    merged = _aggregate([a, b])
+    assert merged["c::t"] == ["pass", "missing"]
+
+
+# ── _flake_rate ─────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "statuses, expected",
+    [
+        # always pass → rate 0
+        (["pass"] * 5,                            (0, 5, 0.0)),
+        # 1/5 fails → rate 0.2
+        (["pass", "pass", "fail", "pass", "pass"], (1, 5, 0.2)),
+        # 5/5 fails → rate 1.0 (broken, not flaky)
+        (["fail"] * 5,                            (5, 5, 1.0)),
+        # error counts as fail
+        (["pass", "error", "pass"],               (1, 3, 1 / 3)),
+        # skips and missing are excluded from denominator
+        (["pass", "skip", "fail", "missing"],     (1, 2, 0.5)),
+        # all-skip → 0/0 → 0.0 (no division by zero)
+        (["skip", "skip"],                        (0, 0, 0.0)),
+    ],
+)
+def test_flake_rate(
+    statuses: list[str], expected: tuple[int, int, float]
+) -> None:
+    fails, total, rate = _flake_rate(statuses)
+    assert (fails, total) == expected[:2]
+    assert rate == pytest.approx(expected[2], abs=1e-9)
+
+
+# ── _format_report ──────────────────────────────────────────────────────────
+
+
+def test_report_clean_when_no_flakes() -> None:
+    merged = {"c::ok": ["pass", "pass", "pass"]}
+    report = _format_report(merged, n_runs=3)
+    assert "No flakes detected" in report
+    assert "✅" in report
+
+
+def test_report_includes_only_partially_failing(tmp_path: Path) -> None:
+    """Always-pass + always-fail tests are excluded — only the ones
+    with mixed pass/fail show in the table."""
+    merged = {
+        "c::stable_pass":   ["pass", "pass", "pass"],
+        "c::stable_broken": ["fail", "fail", "fail"],
+        "c::flaky":         ["pass", "fail", "pass"],
+    }
+    report = _format_report(merged, n_runs=3)
+    assert "c::flaky" in report
+    assert "c::stable_pass" not in report
+    assert "c::stable_broken" not in report
+
+
+def test_report_sorts_by_fail_count_descending() -> None:
+    merged = {
+        "c::low_flake":  ["pass"] * 4 + ["fail"],
+        "c::high_flake": ["fail"] * 3 + ["pass"] * 2,
+    }
+    report = _format_report(merged, n_runs=5)
+    assert report.index("high_flake") < report.index("low_flake")
+
+
+# ── main ────────────────────────────────────────────────────────────────────
+
+
+def test_main_writes_report_md(tmp_path: Path, monkeypatch, capsys) -> None:
+    a = _write_junit(tmp_path / "a.xml", [("c", "t", "pass")])
+    b = _write_junit(tmp_path / "b.xml", [("c", "t", "fail")])
+    monkeypatch.chdir(tmp_path)
+    rc = main([str(a), str(b)])
+    assert rc == 0
+    out = (tmp_path / "flake-report.md").read_text()
+    assert "c::t" in out
+    assert "Flake report" in capsys.readouterr().out
+
+
+def test_main_returns_2_on_no_args(capsys) -> None:
+    rc = main([])
+    assert rc == 2
+    assert "usage:" in capsys.readouterr().err
+
+
+def test_main_warns_on_missing_xml_but_proceeds(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:
+    """Missing XMLs are warnings, not failures — a partial weekly run
+    (one rerun crashed) should still produce a report from the
+    survivors."""
+    a = _write_junit(tmp_path / "a.xml", [("c", "t", "pass")])
+    monkeypatch.chdir(tmp_path)
+    rc = main([str(a), str(tmp_path / "missing.xml")])
+    assert rc == 0
+    err = capsys.readouterr().err
+    assert "skipping 1 missing" in err
+
+
+def test_main_returns_2_when_all_xmls_missing(
+    tmp_path: Path, capsys
+) -> None:
+    rc = main([str(tmp_path / "nope.xml")])
+    assert rc == 2
+    assert "no junit XMLs" in capsys.readouterr().err


### PR DESCRIPTION
Closes #228.

**T1.2** — the **final Tier-1** audit gap. The platform is at ~1968 tests across unit + e2e. At a 0.1 % flake rate that's ~2 spurious failures per 100 PR-CI cycles. CI today runs the suite once per PR; a 1/100 flaky test is invisible and the mitigation is "re-run the workflow".

## What lands

| File | Purpose |
|---|---|
| `scripts/aggregate_flake_runs.py` (new) | junit-XML aggregator: reads N junit files, classifies each test per-run, computes flake rate, writes a markdown report sorted by fail count descending |
| `tests/test_aggregate_flake_runs.py` (new) | **17 unit tests** covering classification, aggregation, edge cases (always-pass, always-fail, all-skip, division-by-zero), report formatting, main() argv handling |
| `.github/workflows/flake_detection.yml` (new) | schedule cron `30 6 * * 1` (Mondays 06:30 UTC, 30 min after mutmut) + `workflow_dispatch` with optional `n_runs` input. Bash loop runs pytest 5× in independent invocations, then aggregates |
| `.gitignore` | excludes `flake-report.md` + `run-*.xml` |
| `docs/ci_pipeline.md` | new "Off-cycle: weekly flake detection" section |

## Why N **independent** runs (not pytest-rerunfailures / pytest-repeat)

Both plugins re-run failing tests within a single pytest process — that obscures whether a failure is reproducible across fresh interpreter invocations. Independent runs surface flake from RNG drift, BLAS thread races, file-system ordering. The bash loop gives us that for free.

## Test plan

- [x] `ruff check .` clean
- [x] `mypy` clean
- [x] `pytest tests/test_aggregate_flake_runs.py` — 17 passed
- [x] `pytest tests/ -m "not integration and not e2e"` — 1879 passed, 80.12 % coverage
- [x] Excellent-test PR gate (#215) self-checks: `scripts/` + `tests/` + `.github/workflows/` + `docs/` only — no source diffs in scoped modules, gate exits 0
- [ ] CI green
- [ ] Manual `workflow_dispatch` of `Flake Detection` after merge — verify the report is produced and uploaded as an artefact

## Audit gap closure

This is the **final Tier-1 ticket** from the testing best-practice audit. After merge, all 5 Tier-1 gaps are closed:

| Ticket | Status |
|---|---|
| T1.1 (#227) determinism trio | merged via PR #233 |
| **T1.2 (#228) flake detection** | **this PR** |
| T1.3 (#229) mypy CI gate | merged via PR #235 |
| T1.4 (#230) bug-regression policy | merged via PR #232 |
| T1.5 (#231) negative-test discipline | merged via PR #234 |

Tier-2 items (T2.3 pytest-randomly, T2.4 codecov trend, T2.5 SARIF upload, T2.7 fixture library) remain available as a future quality-of-life bundle.

https://claude.ai/code/session_01WmG6mAtgV1nr1c9NPxBAD8

---
_Generated by [Claude Code](https://claude.ai/code/session_01WmG6mAtgV1nr1c9NPxBAD8)_