### PR TITLE
chore(deps): bump tornado 6.5.5 → 6.5.6 (CVE-2026-49854)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -58,7 +58,7 @@ streamlit-autorefresh==1.0.1
 ta==0.11.0
 tenacity==9.1.4
 toml==0.10.2
-tornado==6.5.5
+tornado==6.5.6
 typing_extensions==4.15.0
 tzlocal==5.3.1
 urllib3==2.7.0


### PR DESCRIPTION
## Summary

Single-line PATCH bump that clears [CVE-2026-49854 / GHSA-cx3h-4qpv-8hc9](https://github.com/advisories/GHSA-cx3h-4qpv-8hc9) in `tornado`:

> `tornado.speedups.websocket_mask` reads four bytes from `mask` unconditionally, even when Python passes a shorter byte string — exposing up to 3 bytes of uninitialised memory. Reachable from Tornado's XSRF token decoder when `xsrf_cookies=True` and the native extension is active.

Fix landed in `tornado 6.5.6`. We pin `tornado` directly in `requirements.txt` (it's a Streamlit dep but explicitly version-locked in this repo), so the upgrade path is a one-character bump.

## Validation

- [x] `pip-audit -r requirements.txt --ignore-vuln PYSEC-2022-42969` → `No known vulnerabilities found` (was 1 finding, now 0)
- [ ] `pytest tests/ -m "not integration and not e2e"` — deferred to CI (audit container can't reliably install the ML runtime stack in one cycle — same tooling caveat called out in #281, #282)
- [ ] `ruff check .` — deferred to CI
- [ ] `bandit -r . -ll` — deferred to CI

## Test plan

- [ ] CI `merge-gate` is green
- [ ] No `tornado`-related test regressions (we don't exercise speedups in unit tests; Streamlit is the consumer)

Closes #283

https://claude.ai/code/session_01MpMLBNhcvNhTM3hVKUUJqu

---
_Generated by [Claude Code](https://claude.ai/code/session_01MpMLBNhcvNhTM3hVKUUJqu)_