### PR TITLE
deps: bump requests 2.34.0 → 2.34.1 (patch)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -47,7 +47,7 @@ python-dateutil==2.9.0.post0
 python-dotenv==1.2.2
 pytz==2026.2
 referencing==0.37.0
-requests==2.34.0
+requests==2.34.1
 rich==15.0.0
 rpds-py==0.30.0
 six==1.17.0


### PR DESCRIPTION
Closes part of #266.

## Summary

Routine scheduled dependency audit (2026-05-14). Only one out-of-date pin in `requirements.txt` and zero known CVEs:

| Package | From | To | Bump |
|---|---|---|---|
| `requests` | `2.34.0` | `2.34.1` | patch |

Per the auto-apply policy, patch and minor bumps land directly; majors wait for review.

## Verification

- `pip-audit -r requirements.txt --ignore-vuln PYSEC-2022-42969 --no-deps` → 0 vulnerabilities (matches CI).
- Fresh venv install of the updated `requirements.txt` succeeds.
- `pytest tests/ -m "not integration and not e2e" -p no:randomly` → **1953 passed, 48 skipped** locally with `requests==2.34.1`.

## Test plan

- [ ] CI lint passes
- [ ] CI typecheck passes
- [ ] CI security (bandit + pip-audit) passes
- [ ] CI unit tests pass at 76% coverage floor
- [ ] CI e2e job passes
- [ ] Merge gate green

---
_Generated by [Claude Code](https://claude.ai/code/session_01WjMB6bCiAo2ePt114kJgRT)_