### PR TITLE
chore(deps): cachetools 7.1.0→7.1.1, pytz 2026.1.post1→2026.2 (#256)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ APScheduler==3.11.2
 attrs==26.1.0
 beautifulsoup4==4.14.3
 blinker==1.9.0
-cachetools==7.1.0
+cachetools==7.1.1
 certifi==2026.4.22
 cffi==2.0.0
 charset-normalizer==3.4.7
@@ -45,7 +45,7 @@ hypothesis>=6.100.0
 freezegun>=1.5.0
 python-dateutil==2.9.0.post0
 python-dotenv==1.2.2
-pytz==2026.1.post1
+pytz==2026.2
 referencing==0.37.0
 requests==2.33.1
 rich==15.0.0


### PR DESCRIPTION
## Summary

Routine package version + security audit on 2026-05-04 surfaced two within-major bumps. Closes #256.

| Package | Before | After | Type |
|---|---|---|---|
| `cachetools` | `7.1.0` | `7.1.1` | patch (bug fixes) |
| `pytz` | `2026.1.post1` | `2026.2` | minor (CalVer point release; refreshed IANA tz data) |

No API surface changes in either upstream — both are drop-in.

## Why this is auto-applied

Per the dependency-audit policy in CLAUDE.md / repo workflow, **patch + minor bumps within the same major** ship automatically on a new branch with the full test gate. **Major bumps require a written plan and explicit owner approval** (none outstanding for this repo this audit cycle — see #256 for the floor-version landscape).

## Verification

- [x] `pip-audit -r requirements.txt --no-deps` → **0 known vulnerabilities**
- [x] `ruff check .` → **clean**
- [x] `bandit -r . -ll --exclude ./.git,./tests` → **0 HIGH** (38 LOW / 26 MEDIUM unchanged from baseline)
- [x] `pytest tests/ -m "not integration" --cov=. --cov-fail-under=76 --randomly-seed=20260428` → green at **79.93 %** coverage
- [x] One pre-existing order-dependent flake (`tests/test_e2e_risk_exporter_tick_to_alert.py::test_drawdown_breach_fires_alert_then_cooldown`) reproduces identically on the unmodified tree, so it is not introduced by this PR. Tracked separately under the test-pyramid audit (see #244 / #237 ordering discussion).

## Test plan

- [ ] CI lint job passes
- [ ] CI security job (bandit + pip-audit) passes
- [ ] CI unit-test job passes at ≥ 76 % coverage
- [ ] No regressions in `data/fetcher.py` cache behaviour (cachetools 7.1.x is the cache decorator there)
- [ ] No regressions in any `pytz`-using code paths (timezone localisation in journal/scheduler)

## Out of scope

- Tightening `>=` floors for `ccxt`, `structlog`, `lightgbm`, `scikit-learn`, `scipy`, `gensim`, `hypothesis`, `freezegun`, `mypy`, `mutmut` — already permit latest, hygiene only, deferred.
- Pre-existing test ordering flake — see #244.

https://claude.ai/code/session_01MizjaYj9KQLzAQemwMbu3F

---
_Generated by [Claude Code](https://claude.ai/code/session_01MizjaYj9KQLzAQemwMbu3F)_