### PR TITLE
test-infra: pre-commit secret scanning via gitleaks (#249)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,22 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v4
+        # gitleaks scans the diff against the base ref (#249); it
+        # needs full history to compare HEAD vs origin/main on a PR.
+        with: { fetch-depth: 0 }
+
+      # Gitleaks (#249) — server-side safety net for the local
+      # pre-commit hook. Catches leaked tokens in the diff even when
+      # a contributor hasn't installed pre-commit locally. Config in
+      # .gitleaks.toml; bypass-with-justification supported via
+      # ``# gitleaks:allow`` inline comment.
+      - name: Gitleaks (secret scan)
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Action default is to scan only the PR diff, which matches
+          # the local pre-commit hook's behaviour and keeps the run fast.
+
       - uses: actions/setup-python@v5
         with: { python-version: "3.11" }
       # ``bandit-sarif-formatter`` registers the ``-f sarif`` formatter

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,34 @@
+# gitleaks config (#249) — extends the default rule set with a
+# minimal allowlist for known false positives.
+#
+# Default ruleset: https://github.com/gitleaks/gitleaks/blob/master/config/gitleaks.toml
+# That covers AWS / GitHub / Slack / Stripe / OpenAI / Anthropic /
+# generic high-entropy strings. We don't override or disable any of
+# those — the only customisation here is the allowlist.
+
+# Inherit the bundled default rules.
+[extend]
+useDefault = true
+
+# Allowlist — patterns gitleaks shouldn't flag.
+[allowlist]
+description = "false positives that the default ruleset can't distinguish"
+
+# Files / paths that legitimately contain secret-shaped placeholders.
+paths = [
+  '''^\.env\.example$''',          # placeholder values like "your_paper_api_key_here"
+  '''^docs/.*\.md$''',             # docs sometimes show example tokens in code blocks
+  '''^tests/cassettes/.*''',       # future VCR.py cassettes (#245); auth headers are
+                                   # filtered before record by the test fixture, so
+                                   # cassette files committed here are pre-redacted
+]
+
+# Specific regex patterns that look like secrets but aren't.
+regexes = [
+  # ".env.example" placeholders consistently use the suffix "_here"
+  # (e.g. ALPACA_API_KEY=your_paper_api_key_here). Belt-and-braces
+  # in case the file allowlist above is bypassed.
+  '''_here$''',
+  # Schwab token PATH config, not a token value.
+  '''SCHWAB_TOKEN_PATH=\.schwab_token\.json''',
+]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,22 @@
+# Pre-commit hooks (#249) — secret scanning before commit lands.
+#
+# Install once per clone:
+#     pip install pre-commit
+#     pre-commit install
+#
+# After ``pre-commit install`` every ``git commit`` runs the hooks
+# below against the staged diff and aborts on any finding. Bypass
+# with ``git commit --no-verify`` only when you've manually verified
+# the flagged content is a false positive AND added it to the
+# allowlist (see ``.gitleaks.toml``).
+#
+# CI runs the same gitleaks check via ``gitleaks/gitleaks-action`` so
+# devs without the local hook still get caught.
+repos:
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.21.2   # pin so the rule set doesn't drift silently
+    hooks:
+      - id: gitleaks
+        name: gitleaks (secret scan)
+        # gitleaks reads .gitleaks.toml from the repo root for
+        # allowlists / custom rules.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,8 +80,17 @@ python3 -m venv .venv
 source .venv/bin/activate
 pip install -r requirements.txt
 cp .env.example .env        # fill in API keys
-bash run.sh                 # starts Streamlit on :8501
+pip install pre-commit       # secret-scan + lint hooks (#249)
+pre-commit install           # one-time per clone
+bash run.sh                  # starts Streamlit on :8501
 ```
+
+The `pre-commit install` step wires `gitleaks` into every `git commit`
+to catch leaked API keys / tokens before they enter the local history.
+CI runs the same check via `gitleaks/gitleaks-action` so devs without
+the local hook still get caught at PR time, but the pre-commit gate is
+the cheaper layer (it fires before the commit lands, not after the push
+is rejected). False positives go in `.gitleaks.toml`.
 
 ### Running Tests
 


### PR DESCRIPTION
Closes #249.

Pre-commit gate that catches leaked tokens **before the commit lands locally** — the missing layer between `.gitignore` (passive, file-level) and GitHub's server-side secret scanning (which catches *after* push, when the commit is already in your local history).

## What lands

| File | Purpose |
|---|---|
| `.pre-commit-config.yaml` (new) | Single hook from `gitleaks/gitleaks` v8.21.2 (pinned). Devs run `pre-commit install` once per clone. |
| `.gitleaks.toml` (new) | `[extend].useDefault = true` for the bundled ruleset + minimal allowlist for `.env.example` (`_here`-suffixed placeholders), `docs/*.md` (example tokens in code blocks), and `tests/cassettes/*` (future VCR.py cassettes for #245). |
| `.github/workflows/ci.yml:security` | New step using `gitleaks/gitleaks-action@v2` as the server-side safety net. `fetch-depth: 0` on checkout so gitleaks can diff HEAD vs base ref. |
| `CLAUDE.md` § Local Setup | Adds `pre-commit install` to the setup recipe with a paragraph explaining the dual-gate. |

## Why this layer matters

Without it, a leaked token's recovery path is: `.gitignore` (file-level only) → GitHub server-side scanning (post-push; commit already in local history). Recovery means rotating the token + `git reset --hard` (loses WIP) or `git filter-repo` (rewrite history, force-push).

Pre-commit catches the same content **before it ever forms a commit object**. The token never enters even your local SHA. Cheap insurance.

## Test plan

- [x] `.pre-commit-config.yaml` parses as valid YAML; gitleaks repo + `v8.21.2` rev are real
- [x] `.gitleaks.toml` parses as valid TOML; `[extend]` + `[allowlist]` match gitleaks' documented schema
- [x] `ruff check .` clean
- [x] `mypy` clean
- [x] `pytest tests/ -m "not integration and not e2e" -n auto --randomly-seed=20260428` — 1896 passed, 80.20 % coverage
- [x] Excellent-test PR gate (#215) self-checks: only config + docs + CI touched, no `.py` source diffs in scoped modules
- [ ] CI green; gitleaks-action runs without findings on this PR
- [ ] After merge: `pre-commit install && pre-commit run --all-files` exits 0 on `main`

## Manual smoke

A deliberately-staged AWS-shaped key like `AKIA1234567890ABCDEF` would fail `pre-commit run gitleaks` with a file:line pointer; the CI `Gitleaks (secret scan)` step reproduces the same on PR push.

## Out of scope

- History scrubbing (`git filter-repo`) for previously-leaked secrets — one-off remediation, not a recurring gate
- Custom regex rules beyond gitleaks defaults — file reactively if a vendor uses an unusual key format
- Token rotation policy — covered by #245 when it decides on the credentials it needs

https://claude.ai/code/session_01WmG6mAtgV1nr1c9NPxBAD8

---
_Generated by [Claude Code](https://claude.ai/code/session_01WmG6mAtgV1nr1c9NPxBAD8)_