### PR TITLE
ci: enable pytest-xdist (-n auto) for the unit-test job (#240)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,10 +130,18 @@ jobs:
       # pin a seed in CI for determinism so the gate never flakes from
       # a randomly-bad ordering. Local dev runs use fresh seeds (omit
       # ``--randomly-seed``) to surface new order-dependent tests.
+      #
+      # ``-n auto`` enables pytest-xdist (#240 / Tier-3) so the unit
+      # suite runs in parallel across the runner's cores. The cleanup-
+      # invariant fixture (#221) is per-worker safe — ``tmp_path`` and
+      # ``monkeypatch`` are isolated per worker by pytest. The e2e job
+      # below stays serial because its perf gate (#221) and per-module
+      # coverage floor measure single-worker behaviour.
       - name: Run unit tests
         continue-on-error: false
         run: |
           pytest tests/ -v -m "not integration and not e2e" \
+            -n auto \
             --randomly-seed=20260428 \
             --cov=. \
             --cov-report=xml:coverage.xml \

--- a/docs/ci_pipeline.md
+++ b/docs/ci_pipeline.md
@@ -195,5 +195,5 @@ only — no dev deps required.
 |---|---|---|
 | `pytest.ini` `addopts` | `--strict-markers --strict-config --tb=short` | Typos in marker names fail loud; short tracebacks keep PR comments readable. |
 | `pytest.ini` `timeout` | `60 s` per test (`thread` method) | Catches a hung test before it eats the 15-min job budget. Provided by `pytest-timeout`. |
-| `requirements.txt` | `pytest-timeout`, `pytest-xdist`, `pytest-randomly` (#237) | Auto-loaded by pytest. CI pins `--randomly-seed=20260428` for determinism so the gate never flakes on a randomly-bad ordering; local runs without the flag use a fresh seed each time to surface new order-dependent tests. |
+| `requirements.txt` | `pytest-timeout`, `pytest-xdist`, `pytest-randomly` (#237) | Auto-loaded by pytest. CI pins `--randomly-seed=20260428` for determinism so the gate never flakes on a randomly-bad ordering; local runs without the flag use a fresh seed each time to surface new order-dependent tests. CI's unit job runs with `-n auto` (xdist, #240); the e2e job stays serial so its perf gate (#221) and per-module coverage floor measure single-worker behaviour. |
 | `tests/conftest.py` env | `OMP_NUM_THREADS=1` etc. | Prevents OpenBLAS background threads from triggering `std::terminate()` during interpreter shutdown on CI. |

--- a/tests/test_realtime.py
+++ b/tests/test_realtime.py
@@ -287,7 +287,11 @@ class TestPollingExceptions:
 
         with patch('yfinance.Ticker', side_effect=bad_ticker):
             feed.subscribe(['AAPL'])
-            deadline = time.time() + 2.0
+            # 5 s deadline — under xdist + coverage instrumentation the
+            # original 2 s was tight enough that CPU contention could
+            # starve the polling thread. 5 s stays well under the
+            # 60 s pytest-timeout per-test cap.
+            deadline = time.time() + 5.0
             while time.time() < deadline:
                 if feed.get_all_quotes():
                     break


### PR DESCRIPTION
Closes #240 (Tier-3 pytest-xdist parallelisation).

`pytest-xdist` is already in `requirements.txt` (added by #185 as future-use scaffold); this PR enables `-n auto` in the unit-test step. The cleanup-invariant fixture (#221) and per-test `tmp_path` / `monkeypatch` isolation are already xdist-safe, and `pytest-randomly` (#241) flushed any order-dependent tests last week.

## What lands

| Change | File | Why |
|---|---|---|
| `pytest ... -n auto` on unit job | `.github/workflows/ci.yml` | parallelise across the 4-core runner |
| 5 s deadline (was 2 s) on `test_polling_exception_does_not_stop_loop` | `tests/test_realtime.py` | regression fix — surfaced under xdist+coverage CPU contention |

The e2e job stays serial because its perf gate (#221) and per-module coverage floor measure single-worker behaviour.

## Test plan

- [x] `ruff check .` clean
- [x] `mypy` clean
- [x] `pytest tests/ -m "not integration and not e2e" -n auto --randomly-seed=20260428 --cov=.` — **1896 passed**, **80.12 %** coverage. Local box (~2 effective cores) drops 95 s → 55 s; CI on 4 cores will see a larger speedup.
- [x] Excellent-test PR gate (#215) self-checks: `tests/` + `.github/workflows/` + `docs/` only — no `.py` source diffs in scoped modules, gate exits 0
- [ ] CI green; unit-job wall time noticeably lower than the previous baseline

## Audit gap closure — final PR in this bundle

| Track | PRs | Status |
|---|---|---|
| Tier-1 (5) | #232, #233, #234, #235, #236 | ✅ all merged |
| Tier-2 + Tier-3 (3) | #241, #242, **this PR** | ✅ shipping |

After this lands the test-quality work is at "excellent" across: correctness (unit + e2e), mutation testing of math + chain modules, flake detection, determinism (frozen clock + pinned seeds + hypothesis profile), random ordering, type checking, parallel execution, central factory library, bug-regression policy + PR template, and SARIF to GitHub code scanning.

Remaining Tier-2 leftovers (T2.4 Codecov, T2.8 schema fixtures, B2/B3/B4/B5 deferred items) need user action or external services and stay on the backlog.

https://claude.ai/code/session_01WmG6mAtgV1nr1c9NPxBAD8

---
_Generated by [Claude Code](https://claude.ai/code/session_01WmG6mAtgV1nr1c9NPxBAD8)_