### PR TITLE
chore(deps): bump cachetools 7.0.6 → 7.1.0 (audit 2026-05-02)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ APScheduler==3.11.2
 attrs==26.1.0
 beautifulsoup4==4.14.3
 blinker==1.9.0
-cachetools==7.0.6
+cachetools==7.1.0
 certifi==2026.4.22
 cffi==2.0.0
 charset-normalizer==3.4.7


### PR DESCRIPTION
## Summary

Auto-applied minor bump from the 2026-05-02 dependency audit (#252).

- `cachetools`: `7.0.6` → `7.1.0` (minor)

This is the only `==`-pinned PyPI package with a newer release since the 2026-04-29 cycle (#247). `pip-audit` is clean against both `requirements.txt` and `requirements-dev.txt`.

`pytest-randomly` 3.15.0 → 4.1.0 (major) remains blocked pending owner approval per #247 — not in this PR.

## Test plan

- [ ] `ruff check .` clean
- [ ] `pytest tests/ -m "not integration" --cov-fail-under=76` passes
- [ ] `bandit -r . -ll --exclude ./.git,./tests` HIGH-severity clean
- [ ] `pip-audit -r requirements.txt` clean

(Equivalent to `/pre-push`.)

Closes #252 (auto-apply portion).

_Generated by Claude Code._

---
_Generated by [Claude Code](https://claude.ai/code/session_01N587TgP9aEjWtCWwULGCmd)_