### PR TITLE
chore(deps): bump requests 2.34.1 → 2.34.2 (patch)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -47,7 +47,7 @@ python-dateutil==2.9.0.post0
 python-dotenv==1.2.2
 pytz==2026.2
 referencing==0.37.0
-requests==2.34.1
+requests==2.34.2
 rich==15.0.0
 rpds-py==0.30.0
 six==1.17.0


### PR DESCRIPTION
## Summary

Auto-applied patch bump from the 2026-05-15 dependency hygiene sweep. Closes #268.

- `requests` `2.34.1` → `2.34.2`
- All other `==` pins already at PyPI latest
- `>=` floors permit latest install — not raised here

## Audit context

- `pip-audit -r requirements.txt` → **0 vulnerabilities** (no CVE drove this; hygiene only)
- `npm audit` (sister repo) → 0 vulnerabilities

## Test plan

Local `/pre-push` mirror — all four CI gates green against this branch:

- [x] `ruff check .` → `All checks passed!`
- [x] `pytest tests/ -m "not integration and not e2e"` with `--cov-fail-under=76` → **1953 passed**, coverage **81.12%**
- [x] `bandit -r . -ll --exclude ./.git,./tests` → 0 HIGH severity issues
- [x] `pip-audit -r requirements.txt --ignore-vuln PYSEC-2022-42969` → No known vulnerabilities

### Flake note (not caused by this PR)

A first pass with `pytest-randomly` enabled produced 9 order-dependent failures in `tests/test_pages.py` (sqlite connection / Streamlit session-state interactions). Re-running with `-p no:randomly` is fully green, and the same flake reproduces on the parent commit before this bump — i.e. **pre-existing**, not introduced here. Worth filing separately if not already tracked.

## Risk

Patch release of `requests`. No API surface change. Safe to roll forward.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FArJczNsX851GApFjG95PD)_