### PR TITLE
chore(deps): patch/minor bumps — cachetools, click, narwhals, numpy (2026-05-17)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,12 +3,12 @@ APScheduler==3.11.2
 attrs==26.1.0
 beautifulsoup4==4.14.3
 blinker==1.9.0
-cachetools==7.1.1
+cachetools==7.1.2
 certifi==2026.4.22
 cffi==2.0.0
 charset-normalizer==3.4.7
 duckdb==1.5.2
-click==8.3.3
+click==8.4.0
 curl_cffi==0.15.0
 frozendict==2.4.7
 gitdb==4.0.12
@@ -22,8 +22,8 @@ markdown-it-py==4.2.0
 MarkupSafe==3.0.3
 mdurl==0.1.2
 multitasking==0.0.13
-narwhals==2.21.0
-numpy==2.4.4
+narwhals==2.21.2
+numpy==2.4.5
 packaging==26.2
 pandas==3.0.3
 peewee==4.0.5


### PR DESCRIPTION
## Summary

Routine patch/minor freshness bumps from the 2026-05-17 audit (#270).

| Package | Before | After | Bump |
|---|---|---|---|
| `cachetools` | 7.1.1 | 7.1.2 | patch |
| `click` | 8.3.3 | 8.4.0 | minor |
| `narwhals` | 2.21.0 | 2.21.2 | patch |
| `numpy` | 2.4.4 | 2.4.5 | patch |

`pip-audit -r requirements.txt` reports **0 known vulnerabilities** before and after.

No major bumps in this PR; no API changes touched in the bumped libraries that affect this codebase.

## Test plan

- [x] `pytest tests/ -m "not integration and not e2e" -p no:randomly` → **1953 passed, 48 skipped** locally with the new pins installed
- [ ] CI `lint` job green
- [ ] CI `typecheck` job green
- [ ] CI `test` job green (76% coverage floor + per-changed-file 85%)
- [ ] CI `e2e` job green
- [ ] CI `security` job green (bandit HIGH, pip-audit, gitleaks)
- [ ] CI `merge-gate` green

Closes #270.

https://claude.ai/code/session_01Q4cERRL1cU8wCTmzYm7u69

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q4cERRL1cU8wCTmzYm7u69)_