### PR TITLE
chore(deps): bump soupsieve 2.8.3→2.8.4 + yfinance 1.3.0→1.4.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -52,7 +52,7 @@ rich==15.0.0
 rpds-py==0.30.0
 six==1.17.0
 smmap==5.0.3
-soupsieve==2.8.3
+soupsieve==2.8.4
 streamlit==1.57.0
 streamlit-autorefresh==1.0.1
 ta==0.11.0
@@ -63,7 +63,7 @@ typing_extensions==4.15.0
 tzlocal==5.3.1
 urllib3==2.7.0
 websockets==16.0
-yfinance==1.3.0
+yfinance==1.4.0
 ccxt>=4.5.54
 structlog>=24.0.0
 lightgbm>=4.6.0


### PR DESCRIPTION
## Summary

Two safe `==` pin bumps from today's dependency audit (#279):

- `soupsieve` 2.8.3 → 2.8.4 (PATCH, transitive via beautifulsoup4)
- `yfinance` 1.3.0 → 1.4.0 (MINOR, direct dep in `data/fetcher.py`)

`pip-audit -r requirements.txt --ignore-vuln PYSEC-2022-42969 --ignore-vuln PYSEC-2024-277` returns **0 known vulnerabilities** on the updated lockfile.

## Audit context

- Date: 2026-05-25
- Scanner: pip-audit 2.10.0 (OSV + GitHub Advisory DB + NIST NVD cross-reference)
- 110 resolved packages; 0 CVE findings; 2 freshness bumps applied here.

## Test plan

- [ ] CI: ruff check
- [ ] CI: pytest (76 % branch coverage floor)
- [ ] CI: bandit HIGH gate
- [ ] CI: pip-audit
- [ ] Manual: `pages/screener.py` smoke (yfinance consumer)

Closes #279


---
_Generated by [Claude Code](https://claude.ai/code/session_01R53gtdoLmJ359bS8eBGeEy)_