### PR TITLE
chore(deps): minor/patch bumps from 2026-04-29 audit (#247)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,12 +7,12 @@ cachetools==7.0.6
 certifi==2026.4.22
 cffi==2.0.0
 charset-normalizer==3.4.7
-duckdb==1.4.2
+duckdb==1.5.2
 click==8.3.3
 curl_cffi==0.15.0
 frozendict==2.4.7
 gitdb==4.0.12
-GitPython==3.1.47
+GitPython==3.1.49
 idna==3.13
 iniconfig==2.3.0
 Jinja2==3.1.6
@@ -39,7 +39,7 @@ pydeck==0.9.2
 Pygments==2.20.0
 pytest==9.0.3
 pytest-timeout==2.4.0
-pytest-xdist==3.6.1
+pytest-xdist==3.8.0
 pytest-randomly==3.15.0
 hypothesis>=6.100.0
 freezegun>=1.5.0
@@ -53,7 +53,7 @@ rpds-py==0.30.0
 six==1.17.0
 smmap==5.0.3
 soupsieve==2.8.3
-streamlit==1.56.0
+streamlit==1.57.0
 streamlit-autorefresh==1.0.1
 ta==0.11.0
 tenacity==9.1.4


### PR DESCRIPTION
## Summary

Auto-applied minor/patch updates from the 2026-04-29 dependency audit (#247).

| Package | Before | After | Type |
|---|---|---|---|
| duckdb | 1.4.2 | 1.5.2 | minor |
| GitPython | 3.1.47 | 3.1.49 | patch |
| pytest-xdist | 3.6.1 | 3.8.0 | minor |
| streamlit | 1.56.0 | 1.57.0 | minor |

`pytest-randomly` 3.15 → 4.1 is a **major** bump and was deliberately deferred per the repo policy (awaiting owner approval; plan posted in chat).

## Test plan

- [x] `pip-audit -r requirements.txt` → no known vulnerabilities
- [x] `ruff check .` → clean
- [x] `pytest tests/ -m "not integration"` → 1966 passed, 48 skipped
- [x] Coverage 80.85% (gate: ≥76%)
- [x] `bandit -r . -ll --exclude ./.git,./tests` → 0 HIGH severity findings
- [ ] CI green on the PR before merge

Refs #247.

https://claude.ai/code/session_01UHEUNVEviNS7DZRsd8mu3N

---
_Generated by [Claude Code](https://claude.ai/code/session_01UHEUNVEviNS7DZRsd8mu3N)_