### PR TITLE
test-infra: central synthetic-data factory library (#239)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -351,6 +351,25 @@ input, etc.). The Phase-1 e2e injection fixtures
 equivalent — pull them in with the same fixture-based pattern
 where possible.
 
+### Synthetic-data factories (#239)
+
+[`tests/factories.py`](tests/factories.py) is the **single source
+of truth** for synthetic OHLCV / returns / prices / feature
+matrices. New tests pull the helper that fits:
+
+```python
+from tests.factories import make_ohlcv, make_returns, make_prices
+
+df = make_ohlcv(n=60, seed=7)         # canonical capitalised-column OHLCV
+r  = make_returns(n=252, sigma=0.02)  # daily-return series
+p  = make_prices(n=200, last=110.0)   # constant-price for SMA tests
+```
+
+Each factory is fully deterministic given its `seed` argument so
+tests don't depend on the determinism trio (#227) for stability.
+Legacy in-file helpers in older `tests/test_*.py` will migrate
+over time; new tests should reach for `tests.factories` first.
+
 ### Running a Specific Test
 
 ```bash

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -1,0 +1,164 @@
+"""
+tests/factories.py — synthetic-data factories shared across the
+test suite (closes #239 / T2.7).
+
+The audit (#227 et al.) found the same 4-5 factory functions
+re-rolled across every other test file with subtle drift between
+them: one uses ``np.random.seed(42)``, another uses
+``np.random.default_rng(0)``; one uses ``freq="B"``, another
+``freq="D"``; column-name capitalisation varies.
+
+This module is the **single source of truth** for new tests. Pull
+the helper that fits, customise via keyword arguments. Each
+function is fully deterministic given its ``seed`` argument so
+tests don't depend on the determinism trio (#227) for stability.
+
+Usage:
+
+    from tests.factories import make_ohlcv, make_returns
+
+    df = make_ohlcv(n=60, seed=7)
+    r = make_returns(n=252, sigma=0.02)
+
+Legacy in-file helpers in ``tests/test_*.py`` will migrate over
+time. New tests should reach for this module first.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+
+def make_ohlcv(
+    n: int = 100,
+    *,
+    seed: int = 42,
+    base: float = 100.0,
+    drift: float = 0.0,
+    vol: float = 0.5,
+    freq: str = "B",
+    start: str = "2024-01-01",
+) -> pd.DataFrame:
+    """Random-walk OHLCV with capitalised column names.
+
+    The canonical shape: ``Open / High / Low / Close / Volume`` —
+    matches the dataframe ``data/fetcher.py:fetch_ohlcv`` returns and
+    every backtester / strategy / e2e test expects.
+
+    Defaults are tuned to be cheap (n=100, weekday-only frequency)
+    and reproducible. Override ``seed`` / ``base`` / ``drift`` /
+    ``vol`` for sensitivity tests; override ``freq`` to ``"D"`` for
+    calendar-day series; override ``start`` to control the index.
+
+    Parameters
+    ----------
+    n
+        Number of bars. Most caller use 60-300; <30 will trip the
+        risk modules' "too short" guards (which is sometimes the
+        point — pass deliberately).
+    seed
+        Pinned for reproducibility. Defaults to 42 (matches the
+        legacy ``test_features.py`` helper).
+    base
+        Starting price level. Default 100.0.
+    drift
+        Daily drift added to each step (in price units, not %).
+        Default 0.0.
+    vol
+        Per-step Gaussian std. Default 0.5 — produces realistic
+        single-name daily moves for ``base=100``.
+    freq
+        Pandas frequency string for the index. Default ``"B"``
+        (business days). Use ``"D"`` for daily-incl-weekends.
+    start
+        ISO date for the first bar.
+    """
+    rng = np.random.default_rng(seed)
+    close = base + np.cumsum(rng.normal(drift, vol, n))
+    idx = pd.date_range(start, periods=n, freq=freq)
+    return pd.DataFrame(
+        {
+            "Open":   close * 0.99,
+            "High":   close * 1.01,
+            "Low":    close * 0.98,
+            "Close":  close,
+            "Volume": rng.integers(1_000_000, 5_000_000, n).astype(float),
+        },
+        index=idx,
+    )
+
+
+def make_prices(
+    n: int = 250,
+    *,
+    base: float = 100.0,
+    last: float | None = None,
+) -> pd.Series:
+    """Constant-price series with an optional endpoint shift.
+
+    Used by regime tests (``analysis/regime.py``) and SMA-200 tests
+    where the test wants a fully-deterministic 200-day mean and a
+    controlled position relative to it. ``last`` overrides the final
+    value so a single-line test can flip "above 200d SMA" vs
+    "below 200d SMA".
+
+    Returns ``pd.Series`` (no DatetimeIndex — regime tests don't
+    care about dates, only relative magnitudes).
+    """
+    prices = np.full(n, float(base))
+    if last is not None:
+        prices[-1] = float(last)
+    return pd.Series(prices)
+
+
+def make_returns(
+    n: int = 252,
+    *,
+    mu: float = -0.0002,
+    sigma: float = 0.015,
+    seed: int = 42,
+) -> pd.Series:
+    """Normally-distributed daily returns.
+
+    Defaults match the typical equity-index distribution used by
+    risk/var.py and analysis/garch.py tests: slight negative drift
+    (consistent with intraday mean-reversion bias) and ~24 % annual
+    volatility. Override ``sigma`` to test high/low-vol regimes.
+    """
+    rng = np.random.default_rng(seed)
+    return pd.Series(rng.normal(mu, sigma, n))
+
+
+def make_feature_matrix(
+    n_dates: int = 60,
+    n_tickers: int = 10,
+    *,
+    seed: int = 0,
+    freq: str = "B",
+    fwd_signal_strength: float = 0.5,
+) -> pd.DataFrame:
+    """MultiIndex (date, ticker) feature matrix used by ML signal tests.
+
+    Builds a frame indexed by (date, ticker) with the project's
+    standard ``_FEATURE_COLS`` plus a synthetic ``fwd_ret_5d``
+    target whose linear dependence on the first feature is
+    controlled by ``fwd_signal_strength``. Returns to a flat
+    DataFrame (callers re-set the index where needed).
+    """
+    from data.features import _FEATURE_COLS
+
+    rng = np.random.default_rng(seed)
+    dates = pd.date_range("2024-01-01", periods=n_dates, freq=freq)
+    tickers = [f"T{i:02d}" for i in range(n_tickers)]
+    rows = []
+    for d in dates:
+        for t in tickers:
+            row: dict = {"date": d, "ticker": t}
+            for col in _FEATURE_COLS:
+                row[col] = rng.normal(0.0, 1.0)
+            row["fwd_ret_5d"] = (
+                fwd_signal_strength * row[_FEATURE_COLS[0]]
+                + rng.normal(0.0, 0.5)
+            )
+            rows.append(row)
+    return pd.DataFrame(rows)

--- a/tests/test_factories.py
+++ b/tests/test_factories.py
@@ -1,0 +1,149 @@
+"""Tests for ``tests/factories.py`` — synthetic-data factory library.
+
+Locks the canonical factory contract so future drift between
+in-file and library helpers is caught at PR time, not when a test
+silently changes seed and goes flaky.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from tests.factories import (
+    make_feature_matrix,
+    make_ohlcv,
+    make_prices,
+    make_returns,
+)
+
+# ── make_ohlcv ──────────────────────────────────────────────────────────────
+
+
+class TestMakeOHLCV:
+    def test_default_shape_and_columns(self) -> None:
+        df = make_ohlcv()
+        assert len(df) == 100
+        assert list(df.columns) == ["Open", "High", "Low", "Close", "Volume"]
+        assert isinstance(df.index, pd.DatetimeIndex)
+
+    def test_seed_is_deterministic(self) -> None:
+        a = make_ohlcv(n=50, seed=7)
+        b = make_ohlcv(n=50, seed=7)
+        pd.testing.assert_frame_equal(a, b)
+
+    def test_different_seeds_produce_different_data(self) -> None:
+        a = make_ohlcv(n=50, seed=7)
+        b = make_ohlcv(n=50, seed=8)
+        with pytest.raises(AssertionError):
+            pd.testing.assert_frame_equal(a, b)
+
+    def test_ohlc_invariant(self) -> None:
+        """High ≥ Close ≥ Low for every bar."""
+        df = make_ohlcv(n=100)
+        assert (df["High"] >= df["Close"]).all()
+        assert (df["Close"] >= df["Low"]).all()
+
+    def test_volume_in_realistic_range(self) -> None:
+        df = make_ohlcv(n=100)
+        assert (df["Volume"] >= 1_000_000).all()
+        assert (df["Volume"] < 5_000_000).all()
+
+    def test_freq_business_days_skips_weekends(self) -> None:
+        df = make_ohlcv(n=10, freq="B", start="2024-01-08")
+        # Monday Jan 8 + 9 business days = Friday Jan 19; no weekends in there
+        assert all(d.weekday() < 5 for d in df.index)
+
+    def test_drift_increases_endpoint_on_average(self) -> None:
+        """Positive drift → end price systematically higher than base
+        across many seeds."""
+        n = 200
+        endpoints = [
+            make_ohlcv(n=n, seed=s, drift=0.5)["Close"].iloc[-1]
+            for s in range(20)
+        ]
+        # Average endpoint should be > base + n * drift / 4 (rough lower bound)
+        assert np.mean(endpoints) > 100.0 + n * 0.5 / 4
+
+
+# ── make_prices ─────────────────────────────────────────────────────────────
+
+
+class TestMakePrices:
+    def test_constant_when_last_unset(self) -> None:
+        s = make_prices(n=10, base=100.0)
+        assert (s == 100.0).all()
+
+    def test_last_overrides_endpoint(self) -> None:
+        s = make_prices(n=10, base=100.0, last=110.0)
+        assert (s.iloc[:-1] == 100.0).all()
+        assert s.iloc[-1] == 110.0
+
+    def test_sma_recoverable_from_constant_prices(self) -> None:
+        """A constant-then-shift series has a known mean — important
+        for the regime tests' SMA-200 calculations."""
+        s = make_prices(n=200, base=100.0, last=110.0)
+        expected_mean = (199 * 100.0 + 110.0) / 200
+        assert s.mean() == pytest.approx(expected_mean)
+
+
+# ── make_returns ────────────────────────────────────────────────────────────
+
+
+class TestMakeReturns:
+    def test_default_shape(self) -> None:
+        r = make_returns()
+        assert len(r) == 252
+        assert isinstance(r, pd.Series)
+
+    def test_seed_is_deterministic(self) -> None:
+        a = make_returns(n=50, seed=7)
+        b = make_returns(n=50, seed=7)
+        pd.testing.assert_series_equal(a, b)
+
+    def test_sigma_controls_dispersion(self) -> None:
+        """Higher sigma → higher empirical std (within ~10 % at n=10000)."""
+        low = make_returns(n=10_000, sigma=0.005, seed=0)
+        high = make_returns(n=10_000, sigma=0.020, seed=0)
+        assert high.std() > low.std() * 3  # ~4x in expectation
+
+    def test_mu_controls_mean(self) -> None:
+        """Negative mu → negative empirical mean at large n."""
+        r = make_returns(n=10_000, mu=-0.001, sigma=0.005, seed=0)
+        assert r.mean() < 0
+
+
+# ── make_feature_matrix ─────────────────────────────────────────────────────
+
+
+class TestMakeFeatureMatrix:
+    def test_shape_and_columns(self) -> None:
+        from data.features import _FEATURE_COLS
+
+        df = make_feature_matrix(n_dates=20, n_tickers=4, seed=0)
+        assert len(df) == 80  # 20 * 4
+        assert "date" in df.columns
+        assert "ticker" in df.columns
+        assert "fwd_ret_5d" in df.columns
+        assert all(c in df.columns for c in _FEATURE_COLS)
+
+    def test_seed_is_deterministic(self) -> None:
+        a = make_feature_matrix(n_dates=10, n_tickers=3, seed=7)
+        b = make_feature_matrix(n_dates=10, n_tickers=3, seed=7)
+        pd.testing.assert_frame_equal(a, b)
+
+    def test_signal_strength_drives_correlation(self) -> None:
+        """Higher fwd_signal_strength → higher correlation between
+        feature[0] and fwd_ret_5d."""
+        from data.features import _FEATURE_COLS
+
+        col = _FEATURE_COLS[0]
+        weak = make_feature_matrix(
+            n_dates=80, n_tickers=10, seed=0, fwd_signal_strength=0.05
+        )
+        strong = make_feature_matrix(
+            n_dates=80, n_tickers=10, seed=0, fwd_signal_strength=2.0
+        )
+        weak_corr = weak[col].corr(weak["fwd_ret_5d"])
+        strong_corr = strong[col].corr(strong["fwd_ret_5d"])
+        assert strong_corr > weak_corr


### PR DESCRIPTION
Closes #239 (T2.7 central fixture / factory library).

The audit flagged that the same 4-5 factory functions are re-rolled across every other test file with subtle drift between them — different seeds, different `freq`, different column capitalisation. New tests pick up whichever copy they land near, and the drift compounds.

## What lands

| File | Purpose |
|---|---|
| `tests/factories.py` (new) | 4 canonical factories: `make_ohlcv`, `make_prices`, `make_returns`, `make_feature_matrix` |
| `tests/test_factories.py` (new) | **17 unit tests** locking the contract (shape, determinism, OHLC invariant, dispersion, signal-strength correlation) |
| `CLAUDE.md` § Synthetic-data factories | Short convention pointing new tests at the library |

Each factory is fully deterministic given its `seed` argument so tests don't rely on the determinism trio (#227) for stability — useful when a flake-detection rerun (#228) uses a different test order.

## Migration policy

Existing in-file helpers in older `tests/test_*.py` are left in place to avoid behaviour changes from seed-value drift. They'll migrate over time as those files are touched. New tests should reach for `tests.factories` first per the new `CLAUDE.md` section.

## Test plan

- [x] `ruff check .` clean
- [x] `mypy` clean
- [x] `pytest tests/test_factories.py` — 17 passed
- [x] `pytest tests/ -m "not integration and not e2e" --randomly-seed=20260428` — **1896 passed** (1879 + 17 new), **80.20 %** coverage
- [x] Excellent-test PR gate (#215) self-checks: `tests/` + `CLAUDE.md` only — no `.py` source diffs, gate exits 0
- [ ] CI green

https://claude.ai/code/session_01WmG6mAtgV1nr1c9NPxBAD8

---
_Generated by [Claude Code](https://claude.ai/code/session_01WmG6mAtgV1nr1c9NPxBAD8)_