### PR TITLE
chore(deps): bump idna 3.13 → 3.14 (patch)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ curl_cffi==0.15.0
 frozendict==2.4.7
 gitdb==4.0.12
 GitPython==3.1.50
-idna==3.13
+idna==3.14
 iniconfig==2.3.0
 Jinja2==3.1.6
 jsonschema==4.26.0


### PR DESCRIPTION
## Summary

Routine patch bump of the pinned `idna` dependency from **3.13 → 3.14**, surfaced by `pip list --outdated`.

- Patch-level (3.x → 3.x) update — no API changes.
- `pip-audit -r requirements.txt` reports **no known vulnerabilities** on either version. This is *not* a CVE remediation, just a freshness refresh.
- `idna` is a transitive dep used by `requests`, `anyio`, and `yarl` — pinning it consistently keeps the lockfile current and avoids drift between dev / CI / prod resolves.

## Risk

Very low. `idna` 3.14 is a maintenance release; no breaking changes in the project's call paths (we only use `idna` indirectly via `requests`).

## Verification

- [x] `pip-audit -r requirements.txt` → No known vulnerabilities
- [x] Unit suite (`pytest -m "not integration and not e2e"`) → **1953 passed, 48 skipped** in 39.4s
- [ ] CI: lint / typecheck / security / test / e2e (will run on PR open)

## Why this is automatic (per project policy)

Minor / patch dependency bumps are auto-applied on a feature branch with the unit suite as the gate. Major bumps are filed as tickets for review first.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Y6Y7wea71Tnpm18EZMvApc)_