### PR TITLE
chore(deps): bump pytest-randomly 3.15.0 → 4.1.0 (#254)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -40,7 +40,7 @@ Pygments==2.20.0
 pytest==9.0.3
 pytest-timeout==2.4.0
 pytest-xdist==3.8.0
-pytest-randomly==3.15.0
+pytest-randomly==4.1.0
 hypothesis>=6.100.0
 freezegun>=1.5.0
 python-dateutil==2.9.0.post0


### PR DESCRIPTION
## Summary

Major version bump for `pytest-randomly` from 3.15.0 → 4.1.0, closing the last open dependency-audit item from issue #254.

| Package | Before | After | Type |
|---|---|---|---|
| `pytest-randomly` | `3.15.0` | `4.1.0` | **MAJOR** |

## Approval checklist (from #254)

- [x] **`--randomly-seed=NNN` still supported in v4** — confirmed, no flag rename or removal.
- [x] **Deterministic-seed contract from #237 still holds** — test ordering is still seeded by the session seed (`--randomly-seed=20260428`); each run with the same seed produces the same test order. Per-test seeding (each test derives a unique seed from `session_seed + test_id`) replaced single-session seeding internally, but this is strictly better isolation — not a regression.
- [x] **Python 3.9 support dropped in v4** — project targets Python 3.11, unaffected.
- [x] **`ruff check .`** — clean.
- [x] **`bandit -r . -ll --exclude ./.git,./tests`** — 0 HIGH severity findings.
- [x] **`pip-audit -r requirements.txt --ignore-vuln PYSEC-2022-42969`** — no known vulnerabilities.
- [ ] CI green (pytest 76% cov gate validates in CI).

## Regression test

No regression test needed — this is a test-infrastructure dependency bump with no source-code changes.

Closes #254.

https://claude.ai/code/session_01UG6o6cBKJexvLJco9KsBn3

---
_Generated by [Claude Code](https://claude.ai/code/session_01UG6o6cBKJexvLJco9KsBn3)_