### PR TITLE
deps: bump idna, pandas, requests (minor/patch)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ curl_cffi==0.15.0
 frozendict==2.4.7
 gitdb==4.0.12
 GitPython==3.1.50
-idna==3.14
+idna==3.15
 iniconfig==2.3.0
 Jinja2==3.1.6
 jsonschema==4.26.0
@@ -25,7 +25,7 @@ multitasking==0.0.13
 narwhals==2.21.0
 numpy==2.4.4
 packaging==26.2
-pandas==3.0.2
+pandas==3.0.3
 peewee==4.0.5
 pillow==12.2.0
 platformdirs==4.9.6
@@ -47,7 +47,7 @@ python-dateutil==2.9.0.post0
 python-dotenv==1.2.2
 pytz==2026.2
 referencing==0.37.0
-requests==2.33.1
+requests==2.34.0
 rich==15.0.0
 rpds-py==0.30.0
 six==1.17.0


### PR DESCRIPTION
Closes #264.

## Summary

Routine dependency freshness pass on `requirements.txt`. Three pinned runtime
deps had newer same-major-version releases on PyPI; bumped to latest:

| Package    | From    | To     | Type  |
|------------|---------|--------|-------|
| `idna`     | 3.14    | 3.15   | minor |
| `pandas`   | 3.0.2   | 3.0.3  | patch |
| `requests` | 2.33.1  | 2.34.0 | minor |

No production code changes — these are drop-in within-major bumps.

## Security

- `pip-audit -r requirements.txt` — **No known vulnerabilities** (clean
  before *and* after the bump).
- This is preventative maintenance, not a CVE response.

## Test plan

- [x] Local unit suite: `python3 -m pytest tests/ -m "not integration and not e2e"` — **1953 passed, 48 skipped** (0 failures) against the new pins
- [ ] CI: `lint → typecheck → security → test → e2e → merge-gate` must go green
- [ ] CI `security` job (pip-audit) must remain clean

## Out of scope (follow-up)

Several `>=` constraints (`structlog`, `scikit-learn`, `scipy`, `lightgbm`,
`gensim`, `ccxt`, `hypothesis`, `freezegun`) are already satisfied by their
latest upstream releases — no pin change is required here, but tightening
the lower bounds is a sensible follow-up ticket. `structlog` notably has a
new major (24→25) available; that would be a separate, plan-reviewed PR.


---
_Generated by [Claude Code](https://claude.ai/code/session_01ActumdSoEKXUUkYsHGqrJU)_